### PR TITLE
fix(files): Variated Planks

### DIFF
--- a/resource_packs/files/variation/variated_planks/textures/terrain_texture.json
+++ b/resource_packs/files/variation/variated_planks/textures/terrain_texture.json
@@ -4,16 +4,6 @@
 	"padding": 8,
 	"num_mip_levels": 4,
 	"texture_data": {
-		"planks": {
-			"textures": [
-				"textures/blocks/amethyst_block",
-				"textures/blocks/amethyst_block",
-				"textures/blocks/amethyst_block",
-				"textures/blocks/amethyst_block",
-				"textures/blocks/amethyst_block",
-				"textures/blocks/amethyst_block"
-			]
-		},
 		"acacia_planks": {
 			"textures": {
 				"variations": [


### PR DESCRIPTION
## Commit Descriptions
- removed unused 'planks' texture entry

## Discussion
From what I can tell, this pack only breaks when you manually take it to a previous version **before 1.20.50** as that is when Planks were split from being all one block with data to individual blocks, confirmable on the [Minecraft Wiki\Data History](https://minecraft.wiki/w/Planks#Data_history)
All this commit does is remove the blatent debug clause _someone_ has left in the terrain_texture file as per #148 
Reasoning for the behaviour is the entry "planks" is being loaded over the individual textures since that is the block name in those versions.

## Checklist
Resolved: #148 
- [x] The pack was tested ingame in at least one device.
- [x] The pack is an existing BT pack, is a missing pack from VT or is an accepted pack/change in a discussion.
- [x] The pack code follows the style guide.
- [x] The commits follow the contribution guidelines.
- [x] The PR follows the contribution guidelines.

- [x] (Optional) Tested in Windows
- [ ] (Optional) Tested in Android
- [ ] (Optional) Tested in iOS
- [ ] (Optional) Tested in any console
- [ ] (Optional) Tested in BDS