### PR TITLE
fix(files): quieter_water

### DIFF
--- a/resource_packs/files/peace_and_quiet/quieter_water/sounds.json
+++ b/resource_packs/files/peace_and_quiet/quieter_water/sounds.json
@@ -28,9 +28,6 @@
 			"cauldron_drip.water.pointed_dripstone": {
 				"volume": 0.1
 			},
-			"drip.lava.pointed_dripstone" : {
-			   "pitch" : 0.1
-			},
 			"drip.water.pointed_dripstone" : {
 			   "pitch" : 0.1
 			}

--- a/resource_packs/files/peace_and_quiet/quieter_water/sounds.json
+++ b/resource_packs/files/peace_and_quiet/quieter_water/sounds.json
@@ -29,7 +29,7 @@
 				"volume": 0.1
 			},
 			"drip.water.pointed_dripstone" : {
-			   "pitch" : 0.1
+			   "volume" : 0.1
 			}
 		}
 	}

--- a/resource_packs/files/peace_and_quiet/quieter_water/sounds.json
+++ b/resource_packs/files/peace_and_quiet/quieter_water/sounds.json
@@ -29,7 +29,7 @@
 				"volume": 0.1
 			},
 			"drip.water.pointed_dripstone" : {
-			   "volume" : 0.1
+			   "volume": [0.015, 0.05]
 			}
 		}
 	}

--- a/resource_packs/files/peace_and_quiet/quieter_water/sounds.json
+++ b/resource_packs/files/peace_and_quiet/quieter_water/sounds.json
@@ -27,6 +27,12 @@
 			},
 			"cauldron_drip.water.pointed_dripstone": {
 				"volume": 0.1
+			},
+			"drip.lava.pointed_dripstone" : {
+			   "pitch" : 0.1
+			},
+			"drip.water.pointed_dripstone" : {
+			   "pitch" : 0.1
 			}
 		}
 	}


### PR DESCRIPTION
fixes: #251

* add missing drip.lava.pointed_dripstone key
* add missing drip.water.pointed_dripstone key

By checking the following boxes with an X, you ensure that:

- [x] The pack was tested ingame in at least one device.
- [x] The pack is an existing BT pack, is a missing pack from VT or is an accepted pack/change in a discussion.
- [x] The pack code follows the style guide.
- [x] The commits follow the contribution guidelines.
- [x] The PR follows the contribution guidelines.

- [x] (Optional) Tested in Windows
- [ ] (Optional) Tested in Android
- [ ] (Optional) Tested in iOS
- [ ] (Optional) Tested in any console
- [ ] (Optional) Tested in BDS
