### PR TITLE
fix(files): Fix Dark UI not changing some button texts to be white in Dressing Room

### DIFF
--- a/resource_packs/files/gui/dark_ui/ui/_global_variables.json
+++ b/resource_packs/files/gui/dark_ui/ui/_global_variables.json
@@ -144,5 +144,10 @@
 		1.0,
 		1.0,
 		1.0
+	],
+	"$dressing_room_dark_button_color": [
+		1.0,
+		1.0,
+		1.0
 	]
 }

--- a/resource_packs/files/gui/dark_ui/ui/persona_screen.json
+++ b/resource_packs/files/gui/dark_ui/ui/persona_screen.json
@@ -12,7 +12,7 @@
 	"achievement_text_button": {
 		"$default_text_color": "$light_button_default_text_color"
 	},
-	"emotes_right_side_bottom_buttons/play_again": {
+	"emote_play_again_button": {
 		"$default_text_color": "$light_button_default_text_color"
 	},
 	"purchase_button_panel/$purchase_button_control": {

--- a/resource_packs/files/gui/dark_ui/ui/persona_screen.json
+++ b/resource_packs/files/gui/dark_ui/ui/persona_screen.json
@@ -1,0 +1,21 @@
+{
+	"namespace": "persona",
+	"equip_piece_text": {
+		"color": "$light_button_default_text_color"
+	},
+	"select_custom_skin": {
+		"$default_text_color": "$light_button_default_text_color"
+	},
+	"see_skin_pack_in_store": {
+		"$default_text_color": "$light_button_default_text_color"
+	},
+	"achievement_text_button": {
+		"$default_text_color": "$light_button_default_text_color"
+	},
+	"emotes_right_side_bottom_buttons/play_again": {
+		"$default_text_color": "$light_button_default_text_color"
+	},
+	"purchase_button_panel/$purchase_button_control": {
+		"$default_text_color": "$light_button_default_text_color"
+	}
+}

--- a/resource_packs/files/gui/dark_ui/ui/profile_screen.json
+++ b/resource_packs/files/gui/dark_ui/ui/profile_screen.json
@@ -1,6 +1,0 @@
-{
-	"namespace": "profile",
-	"preset_arrow_button": {
-		"$texture_color": "$light_button_default_text_color"
-	}
-}


### PR DESCRIPTION
1. Created a `persona_screen.json` file to make all the button texts which are not visible properly to be white in color in dressing room
2. Made the arrow keys in the skin rotational selector to be white in color in dressing room
3. Deleted the `profile_screen.json` as it becomes useless

Resolves #393 

By checking the following boxes with an X, you ensure that:

- [X] The pack was tested ingame in at least one device.
- [X] The pack is an existing BT pack, is a missing pack from VT or is an accepted pack/change in a discussion.
- [X] The pack code follows the style guide.
- [X] The commits follow the contribution guidelines.
- [X] The PR follows the contribution guidelines.

- [X] (Optional) Tested in Windows
- [ ] (Optional) Tested in Android
- [ ] (Optional) Tested in iOS
- [ ] (Optional) Tested in any console
- [ ] (Optional) Tested in BDS
