### PR TITLE
fix(files): Fix sound_definitions.json is not deep merge consequently fixing combining with old door sounds, quieter nether portals and quieter rain

### DIFF
--- a/resource_packs/packs.json
+++ b/resource_packs/packs.json
@@ -2763,6 +2763,10 @@
 			"filepath": "/sounds.json"
 		},
 		{
+			"filename": "sound_definitions.json",
+			"filepath": "/sounds/sound_definitions.json"
+		},
+		{
 			"filename": "trade_2_screen.json",
 			"filepath": "/ui/trade_2_screen.json"
 		},


### PR DESCRIPTION
Fix sound_definitions.json is not deep merge consequently fixing combining with old door sounds, quieter nether portals and quieter rain

By checking the following boxes with an X, you ensure that:

- [X] The pack was tested ingame in at least one device.
- [X] The pack is an existing BT pack, is a missing pack from VT or is an accepted pack/change in a discussion.
- [X] The pack code follows the style guide.
- [X] The commits follow the contribution guidelines.
- [X] The PR follows the contribution guidelines.

- [X] (Optional) Tested in Windows
- [ ] (Optional) Tested in Android
- [ ] (Optional) Tested in iOS
- [ ] (Optional) Tested in any console
- [ ] (Optional) Tested in BDS
