### PR TITLE
fix(files): Fixed smithing table in no_how_to_play

### DIFF
--- a/resource_packs/files/gui/no_how_to_play/ui/smithing_table_2_screen.json
+++ b/resource_packs/files/gui/no_how_to_play/ui/smithing_table_2_screen.json
@@ -1,0 +1,12 @@
+{
+    "namespace": "smithing_table_2",
+
+    "toolbar_panel/toolbar_background/toolbar_stack_panel/help_button_panel": {
+        "modifications": [
+            {
+                "control_name": "help_button",
+                "operation": "remove"
+            }
+        ]
+    }
+}

--- a/resource_packs/files/gui/no_how_to_play/ui/smithing_table_2_screen_pocket.json
+++ b/resource_packs/files/gui/no_how_to_play/ui/smithing_table_2_screen_pocket.json
@@ -1,0 +1,12 @@
+{
+    "namespace": "smithing_table_2_pocket",
+
+    "right_navigation_tabs": {
+        "modifications": [
+            {
+                "control_name": "pocket_tab_help_button",
+                "operation": "remove"
+            }
+        ]
+    }
+}


### PR DESCRIPTION
Fixed smithing table still having how to play button in no_how_to_play

Fixed issue #86 

By checking the following boxes with an X, you ensure that:

- [X] The pack was tested ingame in at least one device.
- [X] The pack is an existing BT pack, is a missing pack from VT or is an accepted pack/change in a discussion.
- [X] The pack code follows the style guide.
- [X] The commits follow the contribution guidelines.
- [X] The PR follows the contribution guidelines.

- [X] (Optional) Tested in Windows
- [ ] (Optional) Tested in Android
- [ ] (Optional) Tested in iOS
- [ ] (Optional) Tested in any console
- [ ] (Optional) Tested in BDS
