### PR TITLE
fix(files): Fix Quieter Guardians, Quieter Parrots, Quieter Skeletons and Quieter Wardens throwing content log errors

### DIFF
--- a/resource_packs/files/peace_and_quiet/mobs/quieter_guardians/sounds.json
+++ b/resource_packs/files/peace_and_quiet/mobs/quieter_guardians/sounds.json
@@ -2,19 +2,9 @@
 	"entity_sounds": {
 		"entities": {
 			"elder_guardian": {
-				"events": {
-					"guardian.flop": {
-						"volume": 0.05
-					}
-				},
 				"volume": 0.05
 			},
 			"guardian": {
-				"events": {
-					"guardian.flop": {
-						"volume": 0.05
-					}
-				},
 				"volume": 0.05
 			}
 		}

--- a/resource_packs/files/peace_and_quiet/mobs/quieter_parrots/sounds.json
+++ b/resource_packs/files/peace_and_quiet/mobs/quieter_parrots/sounds.json
@@ -15,6 +15,9 @@
 					"imitate.blaze": {
 						"volume": 0.02
 					},
+					"imitate.bogged": {
+						"volume": 0.035
+					},
 					"imitate.breeze": {
 						"volume": 0.035
 					},
@@ -48,14 +51,8 @@
 					"imitate.husk": {
 						"volume": 0.03
 					},
-					"imitate.illusion_illager": {
-						"volume": 0.035
-					},
 					"imitate.magma_cube": {
 						"volume": 0.03
-					},
-					"imitate.panda": {
-						"volume": 0.035
 					},
 					"imitate.polar_bear": {
 						"volume": 0.035

--- a/resource_packs/files/peace_and_quiet/mobs/quieter_skeletons/sounds.json
+++ b/resource_packs/files/peace_and_quiet/mobs/quieter_skeletons/sounds.json
@@ -31,11 +31,8 @@
 					"hurt": {
 						"volume": 0.05
 					},
-					"sound": {
-						"volume": 0.0075
-					},
 					"step": {
-						"volume": 0.05
+						"volume": 0.0075
 					}
 				},
 				"volume": 0.05

--- a/resource_packs/files/peace_and_quiet/mobs/quieter_wardens/sounds.json
+++ b/resource_packs/files/peace_and_quiet/mobs/quieter_wardens/sounds.json
@@ -15,20 +15,11 @@
 					"death": {
 						"volume": 0.05
 					},
-					"dig": {
-						"volume": 0.2
-					},
-					"emerge": {
-						"volume": 0.2
-					},
 					"heartbeat": {
 						"volume": 0.2
 					},
 					"hurt": {
 						"volume": 0.05
-					},
-					"idle": {
-						"volume": 0.15
 					},
 					"listening": {
 						"volume": 0.5
@@ -48,9 +39,6 @@
 					"roar": {
 						"volume": 0.5
 					},
-					"sniff": {
-						"volume": 0.2
-					},
 					"step": {
 						"volume": 0.5
 					}
@@ -68,9 +56,6 @@
 				"volume": 0.05
 			},
 			"nearby_closest": {
-				"volume": 0.05
-			},
-			"slightly_angry": {
 				"volume": 0.05
 			},
 			"sonic_boom": {

--- a/resource_packs/files/peace_and_quiet/quieter_water/sounds.json
+++ b/resource_packs/files/peace_and_quiet/quieter_water/sounds.json
@@ -1,23 +1,23 @@
 {
-	"entity_sounds" : {
-		"defaults" : {
-			"events" : {
-				"splash" : {
-					"volume" : 0.05
-				 },
-				 "swim" : {
-					"volume" : 0.05
-				 }
+	"entity_sounds": {
+		"defaults": {
+			"events": {
+				"splash": {
+					"volume": 0.05
+				},
+				"swim": {
+					"volume": 0.05
+				}
 			}
 		}
 	},
 	"individual_event_sounds": {
 		"events": {
-			"ambient.underwater.enter" : {
-				"volume" : 0.05
+			"ambient.underwater.enter": {
+				"volume": 0.05
 			},
-			"ambient.underwater.exit" : {
-				"volume" : 0.05
+			"ambient.underwater.exit": {
+				"volume": 0.05
 			},
 			"water": {
 				"volume": [
@@ -28,8 +28,11 @@
 			"cauldron_drip.water.pointed_dripstone": {
 				"volume": 0.1
 			},
-			"drip.water.pointed_dripstone" : {
-			   "volume": [0.015, 0.05]
+			"drip.water.pointed_dripstone": {
+				"volume": [
+					0.015,
+					0.05
+				]
 			}
 		}
 	}


### PR DESCRIPTION
Removed the invalid sound events from the `sounds.json` file
Also updated quieter parrots to now quieter bogged sounds made by the parrot

Resolves #341 

By checking the following boxes with an X, you ensure that:

- [X] The pack was tested ingame in at least one device.
- [X] The pack is an existing BT pack, is a missing pack from VT or is an accepted pack/change in a discussion.
- [X] The pack code follows the style guide.
- [X] The commits follow the contribution guidelines.
- [X] The PR follows the contribution guidelines.

- [X] (Optional) Tested in Windows
- [ ] (Optional) Tested in Android
- [ ] (Optional) Tested in iOS
- [ ] (Optional) Tested in any console
- [ ] (Optional) Tested in BDS
