### PR TITLE
fix(files): Fix numbered hotbar being offset in the HUD hotbar on few devices

### DIFF
--- a/resource_packs/files/gui/numbered_hotbar/ui/hud_screen.json
+++ b/resource_packs/files/gui/numbered_hotbar/ui/hud_screen.json
@@ -1,53 +1,12 @@
 {
 	"namespace": "hud",
-	"exp_progress_bar_and_hotbar/resizing_xp_bar_with_hotbar/empty_progress_bar/full_progress_bar/progress_bar_nub/horse_jump_rend/dash_rend": {
+	"hotbar_panel": {
 		"modifications": [
 			{
 				"array_name": "controls",
-				"operation": "insert_back",
+				"operation": "insert_front",
 				"value": {
-					"numbered_hotbar_desktop@bt_numbered_hotbar.numbered_hotbar_panel": {
-						"ignored": "(not $is_desktop)"
-					}
-				}
-			},
-			{
-				"array_name": "controls",
-				"operation": "insert_back",
-				"value": {
-					"numbered_hotbar_other@bt_numbered_hotbar.numbered_hotbar_panel": {
-						"ignored": "$is_desktop",
-						"offset": [
-							-101,
-							16
-						]
-					}
-				}
-			}
-		]
-	},
-	"exp_progress_bar_and_hotbar/resizing_hotbar_no_xp_bar/horse_jump_rend/dash_rend": {
-		"modifications": [
-			{
-				"array_name": "controls",
-				"operation": "insert_back",
-				"value": {
-					"numbered_hotbar_desktop@bt_numbered_hotbar.numbered_hotbar_panel": {
-						"ignored": "(not $is_desktop)"
-					}
-				}
-			},
-			{
-				"array_name": "controls",
-				"operation": "insert_back",
-				"value": {
-					"numbered_hotbar_other@bt_numbered_hotbar.numbered_hotbar_panel": {
-						"ignored": "$is_desktop",
-						"offset": [
-							-101,
-							16
-						]
-					}
+					"numbered_hotbar@bt_numbered_hotbar.numbered_hotbar_panel": {}
 				}
 			}
 		]

--- a/resource_packs/files/gui/numbered_hotbar/uibt/numbered_hotbar.ui
+++ b/resource_packs/files/gui/numbered_hotbar/uibt/numbered_hotbar.ui
@@ -25,12 +25,8 @@
 	"numbered_hotbar_panel": {
 		"type": "stack_panel",
 		"orientation": "horizontal",
-		"offset": [
-			-91,
-			16
-		],
 		"size": [
-			"10%c - 20px",
+			"10%c - 19px",
 			22
 		],
 		"anchor_from": "bottom_center",


### PR DESCRIPTION
Improved the numbered hotbar to no longer using hardcoded offset, instead the numbered hotbar being adjusted by itself

Resolves #396 

By checking the following boxes with an X, you ensure that:

- [X] The pack was tested ingame in at least one device.
- [X] The pack is an existing BT pack, is a missing pack from VT or is an accepted pack/change in a discussion.
- [X] The pack code follows the style guide.
- [X] The commits follow the contribution guidelines.
- [X] The PR follows the contribution guidelines.

- [X] (Optional) Tested in Windows
- [X] (Optional) Tested in Android
- [X] (Optional) Tested in iOS
- [ ] (Optional) Tested in any console
- [ ] (Optional) Tested in BDS
