### PR TITLE
feat(files): add Pale Oak Wood, Logs & Planks to Crafting Tweaks

### DIFF
--- a/crafting_tweaks/files/craftables/craftable_blackstone/recipes/craftable_blackstone/blackstone.recipe.json
+++ b/crafting_tweaks/files/craftables/craftable_blackstone/recipes/craftable_blackstone/blackstone.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:cb.blackstone"

--- a/crafting_tweaks/files/craftables/craftable_blackstone/recipes/craftable_blackstone/polished_blackstone.recipe.json
+++ b/crafting_tweaks/files/craftables/craftable_blackstone/recipes/craftable_blackstone/polished_blackstone.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:cb.polished_blackstone"

--- a/crafting_tweaks/files/craftables/craftable_coral_blocks_2x2/recipes/craftable_coral_blocks_2x2/brain_coral/brain_coral_from_coral.recipe.json
+++ b/crafting_tweaks/files/craftables/craftable_coral_blocks_2x2/recipes/craftable_coral_blocks_2x2/brain_coral/brain_coral_from_coral.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:cc2.brain_coral_block_from_coral"

--- a/crafting_tweaks/files/craftables/craftable_coral_blocks_2x2/recipes/craftable_coral_blocks_2x2/brain_coral/brain_coral_from_fan.recipe.json
+++ b/crafting_tweaks/files/craftables/craftable_coral_blocks_2x2/recipes/craftable_coral_blocks_2x2/brain_coral/brain_coral_from_fan.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:cc2.brain_coral_block_from_fan"

--- a/crafting_tweaks/files/craftables/craftable_coral_blocks_2x2/recipes/craftable_coral_blocks_2x2/brain_coral/dead_brain_coral_from_coral.recipe.json
+++ b/crafting_tweaks/files/craftables/craftable_coral_blocks_2x2/recipes/craftable_coral_blocks_2x2/brain_coral/dead_brain_coral_from_coral.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:cc2.dead_brain_coral_block_from_coral"

--- a/crafting_tweaks/files/craftables/craftable_coral_blocks_2x2/recipes/craftable_coral_blocks_2x2/brain_coral/dead_brain_coral_from_fan.recipe.json
+++ b/crafting_tweaks/files/craftables/craftable_coral_blocks_2x2/recipes/craftable_coral_blocks_2x2/brain_coral/dead_brain_coral_from_fan.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:cc2.dead_brain_coral_block_from_fan"

--- a/crafting_tweaks/files/craftables/craftable_coral_blocks_2x2/recipes/craftable_coral_blocks_2x2/bubble_coral/bubble_coral_from_coral.recipe.json
+++ b/crafting_tweaks/files/craftables/craftable_coral_blocks_2x2/recipes/craftable_coral_blocks_2x2/bubble_coral/bubble_coral_from_coral.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:cc2.bubble_coral_block_from_coral"

--- a/crafting_tweaks/files/craftables/craftable_coral_blocks_2x2/recipes/craftable_coral_blocks_2x2/bubble_coral/bubble_coral_from_fan.recipe.json
+++ b/crafting_tweaks/files/craftables/craftable_coral_blocks_2x2/recipes/craftable_coral_blocks_2x2/bubble_coral/bubble_coral_from_fan.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:cc2.bubble_coral_block_from_fan"

--- a/crafting_tweaks/files/craftables/craftable_coral_blocks_2x2/recipes/craftable_coral_blocks_2x2/bubble_coral/dead_bubble_coral_from_coral.recipe.json
+++ b/crafting_tweaks/files/craftables/craftable_coral_blocks_2x2/recipes/craftable_coral_blocks_2x2/bubble_coral/dead_bubble_coral_from_coral.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:cc2.dead_bubble_coral_block_from_coral"

--- a/crafting_tweaks/files/craftables/craftable_coral_blocks_2x2/recipes/craftable_coral_blocks_2x2/bubble_coral/dead_bubble_coral_from_fan.recipe.json
+++ b/crafting_tweaks/files/craftables/craftable_coral_blocks_2x2/recipes/craftable_coral_blocks_2x2/bubble_coral/dead_bubble_coral_from_fan.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:cc2.dead_bubble_coral_block_from_fan"

--- a/crafting_tweaks/files/craftables/craftable_coral_blocks_2x2/recipes/craftable_coral_blocks_2x2/fire_coral/dead_fire_coral_from_coral.recipe.json
+++ b/crafting_tweaks/files/craftables/craftable_coral_blocks_2x2/recipes/craftable_coral_blocks_2x2/fire_coral/dead_fire_coral_from_coral.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:cc2.dead_fire_coral_block_from_coral"

--- a/crafting_tweaks/files/craftables/craftable_coral_blocks_2x2/recipes/craftable_coral_blocks_2x2/fire_coral/dead_fire_coral_from_fan.recipe.json
+++ b/crafting_tweaks/files/craftables/craftable_coral_blocks_2x2/recipes/craftable_coral_blocks_2x2/fire_coral/dead_fire_coral_from_fan.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:cc2.dead_fire_coral_block_from_fan"

--- a/crafting_tweaks/files/craftables/craftable_coral_blocks_2x2/recipes/craftable_coral_blocks_2x2/fire_coral/fire_coral_from_coral.recipe.json
+++ b/crafting_tweaks/files/craftables/craftable_coral_blocks_2x2/recipes/craftable_coral_blocks_2x2/fire_coral/fire_coral_from_coral.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:cc2.fire_coral_block_from_coral"

--- a/crafting_tweaks/files/craftables/craftable_coral_blocks_2x2/recipes/craftable_coral_blocks_2x2/fire_coral/fire_coral_from_fan.recipe.json
+++ b/crafting_tweaks/files/craftables/craftable_coral_blocks_2x2/recipes/craftable_coral_blocks_2x2/fire_coral/fire_coral_from_fan.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:cc2.fire_coral_block_from_fan"

--- a/crafting_tweaks/files/craftables/craftable_coral_blocks_2x2/recipes/craftable_coral_blocks_2x2/horn_coral/dead_horn_coral_from_coral.recipe.json
+++ b/crafting_tweaks/files/craftables/craftable_coral_blocks_2x2/recipes/craftable_coral_blocks_2x2/horn_coral/dead_horn_coral_from_coral.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:cc2.dead_horn_coral_block_from_coral"

--- a/crafting_tweaks/files/craftables/craftable_coral_blocks_2x2/recipes/craftable_coral_blocks_2x2/horn_coral/dead_horn_coral_from_fan.recipe.json
+++ b/crafting_tweaks/files/craftables/craftable_coral_blocks_2x2/recipes/craftable_coral_blocks_2x2/horn_coral/dead_horn_coral_from_fan.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:cc2.dead_horn_coral_block_from_fan"

--- a/crafting_tweaks/files/craftables/craftable_coral_blocks_2x2/recipes/craftable_coral_blocks_2x2/horn_coral/horn_coral_from_coral.recipe.json
+++ b/crafting_tweaks/files/craftables/craftable_coral_blocks_2x2/recipes/craftable_coral_blocks_2x2/horn_coral/horn_coral_from_coral.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:cc2.horn_coral_block_from_coral"

--- a/crafting_tweaks/files/craftables/craftable_coral_blocks_2x2/recipes/craftable_coral_blocks_2x2/horn_coral/horn_coral_from_fan.recipe.json
+++ b/crafting_tweaks/files/craftables/craftable_coral_blocks_2x2/recipes/craftable_coral_blocks_2x2/horn_coral/horn_coral_from_fan.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:cc2.horn_coral_block_from_fan"

--- a/crafting_tweaks/files/craftables/craftable_coral_blocks_2x2/recipes/craftable_coral_blocks_2x2/tube_coral/dead_tube_coral_from_coral.recipe.json
+++ b/crafting_tweaks/files/craftables/craftable_coral_blocks_2x2/recipes/craftable_coral_blocks_2x2/tube_coral/dead_tube_coral_from_coral.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:cc2.dead_tube_coral_block_from_coral"

--- a/crafting_tweaks/files/craftables/craftable_coral_blocks_2x2/recipes/craftable_coral_blocks_2x2/tube_coral/dead_tube_coral_from_fan.recipe.json
+++ b/crafting_tweaks/files/craftables/craftable_coral_blocks_2x2/recipes/craftable_coral_blocks_2x2/tube_coral/dead_tube_coral_from_fan.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:cc2.dead_tube_coral_block_from_fan"

--- a/crafting_tweaks/files/craftables/craftable_coral_blocks_2x2/recipes/craftable_coral_blocks_2x2/tube_coral/tube_coral_from_coral.recipe.json
+++ b/crafting_tweaks/files/craftables/craftable_coral_blocks_2x2/recipes/craftable_coral_blocks_2x2/tube_coral/tube_coral_from_coral.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:cc2.tube_coral_block_from_coral"

--- a/crafting_tweaks/files/craftables/craftable_coral_blocks_2x2/recipes/craftable_coral_blocks_2x2/tube_coral/tube_coral_from_fan.recipe.json
+++ b/crafting_tweaks/files/craftables/craftable_coral_blocks_2x2/recipes/craftable_coral_blocks_2x2/tube_coral/tube_coral_from_fan.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:cc2.tube_coral_block_from_fan"

--- a/crafting_tweaks/files/craftables/craftable_coral_blocks_3x3/recipes/craftable_coral_blocks_3x3/brain_coral/brain_coral_from_coral.recipe.json
+++ b/crafting_tweaks/files/craftables/craftable_coral_blocks_3x3/recipes/craftable_coral_blocks_3x3/brain_coral/brain_coral_from_coral.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:cc3.brain_coral_block_from_coral"

--- a/crafting_tweaks/files/craftables/craftable_coral_blocks_3x3/recipes/craftable_coral_blocks_3x3/brain_coral/brain_coral_from_fan.recipe.json
+++ b/crafting_tweaks/files/craftables/craftable_coral_blocks_3x3/recipes/craftable_coral_blocks_3x3/brain_coral/brain_coral_from_fan.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:cc3.brain_coral_block_from_fan"

--- a/crafting_tweaks/files/craftables/craftable_coral_blocks_3x3/recipes/craftable_coral_blocks_3x3/brain_coral/dead_brain_coral_from_coral.recipe.json
+++ b/crafting_tweaks/files/craftables/craftable_coral_blocks_3x3/recipes/craftable_coral_blocks_3x3/brain_coral/dead_brain_coral_from_coral.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:cc3.dead_brain_coral_block_from_coral"

--- a/crafting_tweaks/files/craftables/craftable_coral_blocks_3x3/recipes/craftable_coral_blocks_3x3/brain_coral/dead_brain_coral_from_fan.recipe.json
+++ b/crafting_tweaks/files/craftables/craftable_coral_blocks_3x3/recipes/craftable_coral_blocks_3x3/brain_coral/dead_brain_coral_from_fan.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:cc3.dead_brain_coral_block_from_fan"

--- a/crafting_tweaks/files/craftables/craftable_coral_blocks_3x3/recipes/craftable_coral_blocks_3x3/bubble_coral/bubble_coral_from_coral.recipe.json
+++ b/crafting_tweaks/files/craftables/craftable_coral_blocks_3x3/recipes/craftable_coral_blocks_3x3/bubble_coral/bubble_coral_from_coral.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:cc3.bubble_coral_block_from_coral"

--- a/crafting_tweaks/files/craftables/craftable_coral_blocks_3x3/recipes/craftable_coral_blocks_3x3/bubble_coral/bubble_coral_from_fan.recipe.json
+++ b/crafting_tweaks/files/craftables/craftable_coral_blocks_3x3/recipes/craftable_coral_blocks_3x3/bubble_coral/bubble_coral_from_fan.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:cc3.bubble_coral_block_from_fan"

--- a/crafting_tweaks/files/craftables/craftable_coral_blocks_3x3/recipes/craftable_coral_blocks_3x3/bubble_coral/dead_bubble_coral_from_coral.recipe.json
+++ b/crafting_tweaks/files/craftables/craftable_coral_blocks_3x3/recipes/craftable_coral_blocks_3x3/bubble_coral/dead_bubble_coral_from_coral.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:cc3.dead_bubble_coral_block_from_coral"

--- a/crafting_tweaks/files/craftables/craftable_coral_blocks_3x3/recipes/craftable_coral_blocks_3x3/bubble_coral/dead_bubble_coral_from_fan.recipe.json
+++ b/crafting_tweaks/files/craftables/craftable_coral_blocks_3x3/recipes/craftable_coral_blocks_3x3/bubble_coral/dead_bubble_coral_from_fan.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:cc3.dead_bubble_coral_block_from_fan"

--- a/crafting_tweaks/files/craftables/craftable_coral_blocks_3x3/recipes/craftable_coral_blocks_3x3/fire_coral/dead_fire_coral_from_coral.recipe.json
+++ b/crafting_tweaks/files/craftables/craftable_coral_blocks_3x3/recipes/craftable_coral_blocks_3x3/fire_coral/dead_fire_coral_from_coral.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:cc3.dead_fire_coral_block_from_coral"

--- a/crafting_tweaks/files/craftables/craftable_coral_blocks_3x3/recipes/craftable_coral_blocks_3x3/fire_coral/dead_fire_coral_from_fan.recipe.json
+++ b/crafting_tweaks/files/craftables/craftable_coral_blocks_3x3/recipes/craftable_coral_blocks_3x3/fire_coral/dead_fire_coral_from_fan.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:cc3.dead_fire_coral_block_from_fan"

--- a/crafting_tweaks/files/craftables/craftable_coral_blocks_3x3/recipes/craftable_coral_blocks_3x3/fire_coral/fire_coral_from_coral.recipe.json
+++ b/crafting_tweaks/files/craftables/craftable_coral_blocks_3x3/recipes/craftable_coral_blocks_3x3/fire_coral/fire_coral_from_coral.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:cc3.fire_coral_block_from_coral"

--- a/crafting_tweaks/files/craftables/craftable_coral_blocks_3x3/recipes/craftable_coral_blocks_3x3/fire_coral/fire_coral_from_fan.recipe.json
+++ b/crafting_tweaks/files/craftables/craftable_coral_blocks_3x3/recipes/craftable_coral_blocks_3x3/fire_coral/fire_coral_from_fan.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:cc3.fire_coral_block_from_fan"

--- a/crafting_tweaks/files/craftables/craftable_coral_blocks_3x3/recipes/craftable_coral_blocks_3x3/horn_coral/dead_horn_coral_from_coral.recipe.json
+++ b/crafting_tweaks/files/craftables/craftable_coral_blocks_3x3/recipes/craftable_coral_blocks_3x3/horn_coral/dead_horn_coral_from_coral.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:cc3.dead_horn_coral_block_from_coral"

--- a/crafting_tweaks/files/craftables/craftable_coral_blocks_3x3/recipes/craftable_coral_blocks_3x3/horn_coral/dead_horn_coral_from_fan.recipe.json
+++ b/crafting_tweaks/files/craftables/craftable_coral_blocks_3x3/recipes/craftable_coral_blocks_3x3/horn_coral/dead_horn_coral_from_fan.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:cc3.dead_horn_coral_block_from_fan"

--- a/crafting_tweaks/files/craftables/craftable_coral_blocks_3x3/recipes/craftable_coral_blocks_3x3/horn_coral/horn_coral_from_coral.recipe.json
+++ b/crafting_tweaks/files/craftables/craftable_coral_blocks_3x3/recipes/craftable_coral_blocks_3x3/horn_coral/horn_coral_from_coral.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:cc3.horn_coral_block_from_coral"

--- a/crafting_tweaks/files/craftables/craftable_coral_blocks_3x3/recipes/craftable_coral_blocks_3x3/horn_coral/horn_coral_from_fan.recipe.json
+++ b/crafting_tweaks/files/craftables/craftable_coral_blocks_3x3/recipes/craftable_coral_blocks_3x3/horn_coral/horn_coral_from_fan.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:cc3.horn_coral_block_from_fan"

--- a/crafting_tweaks/files/craftables/craftable_coral_blocks_3x3/recipes/craftable_coral_blocks_3x3/tube_coral/dead_tube_coral_from_coral.recipe.json
+++ b/crafting_tweaks/files/craftables/craftable_coral_blocks_3x3/recipes/craftable_coral_blocks_3x3/tube_coral/dead_tube_coral_from_coral.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:cc3.dead_tube_coral_block_from_coral"

--- a/crafting_tweaks/files/craftables/craftable_coral_blocks_3x3/recipes/craftable_coral_blocks_3x3/tube_coral/dead_tube_coral_from_fan.recipe.json
+++ b/crafting_tweaks/files/craftables/craftable_coral_blocks_3x3/recipes/craftable_coral_blocks_3x3/tube_coral/dead_tube_coral_from_fan.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:cc3.dead_tube_coral_block_from_fan"

--- a/crafting_tweaks/files/craftables/craftable_coral_blocks_3x3/recipes/craftable_coral_blocks_3x3/tube_coral/tube_coral_from_coral.recipe.json
+++ b/crafting_tweaks/files/craftables/craftable_coral_blocks_3x3/recipes/craftable_coral_blocks_3x3/tube_coral/tube_coral_from_coral.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:cc3.tube_coral_block_from_coral"

--- a/crafting_tweaks/files/craftables/craftable_coral_blocks_3x3/recipes/craftable_coral_blocks_3x3/tube_coral/tube_coral_from_fan.recipe.json
+++ b/crafting_tweaks/files/craftables/craftable_coral_blocks_3x3/recipes/craftable_coral_blocks_3x3/tube_coral/tube_coral_from_fan.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:cc3.tube_coral_block_from_fan"

--- a/crafting_tweaks/files/craftables/craftable_enchanted_golden_apple/recipes/craftable_enchanted_golden_apple/enchanted_golden_apple.recipe.json
+++ b/crafting_tweaks/files/craftables/craftable_enchanted_golden_apple/recipes/craftable_enchanted_golden_apple/enchanted_golden_apple.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:cega.enchanted_golden_apple"

--- a/crafting_tweaks/files/craftables/craftable_gravel/recipes/craftable_gravel/gravel.recipe.json
+++ b/crafting_tweaks/files/craftables/craftable_gravel/recipes/craftable_gravel/gravel.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:cg.gravel"

--- a/crafting_tweaks/files/craftables/craftable_horse_armor/recipes/craftable_horse_armor/diamond_horse_armor.recipe.json
+++ b/crafting_tweaks/files/craftables/craftable_horse_armor/recipes/craftable_horse_armor/diamond_horse_armor.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:cha.diamond_horse_armor"

--- a/crafting_tweaks/files/craftables/craftable_horse_armor/recipes/craftable_horse_armor/golden_horse_armor.recipe.json
+++ b/crafting_tweaks/files/craftables/craftable_horse_armor/recipes/craftable_horse_armor/golden_horse_armor.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:cha.golden_horse_armor"

--- a/crafting_tweaks/files/craftables/craftable_horse_armor/recipes/craftable_horse_armor/iron_horse_armor.recipe.json
+++ b/crafting_tweaks/files/craftables/craftable_horse_armor/recipes/craftable_horse_armor/iron_horse_armor.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:cha.iron_horse_armor"

--- a/crafting_tweaks/files/craftables/craftable_name_tags/recipes/craftable_name_tags/name_tag.recipe.json
+++ b/crafting_tweaks/files/craftables/craftable_name_tags/recipes/craftable_name_tags/name_tag.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:cnt.name_tag"

--- a/crafting_tweaks/files/more_blocks/more_bark/recipes/more_bark/stripped_wood/stripped_acacia_wood.recipe.json
+++ b/crafting_tweaks/files/more_blocks/more_bark/recipes/more_bark/stripped_wood/stripped_acacia_wood.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:mb.acacia_wood_stripped"

--- a/crafting_tweaks/files/more_blocks/more_bark/recipes/more_bark/stripped_wood/stripped_birch_wood.recipe.json
+++ b/crafting_tweaks/files/more_blocks/more_bark/recipes/more_bark/stripped_wood/stripped_birch_wood.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:mb.birch_wood_stripped"

--- a/crafting_tweaks/files/more_blocks/more_bark/recipes/more_bark/stripped_wood/stripped_cherry_wood.recipe.json
+++ b/crafting_tweaks/files/more_blocks/more_bark/recipes/more_bark/stripped_wood/stripped_cherry_wood.recipe.json
@@ -1,8 +1,8 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
-			"identifier": "bt:mb.cherry_wood_from_stripped_log"
+			"identifier": "bt:mb.cherry_wood_stripped"
 		},
 		"tags": [
 			"crafting_table"

--- a/crafting_tweaks/files/more_blocks/more_bark/recipes/more_bark/stripped_wood/stripped_crimson_hyphae.json
+++ b/crafting_tweaks/files/more_blocks/more_bark/recipes/more_bark/stripped_wood/stripped_crimson_hyphae.json
@@ -1,8 +1,8 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
-			"identifier": "bt:mb.stripped_crimson_hyphae"
+			"identifier": "bt:mb.crimson_hyphae_stripped"
 		},
 		"tags": [
 			"crafting_table"

--- a/crafting_tweaks/files/more_blocks/more_bark/recipes/more_bark/stripped_wood/stripped_dark_oak_wood.recipe.json
+++ b/crafting_tweaks/files/more_blocks/more_bark/recipes/more_bark/stripped_wood/stripped_dark_oak_wood.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:mb.dark_oak_wood_stripped"

--- a/crafting_tweaks/files/more_blocks/more_bark/recipes/more_bark/stripped_wood/stripped_jungle_wood.recipe.json
+++ b/crafting_tweaks/files/more_blocks/more_bark/recipes/more_bark/stripped_wood/stripped_jungle_wood.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:mb.jungle_wood_stripped"

--- a/crafting_tweaks/files/more_blocks/more_bark/recipes/more_bark/stripped_wood/stripped_mangrove_wood.recipe.json
+++ b/crafting_tweaks/files/more_blocks/more_bark/recipes/more_bark/stripped_wood/stripped_mangrove_wood.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:mb.mangrove_wood_stripped"

--- a/crafting_tweaks/files/more_blocks/more_bark/recipes/more_bark/stripped_wood/stripped_oak_wood.recipe.json
+++ b/crafting_tweaks/files/more_blocks/more_bark/recipes/more_bark/stripped_wood/stripped_oak_wood.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:mb.oak_wood_stripped"

--- a/crafting_tweaks/files/more_blocks/more_bark/recipes/more_bark/stripped_wood/stripped_pale_oak_wood.json
+++ b/crafting_tweaks/files/more_blocks/more_bark/recipes/more_bark/stripped_wood/stripped_pale_oak_wood.json
@@ -1,0 +1,31 @@
+{
+	"format_version": "1.21.50",
+	"minecraft:recipe_shaped": {
+		"description": {
+			"identifier": "bt:mb.pale_oak_wood_stripped"
+		},
+		"tags": [
+			"crafting_table"
+		],
+		"group": "wood",
+		"priority": -1,
+		"pattern": [
+			"##",
+			"##"
+		],
+		"key": {
+			"#": {
+				"item": "minecraft:stripped_pale_oak_log"
+			}
+		},
+		"unlock": [
+			{
+				"item": "minecraft:stripped_pale_oak_log"
+			}
+		],
+		"result": {
+			"item": "minecraft:stripped_pale_oak_wood",
+			"count": 4
+		}
+	}
+}

--- a/crafting_tweaks/files/more_blocks/more_bark/recipes/more_bark/stripped_wood/stripped_spruce_wood.recipe.json
+++ b/crafting_tweaks/files/more_blocks/more_bark/recipes/more_bark/stripped_wood/stripped_spruce_wood.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:mb.spruce_wood_stripped"

--- a/crafting_tweaks/files/more_blocks/more_bark/recipes/more_bark/stripped_wood/stripped_warped_hyphae.recipe.json
+++ b/crafting_tweaks/files/more_blocks/more_bark/recipes/more_bark/stripped_wood/stripped_warped_hyphae.recipe.json
@@ -1,8 +1,8 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
-			"identifier": "bt:mb.stripped_warped_hyphae"
+			"identifier": "bt:mb.warped_hyphae_stripped"
 		},
 		"tags": [
 			"crafting_table"

--- a/crafting_tweaks/files/more_blocks/more_bark/recipes/more_bark/wood/acacia_wood.recipe.json
+++ b/crafting_tweaks/files/more_blocks/more_bark/recipes/more_bark/wood/acacia_wood.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:mb.acacia_wood"

--- a/crafting_tweaks/files/more_blocks/more_bark/recipes/more_bark/wood/birch_wood.recipe.json
+++ b/crafting_tweaks/files/more_blocks/more_bark/recipes/more_bark/wood/birch_wood.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:mb.birch_wood"

--- a/crafting_tweaks/files/more_blocks/more_bark/recipes/more_bark/wood/cherry_wood.recipe.json
+++ b/crafting_tweaks/files/more_blocks/more_bark/recipes/more_bark/wood/cherry_wood.recipe.json
@@ -1,8 +1,8 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
-			"identifier": "bt:mb.cherry_wood_from_log"
+			"identifier": "bt:mb.cherry_wood"
 		},
 		"tags": [
 			"crafting_table"

--- a/crafting_tweaks/files/more_blocks/more_bark/recipes/more_bark/wood/crimson_hyphae.recipe.json
+++ b/crafting_tweaks/files/more_blocks/more_bark/recipes/more_bark/wood/crimson_hyphae.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:mb.crimson_hyphae"

--- a/crafting_tweaks/files/more_blocks/more_bark/recipes/more_bark/wood/dark_oak_wood.recipe.json
+++ b/crafting_tweaks/files/more_blocks/more_bark/recipes/more_bark/wood/dark_oak_wood.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:mb.dark_oak_wood"

--- a/crafting_tweaks/files/more_blocks/more_bark/recipes/more_bark/wood/jungle_wood.recipe.json
+++ b/crafting_tweaks/files/more_blocks/more_bark/recipes/more_bark/wood/jungle_wood.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:mb.jungle_wood"

--- a/crafting_tweaks/files/more_blocks/more_bark/recipes/more_bark/wood/mangrove_wood.recipe.json
+++ b/crafting_tweaks/files/more_blocks/more_bark/recipes/more_bark/wood/mangrove_wood.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:mb.mangrove_wood"

--- a/crafting_tweaks/files/more_blocks/more_bark/recipes/more_bark/wood/oak_wood.recipe.json
+++ b/crafting_tweaks/files/more_blocks/more_bark/recipes/more_bark/wood/oak_wood.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:mb.oak_wood"

--- a/crafting_tweaks/files/more_blocks/more_bark/recipes/more_bark/wood/pale_oak_wood.json
+++ b/crafting_tweaks/files/more_blocks/more_bark/recipes/more_bark/wood/pale_oak_wood.json
@@ -1,0 +1,31 @@
+{
+	"format_version": "1.21.50",
+	"minecraft:recipe_shaped": {
+		"description": {
+			"identifier": "bt:mb.oak_wood"
+		},
+		"tags": [
+			"crafting_table"
+		],
+		"group": "wood",
+		"priority": -1,
+		"pattern": [
+			"##",
+			"##"
+		],
+		"key": {
+			"#": {
+				"item": "minecraft:pale_oak_log"
+			}
+		},
+		"unlock": [
+			{
+				"item": "minecraft:pale_oak_log"
+			}
+		],
+		"result": {
+			"item": "minecraft:pale_oak_wood",
+			"count": 4
+		}
+	}
+}

--- a/crafting_tweaks/files/more_blocks/more_bark/recipes/more_bark/wood/pale_oak_wood.json
+++ b/crafting_tweaks/files/more_blocks/more_bark/recipes/more_bark/wood/pale_oak_wood.json
@@ -2,7 +2,7 @@
 	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
-			"identifier": "bt:mb.oak_wood"
+			"identifier": "bt:mb.pale_oak_wood"
 		},
 		"tags": [
 			"crafting_table"

--- a/crafting_tweaks/files/more_blocks/more_bark/recipes/more_bark/wood/spruce_wood.recipe.json
+++ b/crafting_tweaks/files/more_blocks/more_bark/recipes/more_bark/wood/spruce_wood.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:mb.spruce_wood"

--- a/crafting_tweaks/files/more_blocks/more_bark/recipes/more_bark/wood/warped_hyphae.recipe.json
+++ b/crafting_tweaks/files/more_blocks/more_bark/recipes/more_bark/wood/warped_hyphae.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:mb.warped_hyphae"

--- a/crafting_tweaks/files/more_blocks/more_bricks/recipes/more_bricks/brick_block.recipe.json
+++ b/crafting_tweaks/files/more_blocks/more_bricks/recipes/more_bricks/brick_block.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:mb.brick_block"

--- a/crafting_tweaks/files/more_blocks/more_bricks/recipes/more_bricks/nether_brick_block.recipe.json
+++ b/crafting_tweaks/files/more_blocks/more_bricks/recipes/more_bricks/nether_brick_block.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:mb.nether_brick_block"

--- a/crafting_tweaks/files/more_blocks/more_bricks/recipes/more_bricks/red_nether_brick_block.recipe.json
+++ b/crafting_tweaks/files/more_blocks/more_bricks/recipes/more_bricks/red_nether_brick_block.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:mb.red_nether_brick_block"

--- a/crafting_tweaks/files/more_blocks/more_stairs/recipes/more_stairs/acacia_stairs.recipe.json
+++ b/crafting_tweaks/files/more_blocks/more_stairs/recipes/more_stairs/acacia_stairs.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:ms.acacia_stairs"

--- a/crafting_tweaks/files/more_blocks/more_stairs/recipes/more_stairs/andesite_stairs.recipe.json
+++ b/crafting_tweaks/files/more_blocks/more_stairs/recipes/more_stairs/andesite_stairs.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:ms.andesite_stairs"

--- a/crafting_tweaks/files/more_blocks/more_stairs/recipes/more_stairs/bamboo_mosiac_stairs.recipe.json
+++ b/crafting_tweaks/files/more_blocks/more_stairs/recipes/more_stairs/bamboo_mosiac_stairs.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:ms.bamboo_mosaic_stairs"

--- a/crafting_tweaks/files/more_blocks/more_stairs/recipes/more_stairs/bamboo_stairs.recipe.json
+++ b/crafting_tweaks/files/more_blocks/more_stairs/recipes/more_stairs/bamboo_stairs.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:ms.bamboo_stairs"

--- a/crafting_tweaks/files/more_blocks/more_stairs/recipes/more_stairs/birch_stairs.recipe.json
+++ b/crafting_tweaks/files/more_blocks/more_stairs/recipes/more_stairs/birch_stairs.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:ms.birch_stairs"

--- a/crafting_tweaks/files/more_blocks/more_stairs/recipes/more_stairs/blackstone_stairs.recipe.json
+++ b/crafting_tweaks/files/more_blocks/more_stairs/recipes/more_stairs/blackstone_stairs.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:ms.blackstone_stairs"

--- a/crafting_tweaks/files/more_blocks/more_stairs/recipes/more_stairs/brick_stairs.recipe.json
+++ b/crafting_tweaks/files/more_blocks/more_stairs/recipes/more_stairs/brick_stairs.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:ms.brick_stairs"

--- a/crafting_tweaks/files/more_blocks/more_stairs/recipes/more_stairs/cherry_stairs.recipe.json
+++ b/crafting_tweaks/files/more_blocks/more_stairs/recipes/more_stairs/cherry_stairs.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:ms.cherry_stairs"

--- a/crafting_tweaks/files/more_blocks/more_stairs/recipes/more_stairs/cobbled_deepslate_stairs.recipe.json
+++ b/crafting_tweaks/files/more_blocks/more_stairs/recipes/more_stairs/cobbled_deepslate_stairs.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:ms.cobbled_deepslate_stairs"

--- a/crafting_tweaks/files/more_blocks/more_stairs/recipes/more_stairs/cobblestone_stairs.recipe.json
+++ b/crafting_tweaks/files/more_blocks/more_stairs/recipes/more_stairs/cobblestone_stairs.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:ms.cobblestone_stairs"

--- a/crafting_tweaks/files/more_blocks/more_stairs/recipes/more_stairs/crimson_stairs.recipe.json
+++ b/crafting_tweaks/files/more_blocks/more_stairs/recipes/more_stairs/crimson_stairs.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:ms.crimson_stairs"

--- a/crafting_tweaks/files/more_blocks/more_stairs/recipes/more_stairs/cut_copper_stairs.recipe.json
+++ b/crafting_tweaks/files/more_blocks/more_stairs/recipes/more_stairs/cut_copper_stairs.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:ms.cut_copper_stairs"

--- a/crafting_tweaks/files/more_blocks/more_stairs/recipes/more_stairs/dark_oak_stairs.recipe.json
+++ b/crafting_tweaks/files/more_blocks/more_stairs/recipes/more_stairs/dark_oak_stairs.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:ms.dark_oak_stairs"

--- a/crafting_tweaks/files/more_blocks/more_stairs/recipes/more_stairs/dark_prismarine_stairs.recipe.json
+++ b/crafting_tweaks/files/more_blocks/more_stairs/recipes/more_stairs/dark_prismarine_stairs.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:ms.dark_prismarine_stairs"
@@ -15,14 +15,12 @@
 		],
 		"key": {
 			"#": {
-				"item": "minecraft:prismarine",
-				"data": 1
+				"item": "minecraft:dark_prismarine"
 			}
 		},
 		"unlock": [
 			{
-				"item": "minecraft:prismarine",
-				"data": 1
+				"item": "minecraft:dark_prismarine"
 			}
 		],
 		"result": {

--- a/crafting_tweaks/files/more_blocks/more_stairs/recipes/more_stairs/deepslate_brick_stairs.recipe.json
+++ b/crafting_tweaks/files/more_blocks/more_stairs/recipes/more_stairs/deepslate_brick_stairs.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:ms.deepslate_brick_stairs"

--- a/crafting_tweaks/files/more_blocks/more_stairs/recipes/more_stairs/deepslate_tile_stairs.recipe.json
+++ b/crafting_tweaks/files/more_blocks/more_stairs/recipes/more_stairs/deepslate_tile_stairs.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:ms.deepslate_tile_stairs"

--- a/crafting_tweaks/files/more_blocks/more_stairs/recipes/more_stairs/diorite_stairs.recipe.json
+++ b/crafting_tweaks/files/more_blocks/more_stairs/recipes/more_stairs/diorite_stairs.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:ms.diorite_stairs"

--- a/crafting_tweaks/files/more_blocks/more_stairs/recipes/more_stairs/end_brick_stairs.recipe.json
+++ b/crafting_tweaks/files/more_blocks/more_stairs/recipes/more_stairs/end_brick_stairs.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:ms.end_brick_stairs"

--- a/crafting_tweaks/files/more_blocks/more_stairs/recipes/more_stairs/exposed_cut_copper_stairs.recipe.json
+++ b/crafting_tweaks/files/more_blocks/more_stairs/recipes/more_stairs/exposed_cut_copper_stairs.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:ms.exposed_cut_copper_stairs"

--- a/crafting_tweaks/files/more_blocks/more_stairs/recipes/more_stairs/granite_stairs.recipe.json
+++ b/crafting_tweaks/files/more_blocks/more_stairs/recipes/more_stairs/granite_stairs.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:ms.granite_stairs"

--- a/crafting_tweaks/files/more_blocks/more_stairs/recipes/more_stairs/jungle_stairs.recipe.json
+++ b/crafting_tweaks/files/more_blocks/more_stairs/recipes/more_stairs/jungle_stairs.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:ms.jungle_stairs"

--- a/crafting_tweaks/files/more_blocks/more_stairs/recipes/more_stairs/mangrove_stairs.recipe.json
+++ b/crafting_tweaks/files/more_blocks/more_stairs/recipes/more_stairs/mangrove_stairs.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:ms.mangrove_stairs"

--- a/crafting_tweaks/files/more_blocks/more_stairs/recipes/more_stairs/mossy_cobblestone_stairs.recipe.json
+++ b/crafting_tweaks/files/more_blocks/more_stairs/recipes/more_stairs/mossy_cobblestone_stairs.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:ms.mossy_cobblestone_stairs"

--- a/crafting_tweaks/files/more_blocks/more_stairs/recipes/more_stairs/mossy_stone_brick_stairs.recipe.json
+++ b/crafting_tweaks/files/more_blocks/more_stairs/recipes/more_stairs/mossy_stone_brick_stairs.recipe.json
@@ -15,12 +15,12 @@
 		],
 		"key": {
 			"#": {
-				"item": "minecraft:mossy_stone_brick"
+				"item": "minecraft:mossy_stone_bricks"
 			}
 		},
 		"unlock": [
 			{
-				"item": "minecraft:mossy_stone_brick"
+				"item": "minecraft:mossy_stone_bricks"
 			}
 		],
 		"result": {

--- a/crafting_tweaks/files/more_blocks/more_stairs/recipes/more_stairs/mossy_stone_brick_stairs.recipe.json
+++ b/crafting_tweaks/files/more_blocks/more_stairs/recipes/more_stairs/mossy_stone_brick_stairs.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:ms.mossy_stone_brick_stairs"
@@ -15,14 +15,12 @@
 		],
 		"key": {
 			"#": {
-				"item": "minecraft:stonebrick",
-				"data": 1
+				"item": "minecraft:mossy_stone_brick"
 			}
 		},
 		"unlock": [
 			{
-				"item": "minecraft:stonebrick",
-				"data": 1
+				"item": "minecraft:mossy_stone_brick"
 			}
 		],
 		"result": {

--- a/crafting_tweaks/files/more_blocks/more_stairs/recipes/more_stairs/mud_brick_stairs.recipe.json
+++ b/crafting_tweaks/files/more_blocks/more_stairs/recipes/more_stairs/mud_brick_stairs.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:ms.mud_brick_stairs"

--- a/crafting_tweaks/files/more_blocks/more_stairs/recipes/more_stairs/nether_brick_stairs.recipe.json
+++ b/crafting_tweaks/files/more_blocks/more_stairs/recipes/more_stairs/nether_brick_stairs.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:ms.nether_brick_stairs"

--- a/crafting_tweaks/files/more_blocks/more_stairs/recipes/more_stairs/oak_stairs.recipe.json
+++ b/crafting_tweaks/files/more_blocks/more_stairs/recipes/more_stairs/oak_stairs.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:ms.oak_stairs"

--- a/crafting_tweaks/files/more_blocks/more_stairs/recipes/more_stairs/oxidized_cut_copper_stairs.recipe.json
+++ b/crafting_tweaks/files/more_blocks/more_stairs/recipes/more_stairs/oxidized_cut_copper_stairs.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:ms.oxidized_cut_copper_stairs"

--- a/crafting_tweaks/files/more_blocks/more_stairs/recipes/more_stairs/pale_oak_stairs.recipe.json
+++ b/crafting_tweaks/files/more_blocks/more_stairs/recipes/more_stairs/pale_oak_stairs.recipe.json
@@ -1,0 +1,32 @@
+{
+	"format_version": "1.21.50",
+	"minecraft:recipe_shaped": {
+		"description": {
+			"identifier": "bt:ms.pale_oak_stairs"
+		},
+		"tags": [
+			"crafting_table"
+		],
+		"group": "wooden_stairs",
+		"priority": -1,
+		"pattern": [
+			"#",
+			"##",
+			"###"
+		],
+		"key": {
+			"#": {
+				"item": "minecraft:pale_oak_planks"
+			}
+		},
+		"unlock": [
+			{
+				"item": "minecraft:pale_oak_planks"
+			}
+		],
+		"result": {
+			"item": "minecraft:pale_oak_stairs",
+			"count": 8
+		}
+	}
+}

--- a/crafting_tweaks/files/more_blocks/more_stairs/recipes/more_stairs/polished_andesite_stairs.recipe.json
+++ b/crafting_tweaks/files/more_blocks/more_stairs/recipes/more_stairs/polished_andesite_stairs.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:ms.polished_andesite_stairs"

--- a/crafting_tweaks/files/more_blocks/more_stairs/recipes/more_stairs/polished_blackstone_brick_stairs.recipe.json
+++ b/crafting_tweaks/files/more_blocks/more_stairs/recipes/more_stairs/polished_blackstone_brick_stairs.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:ms.polished_blackstone_brick_stairs"

--- a/crafting_tweaks/files/more_blocks/more_stairs/recipes/more_stairs/polished_blackstone_stairs.recipe.json
+++ b/crafting_tweaks/files/more_blocks/more_stairs/recipes/more_stairs/polished_blackstone_stairs.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:ms.polished_blackstone_stairs"

--- a/crafting_tweaks/files/more_blocks/more_stairs/recipes/more_stairs/polished_deepslate_stairs.recipe.json
+++ b/crafting_tweaks/files/more_blocks/more_stairs/recipes/more_stairs/polished_deepslate_stairs.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:ms.polished_deepslate_stairs"

--- a/crafting_tweaks/files/more_blocks/more_stairs/recipes/more_stairs/polished_diorite_stairs.recipe.json
+++ b/crafting_tweaks/files/more_blocks/more_stairs/recipes/more_stairs/polished_diorite_stairs.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:ms.polished_diorite_stairs"

--- a/crafting_tweaks/files/more_blocks/more_stairs/recipes/more_stairs/polished_granite_stairs.recipe.json
+++ b/crafting_tweaks/files/more_blocks/more_stairs/recipes/more_stairs/polished_granite_stairs.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:ms.polished_granite_stairs"

--- a/crafting_tweaks/files/more_blocks/more_stairs/recipes/more_stairs/polished_tuff_stairs.recipe.json
+++ b/crafting_tweaks/files/more_blocks/more_stairs/recipes/more_stairs/polished_tuff_stairs.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:ms.polished_tuff_stairs"

--- a/crafting_tweaks/files/more_blocks/more_stairs/recipes/more_stairs/prismarine_brick_stairs.recipe.json
+++ b/crafting_tweaks/files/more_blocks/more_stairs/recipes/more_stairs/prismarine_brick_stairs.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:ms.prismarine_bricks_stairs"
@@ -15,14 +15,12 @@
 		],
 		"key": {
 			"#": {
-				"item": "minecraft:prismarine",
-				"data": 2
+				"item": "minecraft:prismarine_bricks"
 			}
 		},
 		"unlock": [
 			{
-				"item": "minecraft:prismarine",
-				"data": 2
+				"item": "minecraft:prismarine_bricks"
 			}
 		],
 		"result": {

--- a/crafting_tweaks/files/more_blocks/more_stairs/recipes/more_stairs/prismarine_stairs.recipe.json
+++ b/crafting_tweaks/files/more_blocks/more_stairs/recipes/more_stairs/prismarine_stairs.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:ms.prismarine_stairs"
@@ -15,14 +15,12 @@
 		],
 		"key": {
 			"#": {
-				"item": "minecraft:prismarine",
-				"data": 0
+				"item": "minecraft:prismarine"
 			}
 		},
 		"unlock": [
 			{
-				"item": "minecraft:prismarine",
-				"data": 0
+				"item": "minecraft:prismarine"
 			}
 		],
 		"result": {

--- a/crafting_tweaks/files/more_blocks/more_stairs/recipes/more_stairs/purpur_stairs.recipe.json
+++ b/crafting_tweaks/files/more_blocks/more_stairs/recipes/more_stairs/purpur_stairs.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:ms.purpur_stairs"

--- a/crafting_tweaks/files/more_blocks/more_stairs/recipes/more_stairs/quartz_stairs.recipe.json
+++ b/crafting_tweaks/files/more_blocks/more_stairs/recipes/more_stairs/quartz_stairs.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:ms.quartz_stairs"

--- a/crafting_tweaks/files/more_blocks/more_stairs/recipes/more_stairs/red_nether_brick_stairs.recipe.json
+++ b/crafting_tweaks/files/more_blocks/more_stairs/recipes/more_stairs/red_nether_brick_stairs.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:ms.red_nether_brick_stairs"

--- a/crafting_tweaks/files/more_blocks/more_stairs/recipes/more_stairs/red_sandstone_stairs.recipe.json
+++ b/crafting_tweaks/files/more_blocks/more_stairs/recipes/more_stairs/red_sandstone_stairs.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:ms.red_sandstone_stairs"
@@ -15,14 +15,12 @@
 		],
 		"key": {
 			"#": {
-				"item": "minecraft:red_sandstone",
-				"data": 0
+				"item": "minecraft:red_sandstone"
 			}
 		},
 		"unlock": [
 			{
-				"item": "minecraft:red_sandstone",
-				"data": 0
+				"item": "minecraft:red_sandstone"
 			}
 		],
 		"result": {

--- a/crafting_tweaks/files/more_blocks/more_stairs/recipes/more_stairs/sandstone_stairs.recipe.json
+++ b/crafting_tweaks/files/more_blocks/more_stairs/recipes/more_stairs/sandstone_stairs.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:ms.sandstone_stairs"
@@ -15,14 +15,12 @@
 		],
 		"key": {
 			"#": {
-				"item": "minecraft:sandstone",
-				"data": 0
+				"item": "minecraft:sandstone"
 			}
 		},
 		"unlock": [
 			{
-				"item": "minecraft:sandstone",
-				"data": 0
+				"item": "minecraft:sandstone"
 			}
 		],
 		"result": {

--- a/crafting_tweaks/files/more_blocks/more_stairs/recipes/more_stairs/smooth_quartz_stairs.recipe.json
+++ b/crafting_tweaks/files/more_blocks/more_stairs/recipes/more_stairs/smooth_quartz_stairs.recipe.json
@@ -15,12 +15,12 @@
 		],
 		"key": {
 			"#": {
-				"item": "minecraft:smooth_quartz_block"
+				"item": "minecraft:smooth_quartz"
 			}
 		},
 		"unlock": [
 			{
-				"item": "minecraft:smooth_quartz_block"
+				"item": "minecraft:smooth_quartz"
 			}
 		],
 		"result": {

--- a/crafting_tweaks/files/more_blocks/more_stairs/recipes/more_stairs/smooth_quartz_stairs.recipe.json
+++ b/crafting_tweaks/files/more_blocks/more_stairs/recipes/more_stairs/smooth_quartz_stairs.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:ms.smooth_quartz_stairs"
@@ -15,14 +15,12 @@
 		],
 		"key": {
 			"#": {
-				"item": "minecraft:quartz_block",
-				"data": 3
+				"item": "minecraft:smooth_quartz_block"
 			}
 		},
 		"unlock": [
 			{
-				"item": "minecraft:quartz_block",
-				"data": 3
+				"item": "minecraft:smooth_quartz_block"
 			}
 		],
 		"result": {

--- a/crafting_tweaks/files/more_blocks/more_stairs/recipes/more_stairs/smooth_red_sandstone_stairs.recipe.json
+++ b/crafting_tweaks/files/more_blocks/more_stairs/recipes/more_stairs/smooth_red_sandstone_stairs.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:ms.smooth_red_sandstone_stairs"
@@ -15,14 +15,12 @@
 		],
 		"key": {
 			"#": {
-				"item": "minecraft:red_sandstone",
-				"data": 3
+				"item": "minecraft:smooth_red_sandstone"
 			}
 		},
 		"unlock": [
 			{
-				"item": "minecraft:red_sandstone",
-				"data": 3
+				"item": "minecraft:smooth_red_sandstone"
 			}
 		],
 		"result": {

--- a/crafting_tweaks/files/more_blocks/more_stairs/recipes/more_stairs/smooth_sandstone_stairs.recipe.json
+++ b/crafting_tweaks/files/more_blocks/more_stairs/recipes/more_stairs/smooth_sandstone_stairs.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:ms.smooth_sandstone_stairs"
@@ -15,14 +15,12 @@
 		],
 		"key": {
 			"#": {
-				"item": "minecraft:sandstone",
-				"data": 3
+				"item": "minecraft:smooth_sandstone"
 			}
 		},
 		"unlock": [
 			{
-				"item": "minecraft:sandstone",
-				"data": 3
+				"item": "minecraft:smooth_sandstone"
 			}
 		],
 		"result": {

--- a/crafting_tweaks/files/more_blocks/more_stairs/recipes/more_stairs/spruce_stairs.recipe.json
+++ b/crafting_tweaks/files/more_blocks/more_stairs/recipes/more_stairs/spruce_stairs.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:ms.spruce_stairs"

--- a/crafting_tweaks/files/more_blocks/more_stairs/recipes/more_stairs/stone_brick_stairs.recipe.json
+++ b/crafting_tweaks/files/more_blocks/more_stairs/recipes/more_stairs/stone_brick_stairs.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:ms.stone_brick_stairs"
@@ -15,14 +15,12 @@
 		],
 		"key": {
 			"#": {
-				"item": "minecraft:stonebrick",
-				"data": 0
+				"item": "minecraft:stone_bricks"
 			}
 		},
 		"unlock": [
 			{
-				"item": "minecraft:stonebrick",
-				"data": 0
+				"item": "minecraft:stone_bricks"
 			}
 		],
 		"result": {

--- a/crafting_tweaks/files/more_blocks/more_stairs/recipes/more_stairs/stone_stairs.recipe.json
+++ b/crafting_tweaks/files/more_blocks/more_stairs/recipes/more_stairs/stone_stairs.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:ms.stone_stairs"
@@ -15,14 +15,12 @@
 		],
 		"key": {
 			"#": {
-				"item": "minecraft:stone",
-				"data": 0
+				"item": "minecraft:stone"
 			}
 		},
 		"unlock": [
 			{
-				"item": "minecraft:stone",
-				"data": 0
+				"item": "minecraft:stone"
 			}
 		],
 		"result": {

--- a/crafting_tweaks/files/more_blocks/more_stairs/recipes/more_stairs/tuff_brick_stairs.recipe.json
+++ b/crafting_tweaks/files/more_blocks/more_stairs/recipes/more_stairs/tuff_brick_stairs.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:ms.tuff_brick_stairs"

--- a/crafting_tweaks/files/more_blocks/more_stairs/recipes/more_stairs/tuff_stairs.recipe.json
+++ b/crafting_tweaks/files/more_blocks/more_stairs/recipes/more_stairs/tuff_stairs.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:ms.tuff_stairs"

--- a/crafting_tweaks/files/more_blocks/more_stairs/recipes/more_stairs/warped_stairs.recipe.json
+++ b/crafting_tweaks/files/more_blocks/more_stairs/recipes/more_stairs/warped_stairs.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:ms.warped_stairs"

--- a/crafting_tweaks/files/more_blocks/more_stairs/recipes/more_stairs/waxed_cut_copper_stairs.recipe.json
+++ b/crafting_tweaks/files/more_blocks/more_stairs/recipes/more_stairs/waxed_cut_copper_stairs.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:ms.waxed_cut_copper_stairs"

--- a/crafting_tweaks/files/more_blocks/more_stairs/recipes/more_stairs/waxed_exposed_cut_copper_stairs.recipe.json
+++ b/crafting_tweaks/files/more_blocks/more_stairs/recipes/more_stairs/waxed_exposed_cut_copper_stairs.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:ms.waxed_exposed_cut_copper_stairs"

--- a/crafting_tweaks/files/more_blocks/more_stairs/recipes/more_stairs/waxed_oxidized_cut_copper_stairs.recipe.json
+++ b/crafting_tweaks/files/more_blocks/more_stairs/recipes/more_stairs/waxed_oxidized_cut_copper_stairs.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:ms.waxed_oxidized_cut_copper_stairs"

--- a/crafting_tweaks/files/more_blocks/more_stairs/recipes/more_stairs/waxed_weathered_cut_copper_stairs.recipe.json
+++ b/crafting_tweaks/files/more_blocks/more_stairs/recipes/more_stairs/waxed_weathered_cut_copper_stairs.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:ms.waxed_weathered_cut_copper_stairs"

--- a/crafting_tweaks/files/more_blocks/more_stairs/recipes/more_stairs/weathered_cut_copper_stairs.recipe.json
+++ b/crafting_tweaks/files/more_blocks/more_stairs/recipes/more_stairs/weathered_cut_copper_stairs.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:ms.weathered_cut_copper_stairs"

--- a/crafting_tweaks/files/more_blocks/more_trapdoors/recipes/more_trapdoors/acacia_trapdoor.recipe.json
+++ b/crafting_tweaks/files/more_blocks/more_trapdoors/recipes/more_trapdoors/acacia_trapdoor.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:mt.acacia_trapdoor"

--- a/crafting_tweaks/files/more_blocks/more_trapdoors/recipes/more_trapdoors/bamboo_trapdoor.recipe.json
+++ b/crafting_tweaks/files/more_blocks/more_trapdoors/recipes/more_trapdoors/bamboo_trapdoor.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:mt.bamboo_trapdoor"

--- a/crafting_tweaks/files/more_blocks/more_trapdoors/recipes/more_trapdoors/birch_trapdoor.recipe.json
+++ b/crafting_tweaks/files/more_blocks/more_trapdoors/recipes/more_trapdoors/birch_trapdoor.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:mt.birch_trapdoor"

--- a/crafting_tweaks/files/more_blocks/more_trapdoors/recipes/more_trapdoors/cherry_trapdoor.recipe.json
+++ b/crafting_tweaks/files/more_blocks/more_trapdoors/recipes/more_trapdoors/cherry_trapdoor.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:mt.cherry_trapdoor"

--- a/crafting_tweaks/files/more_blocks/more_trapdoors/recipes/more_trapdoors/crimson_trapdoor.recipe.json
+++ b/crafting_tweaks/files/more_blocks/more_trapdoors/recipes/more_trapdoors/crimson_trapdoor.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:mt.crimson_trapdoor"

--- a/crafting_tweaks/files/more_blocks/more_trapdoors/recipes/more_trapdoors/dark_oak_trapdoor.recipe.json
+++ b/crafting_tweaks/files/more_blocks/more_trapdoors/recipes/more_trapdoors/dark_oak_trapdoor.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:mt.dark_oak_trapdoor"

--- a/crafting_tweaks/files/more_blocks/more_trapdoors/recipes/more_trapdoors/jungle_trapdoor.recipe.json
+++ b/crafting_tweaks/files/more_blocks/more_trapdoors/recipes/more_trapdoors/jungle_trapdoor.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:mt.jungle_trapdoor"

--- a/crafting_tweaks/files/more_blocks/more_trapdoors/recipes/more_trapdoors/mangrove_trapdoor.recipe.json
+++ b/crafting_tweaks/files/more_blocks/more_trapdoors/recipes/more_trapdoors/mangrove_trapdoor.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:mt.mangrove_trapdoor"

--- a/crafting_tweaks/files/more_blocks/more_trapdoors/recipes/more_trapdoors/oak_trapdoor.recipe.json
+++ b/crafting_tweaks/files/more_blocks/more_trapdoors/recipes/more_trapdoors/oak_trapdoor.recipe.json
@@ -1,8 +1,8 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
-			"identifier": "bt:mt.trapdoor"
+			"identifier": "bt:mt.oak_trapdoor"
 		},
 		"tags": [
 			"crafting_table"

--- a/crafting_tweaks/files/more_blocks/more_trapdoors/recipes/more_trapdoors/pale_oak_trapdoor.recipe.json
+++ b/crafting_tweaks/files/more_blocks/more_trapdoors/recipes/more_trapdoors/pale_oak_trapdoor.recipe.json
@@ -1,0 +1,31 @@
+{
+	"format_version": "1.21.50",
+	"minecraft:recipe_shaped": {
+		"description": {
+			"identifier": "bt:mt.pale_oak_trapdoor"
+		},
+		"tags": [
+			"crafting_table"
+		],
+		"group": "wooden_trap_door",
+		"priority": -1,
+		"pattern": [
+			"###",
+			"###"
+		],
+		"key": {
+			"#": {
+				"item": "minecraft:pale_oak_planks"
+			}
+		},
+		"unlock": [
+			{
+				"item": "minecraft:pale_oak_planks"
+			}
+		],
+		"result": {
+			"item": "minecraft:pale_oak_trapdoor",
+			"count": 12
+		}
+	}
+}

--- a/crafting_tweaks/files/more_blocks/more_trapdoors/recipes/more_trapdoors/spruce_trapdoor.recipe.json
+++ b/crafting_tweaks/files/more_blocks/more_trapdoors/recipes/more_trapdoors/spruce_trapdoor.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:mt.spruce_trapdoor"

--- a/crafting_tweaks/files/more_blocks/more_trapdoors/recipes/more_trapdoors/warped_trapdoor.recipe.json
+++ b/crafting_tweaks/files/more_blocks/more_trapdoors/recipes/more_trapdoors/warped_trapdoor.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:mt.warped_trapdoor"

--- a/crafting_tweaks/files/quality_of_life/alternate_cobblestone/recipes/alternate_cobblestones/dispenser.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/alternate_cobblestone/recipes/alternate_cobblestones/dispenser.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:ac.dispenser"

--- a/crafting_tweaks/files/quality_of_life/alternate_cobblestone/recipes/alternate_cobblestones/dropper.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/alternate_cobblestone/recipes/alternate_cobblestones/dropper.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:ac.dropper"

--- a/crafting_tweaks/files/quality_of_life/alternate_cobblestone/recipes/alternate_cobblestones/lever.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/alternate_cobblestone/recipes/alternate_cobblestones/lever.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:ac.lever"

--- a/crafting_tweaks/files/quality_of_life/alternate_cobblestone/recipes/alternate_cobblestones/observer.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/alternate_cobblestone/recipes/alternate_cobblestones/observer.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "minecraft:observer"

--- a/crafting_tweaks/files/quality_of_life/alternate_cobblestone/recipes/alternate_cobblestones/piston.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/alternate_cobblestone/recipes/alternate_cobblestones/piston.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "minecraft:piston"

--- a/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/slabs/acacia_planks.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/slabs/acacia_planks.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:bb.slabs.acacia_planks"

--- a/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/slabs/andesite.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/slabs/andesite.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:bb.slabs.andesite"
@@ -14,14 +14,12 @@
 		],
 		"key": {
 			"#": {
-				"item": "minecraft:stone_block_slab3",
-				"data": 3
+				"item": "minecraft:andesite_slab"
 			}
 		},
 		"unlock": [
 			{
-				"item": "minecraft:stone_block_slab3",
-				"data": 3
+				"item": "minecraft:andesite_slab"
 			}
 		],
 		"result": {

--- a/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/slabs/bamboo_mosiac.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/slabs/bamboo_mosiac.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:bb.slabs.bamboo_mosaic"

--- a/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/slabs/bamboo_planks.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/slabs/bamboo_planks.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:bb.slabs.bamboo_planks"

--- a/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/slabs/birch_planks.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/slabs/birch_planks.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:bb.slabs.birch_planks"

--- a/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/slabs/blackstone.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/slabs/blackstone.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:bb.slabs.blackstone"

--- a/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/slabs/brick_block.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/slabs/brick_block.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:bb.slabs.brick_block"

--- a/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/slabs/cherry_planks.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/slabs/cherry_planks.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:bb.slabs.cherry_planks"

--- a/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/slabs/cobbled_deepslate.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/slabs/cobbled_deepslate.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:bb.slabs.cobbled_deepslate"

--- a/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/slabs/cobblestone.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/slabs/cobblestone.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:bb.slabs.cobblestone"

--- a/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/slabs/crimson_planks.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/slabs/crimson_planks.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:bb.slabs.crimson_planks"

--- a/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/slabs/cut_copper.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/slabs/cut_copper.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:bb.slabs.cut_copper"

--- a/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/slabs/cut_red_sandstone.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/slabs/cut_red_sandstone.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:bb.slabs.cut_red_sandstone"
@@ -14,19 +14,16 @@
 		],
 		"key": {
 			"#": {
-				"item": "minecraft:stone_block_slab4",
-				"data": 4
+				"item": "minecraft:cut_red_sandstone_slab"
 			}
 		},
 		"unlock": [
 			{
-				"item": "minecraft:stone_block_slab4",
-				"data": 4
+				"item": "minecraft:cut_red_sandstone_slab"
 			}
 		],
 		"result": {
-			"item": "minecraft:red_sandstone",
-			"data": 2,
+			"item": "minecraft:cut_red_sandstone",
 			"count": 1
 		}
 	}

--- a/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/slabs/cut_sandstone.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/slabs/cut_sandstone.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:bb.slabs.cut_sandstone"
@@ -14,19 +14,16 @@
 		],
 		"key": {
 			"#": {
-				"item": "minecraft:stone_block_slab4",
-				"data": 3
+				"item": "minecraft:cut_sandstone_slab"
 			}
 		},
 		"unlock": [
 			{
-				"item": "minecraft:stone_block_slab4",
-				"data": 3
+				"item": "minecraft:cut_sandstone_slab"
 			}
 		],
 		"result": {
-			"item": "minecraft:sandstone",
-			"data": 2,
+			"item": "minecraft:cut_sandstone",
 			"count": 1
 		}
 	}

--- a/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/slabs/dark_oak_planks.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/slabs/dark_oak_planks.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:bb.slabs.dark_oak_planks"

--- a/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/slabs/dark_prismarine.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/slabs/dark_prismarine.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:bb.slabs.dark_prismarine"
@@ -14,19 +14,16 @@
 		],
 		"key": {
 			"#": {
-				"item": "minecraft:stone_block_slab2",
-				"data": 3
+				"item": "minecraft:dark_prismarine_slab"
 			}
 		},
 		"unlock": [
 			{
-				"item": "minecraft:stone_block_slab2",
-				"data": 3
+				"item": "minecraft:dark_prismarine_slab"
 			}
 		],
 		"result": {
-			"item": "minecraft:prismarine",
-			"data": 1,
+			"item": "minecraft:dark_prismarine",
 			"count": 1
 		}
 	}

--- a/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/slabs/deepslate_bricks.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/slabs/deepslate_bricks.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:bb.slabs.deepslate_bricks"

--- a/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/slabs/deepslate_tiles.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/slabs/deepslate_tiles.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:bb.slabs.deepslate_tiles"

--- a/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/slabs/diorite.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/slabs/diorite.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:bb.slabs.diorite"
@@ -14,14 +14,12 @@
 		],
 		"key": {
 			"#": {
-				"item": "minecraft:stone_block_slab3",
-				"data": 4
+				"item": "minecraft:diorite_slab"
 			}
 		},
 		"unlock": [
 			{
-				"item": "minecraft:stone_block_slab3",
-				"data": 4
+				"item": "minecraft:diorite_slab"
 			}
 		],
 		"result": {

--- a/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/slabs/end_bricks.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/slabs/end_bricks.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:bb.slabs.end_bricks"
@@ -14,13 +14,13 @@
 		],
 		"key": {
 			"#": {
-				"item": "minecraft:stone_block_slab3",
+				"item": "minecraft:end_stone_brick_slab",
 				"data": 0
 			}
 		},
 		"unlock": [
 			{
-				"item": "minecraft:stone_block_slab3",
+				"item": "minecraft:end_stone_brick_slab",
 				"data": 0
 			}
 		],

--- a/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/slabs/exposed_cut_copper.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/slabs/exposed_cut_copper.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:bb.slabs.exposed_cut_copper"

--- a/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/slabs/granite.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/slabs/granite.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:bb.slabs.granite"
@@ -14,14 +14,12 @@
 		],
 		"key": {
 			"#": {
-				"item": "minecraft:stone_block_slab3",
-				"data": 6
+				"item": "minecraft:granite_slab"
 			}
 		},
 		"unlock": [
 			{
-				"item": "minecraft:stone_block_slab3",
-				"data": 6
+				"item": "minecraft:granite_slab"
 			}
 		],
 		"result": {

--- a/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/slabs/jungle_planks.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/slabs/jungle_planks.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:bb.slabs.jungle_planks"

--- a/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/slabs/mangrove_planks.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/slabs/mangrove_planks.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:bb.slabs.mangrove_planks"

--- a/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/slabs/mossy_cobblestone.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/slabs/mossy_cobblestone.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:bb.slabs.mossy_cobblestone"
@@ -14,14 +14,12 @@
 		],
 		"key": {
 			"#": {
-				"item": "minecraft:stone_block_slab2",
-				"data": 5
+				"item": "minecraft:mossy_cobblestone_slab"
 			}
 		},
 		"unlock": [
 			{
-				"item": "minecraft:stone_block_slab2",
-				"data": 5
+				"item": "minecraft:mossy_cobblestone_slab"
 			}
 		],
 		"result": {

--- a/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/slabs/mossy_stone_brick.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/slabs/mossy_stone_brick.recipe.json
@@ -2,7 +2,7 @@
 	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
-			"identifier": "bt:bb.slabs.mossy_stone_brick"
+			"identifier": "bt:bb.slabs.mossy_stone_bricks"
 		},
 		"tags": [
 			"crafting_table"
@@ -23,7 +23,7 @@
 			}
 		],
 		"result": {
-			"item": "minecraft:mossy_stone_brick",
+			"item": "minecraft:mossy_stone_bricks",
 			"count": 1
 		}
 	}

--- a/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/slabs/mossy_stone_brick.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/slabs/mossy_stone_brick.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:bb.slabs.mossy_stone_brick"
@@ -14,19 +14,16 @@
 		],
 		"key": {
 			"#": {
-				"item": "minecraft:stone_block_slab4",
-				"data": 0
+				"item": "minecraft:mossy_stone_brick_slab"
 			}
 		},
 		"unlock": [
 			{
-				"item": "minecraft:stone_block_slab4",
-				"data": 0
+				"item": "minecraft:mossy_stone_brick_slab"
 			}
 		],
 		"result": {
-			"item": "minecraft:stonebrick",
-			"data": 1,
+			"item": "minecraft:mossy_stone_brick",
 			"count": 1
 		}
 	}

--- a/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/slabs/mud_bricks.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/slabs/mud_bricks.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:bb.slabs.mud_bricks"

--- a/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/slabs/nether_brick.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/slabs/nether_brick.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:bb.slabs.nether_brick"

--- a/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/slabs/oak_planks.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/slabs/oak_planks.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:bb.slabs.oak_planks"

--- a/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/slabs/oxidized_cut_copper.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/slabs/oxidized_cut_copper.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:bb.slabs.oxidized_cut_copper"

--- a/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/slabs/pale_oak_planks.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/slabs/pale_oak_planks.recipe.json
@@ -1,0 +1,30 @@
+{
+	"format_version": "1.21.50",
+	"minecraft:recipe_shaped": {
+		"description": {
+			"identifier": "bt:bb.slabs.pale_oak_planks"
+		},
+		"tags": [
+			"crafting_table"
+		],
+		"group": "slabs_to_blocks",
+		"priority": -1,
+		"pattern": [
+			"##"
+		],
+		"key": {
+			"#": {
+				"item": "minecraft:pale_oak_slab"
+			}
+		},
+		"unlock": [
+			{
+				"item": "minecraft:pale_oak_slab"
+			}
+		],
+		"result": {
+			"item": "minecraft:pale_oak_planks",
+			"count": 1
+		}
+	}
+}

--- a/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/slabs/polished_andesite.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/slabs/polished_andesite.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:bb.slabs.polished_andesite"
@@ -14,14 +14,12 @@
 		],
 		"key": {
 			"#": {
-				"item": "minecraft:stone_block_slab3",
-				"data": 2
+				"item": "minecraft:polished_andesite_slab"
 			}
 		},
 		"unlock": [
 			{
-				"item": "minecraft:stone_block_slab3",
-				"data": 2
+				"item": "minecraft:polished_andesite_slab"
 			}
 		],
 		"result": {

--- a/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/slabs/polished_blackstone.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/slabs/polished_blackstone.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:bb.slabs.polished_blackstone"

--- a/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/slabs/polished_blackstone_bricks.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/slabs/polished_blackstone_bricks.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:bb.slabs.polished_blackstone_bricks"

--- a/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/slabs/polished_deepslate.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/slabs/polished_deepslate.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:bb.slabs.polished_deepslate"

--- a/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/slabs/polished_diorite.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/slabs/polished_diorite.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:bb.slabs.polished_diorite"
@@ -14,14 +14,12 @@
 		],
 		"key": {
 			"#": {
-				"item": "minecraft:stone_block_slab3",
-				"data": 5
+				"item": "minecraft:polished_diorite_slab"
 			}
 		},
 		"unlock": [
 			{
-				"item": "minecraft:stone_block_slab3",
-				"data": 5
+				"item": "minecraft:polished_diorite_slab"
 			}
 		],
 		"result": {

--- a/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/slabs/polished_granite.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/slabs/polished_granite.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:bb.slabs.polished_granite"
@@ -14,14 +14,12 @@
 		],
 		"key": {
 			"#": {
-				"item": "minecraft:stone_block_slab3",
-				"data": 7
+				"item": "minecraft:polished_granite_slab"
 			}
 		},
 		"unlock": [
 			{
-				"item": "minecraft:stone_block_slab3",
-				"data": 7
+				"item": "minecraft:polished_granite_slab"
 			}
 		],
 		"result": {

--- a/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/slabs/polished_tuff.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/slabs/polished_tuff.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:bb.slabs.polished_tuff"

--- a/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/slabs/prismarine.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/slabs/prismarine.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:bb.slabs.prismarine"
@@ -14,19 +14,16 @@
 		],
 		"key": {
 			"#": {
-				"item": "minecraft:stone_block_slab2",
-				"data": 2
+				"item": "minecraft:prismarine_slab"
 			}
 		},
 		"unlock": [
 			{
-				"item": "minecraft:stone_block_slab2",
-				"data": 2
+				"item": "minecraft:prismarine_slab"
 			}
 		],
 		"result": {
 			"item": "minecraft:prismarine",
-			"data": 0,
 			"count": 1
 		}
 	}

--- a/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/slabs/prismarine_bricks.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/slabs/prismarine_bricks.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:bb.slabs.prismarine_bricks"
@@ -14,19 +14,16 @@
 		],
 		"key": {
 			"#": {
-				"item": "minecraft:stone_block_slab2",
-				"data": 4
+				"item": "minecraft:prismarine_brick_slab"
 			}
 		},
 		"unlock": [
 			{
-				"item": "minecraft:stone_block_slab2",
-				"data": 4
+				"item": "minecraft:prismarine_brick_slab"
 			}
 		],
 		"result": {
-			"item": "minecraft:prismarine",
-			"data": 2,
+			"item": "minecraft:prismarine_bricks",
 			"count": 1
 		}
 	}

--- a/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/slabs/purpur_block.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/slabs/purpur_block.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:bb.slabs.purpur_block"
@@ -14,14 +14,12 @@
 		],
 		"key": {
 			"#": {
-				"item": "minecraft:stone_block_slab2",
-				"data": 1
+				"item": "minecraft:purpur_slab"
 			}
 		},
 		"unlock": [
 			{
-				"item": "minecraft:stone_block_slab2",
-				"data": 1
+				"item": "minecraft:purpur_slab"
 			}
 		],
 		"result": {

--- a/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/slabs/quartz_block.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/slabs/quartz_block.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:bb.slabs.quartz_block"

--- a/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/slabs/red_nether_brick.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/slabs/red_nether_brick.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:bb.slabs.red_nether_brick"
@@ -14,14 +14,12 @@
 		],
 		"key": {
 			"#": {
-				"item": "minecraft:stone_block_slab2",
-				"data": 7
+				"item": "minecraft:red_nether_brick_slab"
 			}
 		},
 		"unlock": [
 			{
-				"item": "minecraft:stone_block_slab2",
-				"data": 7
+				"item": "minecraft:red_nether_brick_slab"
 			}
 		],
 		"result": {

--- a/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/slabs/red_sandstone.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/slabs/red_sandstone.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:bb.slabs.red_sandstone"
@@ -14,19 +14,16 @@
 		],
 		"key": {
 			"#": {
-				"item": "minecraft:stone_block_slab2",
-				"data": 0
+				"item": "minecraft:red_sandstone_slab"
 			}
 		},
 		"unlock": [
 			{
-				"item": "minecraft:stone_block_slab2",
-				"data": 0
+				"item": "minecraft:red_sandstone_slab"
 			}
 		],
 		"result": {
 			"item": "minecraft:red_sandstone",
-			"data": 0,
 			"count": 1
 		}
 	}

--- a/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/slabs/sandstone.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/slabs/sandstone.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:bb.slabs.sandstone"
@@ -24,7 +24,6 @@
 		],
 		"result": {
 			"item": "minecraft:sandstone",
-			"data": 0,
 			"count": 1
 		}
 	}

--- a/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/slabs/smooth_quartz.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/slabs/smooth_quartz.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:bb.slabs.smooth_quartz"
@@ -14,19 +14,16 @@
 		],
 		"key": {
 			"#": {
-				"item": "minecraft:stone_block_slab4",
-				"data": 1
+				"item": "minecraft:smooth_quartz_slab"
 			}
 		},
 		"unlock": [
 			{
-				"item": "minecraft:stone_block_slab4",
-				"data": 1
+				"item": "minecraft:smooth_quartz_slab"
 			}
 		],
 		"result": {
-			"item": "minecraft:quartz_block",
-			"data": 3,
+			"item": "minecraft:smooth_quartz",
 			"count": 1
 		}
 	}

--- a/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/slabs/smooth_red_sandstone.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/slabs/smooth_red_sandstone.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:bb.slabs.smooth_red_sandstone"
@@ -14,19 +14,16 @@
 		],
 		"key": {
 			"#": {
-				"item": "minecraft:stone_block_slab3",
-				"data": 1
+				"item": "minecraft:smooth_red_sandstone_slab"
 			}
 		},
 		"unlock": [
 			{
-				"item": "minecraft:stone_block_slab3",
-				"data": 1
+				"item": "minecraft:smooth_red_sandstone_slab"
 			}
 		],
 		"result": {
-			"item": "minecraft:red_sandstone",
-			"data": 3,
+			"item": "minecraft:smooth_red_sandstone",
 			"count": 1
 		}
 	}

--- a/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/slabs/smooth_sandstone.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/slabs/smooth_sandstone.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:bb.slabs.smooth_sandstone"
@@ -14,19 +14,16 @@
 		],
 		"key": {
 			"#": {
-				"item": "minecraft:stone_block_slab2",
-				"data": 6
+				"item": "minecraft:smooth_sandstone"
 			}
 		},
 		"unlock": [
 			{
-				"item": "minecraft:stone_block_slab2",
-				"data": 6
+				"item": "minecraft:smooth_sandstone"
 			}
 		],
 		"result": {
-			"item": "minecraft:sandstone",
-			"data": 3,
+			"item": "minecraft:smooth_sandstone",
 			"count": 1
 		}
 	}

--- a/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/slabs/smooth_stone.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/slabs/smooth_stone.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:bb.slabs.smooth_stone"

--- a/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/slabs/spruce_planks.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/slabs/spruce_planks.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:bb.slabs.spruce_planks"

--- a/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/slabs/stone.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/slabs/stone.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:bb.slabs.stone"
@@ -14,19 +14,16 @@
 		],
 		"key": {
 			"#": {
-				"item": "minecraft:stone_block_slab4",
-				"data": 2
+				"item": "minecraft:normal_stone_slab"
 			}
 		},
 		"unlock": [
 			{
-				"item": "minecraft:stone_block_slab4",
-				"data": 2
+				"item": "minecraft:normal_stone_slab"
 			}
 		],
 		"result": {
 			"item": "minecraft:stone",
-			"data": 0,
 			"count": 1
 		}
 	}

--- a/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/slabs/stone_brick.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/slabs/stone_brick.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:bb.slabs.stone_brick"
@@ -23,8 +23,7 @@
 			}
 		],
 		"result": {
-			"item": "minecraft:stonebrick",
-			"data": 0,
+			"item": "minecraft:stone_bricks",
 			"count": 1
 		}
 	}

--- a/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/slabs/tuff.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/slabs/tuff.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:bb.slabs.tuff"

--- a/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/slabs/tuff_bricks.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/slabs/tuff_bricks.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:bb.slabs.tuff_bricks"

--- a/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/slabs/warped_planks.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/slabs/warped_planks.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:bb.slabs.warped_planks"

--- a/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/slabs/waxed_cut_copper.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/slabs/waxed_cut_copper.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:bb.slabs.waxed_cut_copper"

--- a/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/slabs/waxed_exposed_cut_copper.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/slabs/waxed_exposed_cut_copper.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:bb.slabs.waxed_exposed_cut_copper"

--- a/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/slabs/waxed_oxidized_cut_copper.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/slabs/waxed_oxidized_cut_copper.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:bb.slabs.waxed_oxidized_cut_copper"

--- a/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/slabs/waxed_weathered_cut_copper.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/slabs/waxed_weathered_cut_copper.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:bb.slabs.waxed_weathered_cut_copper"

--- a/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/slabs/weathered_cut_copper.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/slabs/weathered_cut_copper.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:bb.slabs.weathered_cut_copper"

--- a/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/stairs/acacia_planks.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/stairs/acacia_planks.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:bb.stairs.acacia_planks"

--- a/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/stairs/andesite.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/stairs/andesite.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:bb.stairs.andesite"

--- a/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/stairs/bamboo_mosiac.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/stairs/bamboo_mosiac.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:bb.stairs.bamboo_mosaic"

--- a/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/stairs/bamboo_planks.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/stairs/bamboo_planks.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:bb.stairs.bamboo_planks"

--- a/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/stairs/birch_planks.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/stairs/birch_planks.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:bb.stairs.birch_planks"

--- a/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/stairs/blackstone.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/stairs/blackstone.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:bb.stairs.blackstone"

--- a/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/stairs/brick_block.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/stairs/brick_block.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:bb.stairs.brick_block"

--- a/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/stairs/cherry_planks.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/stairs/cherry_planks.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:bb.stairs.cherry_planks"

--- a/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/stairs/cobbled_deepslate.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/stairs/cobbled_deepslate.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:bb.stairs.cobbled_deepslate"

--- a/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/stairs/cobblestone.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/stairs/cobblestone.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:bb.stairs.cobblestone"

--- a/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/stairs/crimson_planks.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/stairs/crimson_planks.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:bb.stairs.crimson_planks"

--- a/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/stairs/cut_copper.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/stairs/cut_copper.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:bb.stairs.cut_copper"

--- a/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/stairs/dark_oak_planks.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/stairs/dark_oak_planks.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:bb.stairs.dark_oak_planks"

--- a/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/stairs/dark_prismarine.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/stairs/dark_prismarine.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:bb.stairs.dark_prismarine"
@@ -24,8 +24,7 @@
 			}
 		],
 		"result": {
-			"item": "minecraft:prismarine",
-			"data": 1,
+			"item": "minecraft:dark_prismarine",
 			"count": 3
 		}
 	}

--- a/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/stairs/deepslate_bricks.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/stairs/deepslate_bricks.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:bb.stairs.deepslate_bricks"

--- a/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/stairs/deepslate_tiles.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/stairs/deepslate_tiles.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:bb.stairs.deepslate_tiles"

--- a/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/stairs/diorite.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/stairs/diorite.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:bb.stairs.diorite"

--- a/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/stairs/end_bricks.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/stairs/end_bricks.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:bb.stairs.end_bricks"

--- a/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/stairs/exposed_cut_copper.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/stairs/exposed_cut_copper.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:bb.stairs.exposed_cut_copper"

--- a/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/stairs/granite.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/stairs/granite.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:bb.stairs.granite"

--- a/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/stairs/jungle_planks.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/stairs/jungle_planks.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:bb.stairs.jungle_planks"

--- a/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/stairs/mangrove_planks.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/stairs/mangrove_planks.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:bb.stairs.mangrove_planks"

--- a/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/stairs/mossy_cobblestone.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/stairs/mossy_cobblestone.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:bb.stairs.mossy_cobblestone"

--- a/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/stairs/mossy_stone_brick.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/stairs/mossy_stone_brick.recipe.json
@@ -2,7 +2,7 @@
 	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
-			"identifier": "bt:bb.stairs.mossy_stone_brick"
+			"identifier": "bt:bb.stairs.mossy_stone_bricks"
 		},
 		"tags": [
 			"crafting_table"
@@ -24,7 +24,7 @@
 			}
 		],
 		"result": {
-			"item": "minecraft:mossy_stone_brick",
+			"item": "minecraft:mossy_stone_bricks",
 			"count": 3
 		}
 	}

--- a/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/stairs/mossy_stone_brick.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/stairs/mossy_stone_brick.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:bb.stairs.mossy_stone_brick"
@@ -24,8 +24,7 @@
 			}
 		],
 		"result": {
-			"item": "minecraft:stonebrick",
-			"data": 1,
+			"item": "minecraft:mossy_stone_brick",
 			"count": 3
 		}
 	}

--- a/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/stairs/mud_bricks.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/stairs/mud_bricks.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:bb.stairs.mud_bricks"

--- a/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/stairs/nether_brick.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/stairs/nether_brick.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:bb.stairs.nether_brick"

--- a/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/stairs/oak_planks.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/stairs/oak_planks.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:bb.stairs.oak_planks"

--- a/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/stairs/oxidized_cut_copper.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/stairs/oxidized_cut_copper.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:bb.stairs.oxidized_cut_copper"

--- a/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/stairs/pale_oak_planks.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/stairs/pale_oak_planks.recipe.json
@@ -1,0 +1,31 @@
+{
+	"format_version": "1.21.50",
+	"minecraft:recipe_shaped": {
+		"description": {
+			"identifier": "bt:bb.stairs.pale_oak_planks"
+		},
+		"tags": [
+			"crafting_table"
+		],
+		"group": "stairs_to_blocks",
+		"priority": -1,
+		"pattern": [
+			"##",
+			"##"
+		],
+		"key": {
+			"#": {
+				"item": "minecraft:pale_oak_stairs"
+			}
+		},
+		"unlock": [
+			{
+				"item": "minecraft:pale_oak_stairs"
+			}
+		],
+		"result": {
+			"item": "minecraft:pale_oak_planks",
+			"count": 3
+		}
+	}
+}

--- a/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/stairs/polished_andesite.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/stairs/polished_andesite.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:bb.stairs.polished_andesite"

--- a/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/stairs/polished_blackstone.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/stairs/polished_blackstone.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:bb.stairs.polished_blackstone"

--- a/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/stairs/polished_blackstone_bricks.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/stairs/polished_blackstone_bricks.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:bb.stairs.polished_blackstone_bricks"

--- a/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/stairs/polished_deepslate.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/stairs/polished_deepslate.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:bb.stairs.polished_deepslate"

--- a/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/stairs/polished_diorite.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/stairs/polished_diorite.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:bb.stairs.polished_diorite"

--- a/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/stairs/polished_granite.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/stairs/polished_granite.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:bb.stairs.polished_granite"

--- a/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/stairs/polished_tuff.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/stairs/polished_tuff.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:bb.stairs.polished_tuff"

--- a/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/stairs/prismarine.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/stairs/prismarine.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:bb.stairs.prismarine"
@@ -25,7 +25,6 @@
 		],
 		"result": {
 			"item": "minecraft:prismarine",
-			"data": 0,
 			"count": 3
 		}
 	}

--- a/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/stairs/prismarine_bricks.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/stairs/prismarine_bricks.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:bb.stairs.prismarine_bricks"
@@ -24,8 +24,7 @@
 			}
 		],
 		"result": {
-			"item": "minecraft:prismarine",
-			"data": 2,
+			"item": "minecraft:prismarine_bricks",
 			"count": 3
 		}
 	}

--- a/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/stairs/purpur_block.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/stairs/purpur_block.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:bb.stairs.purpur_block"

--- a/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/stairs/quartz_block.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/stairs/quartz_block.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:bb.stairs.quartz_block"
@@ -25,7 +25,6 @@
 		],
 		"result": {
 			"item": "minecraft:quartz_block",
-			"data": 0,
 			"count": 3
 		}
 	}

--- a/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/stairs/red_nether_brick.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/stairs/red_nether_brick.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:bb.stairs.red_nether_brick"

--- a/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/stairs/red_sandstone.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/stairs/red_sandstone.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:bb.stairs.red_sandstone"
@@ -25,7 +25,6 @@
 		],
 		"result": {
 			"item": "minecraft:red_sandstone",
-			"data": 0,
 			"count": 3
 		}
 	}

--- a/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/stairs/sandstone.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/stairs/sandstone.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:bb.stairs.sandstone"
@@ -25,7 +25,6 @@
 		],
 		"result": {
 			"item": "minecraft:sandstone",
-			"data": 0,
 			"count": 3
 		}
 	}

--- a/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/stairs/smooth_quartz.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/stairs/smooth_quartz.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:bb.stairs.smooth_quartz"
@@ -24,8 +24,7 @@
 			}
 		],
 		"result": {
-			"item": "minecraft:quartz_block",
-			"data": 3,
+			"item": "minecraft:smooth_quartz",
 			"count": 3
 		}
 	}

--- a/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/stairs/smooth_red_sandstone.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/stairs/smooth_red_sandstone.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:bb.stairs.smooth_red_sandstone"
@@ -24,8 +24,7 @@
 			}
 		],
 		"result": {
-			"item": "minecraft:red_sandstone",
-			"data": 3,
+			"item": "minecraft:smooth_red_sandstone",
 			"count": 3
 		}
 	}

--- a/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/stairs/smooth_sandstone.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/stairs/smooth_sandstone.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:bb.stairs.smooth_sandstone"
@@ -24,8 +24,7 @@
 			}
 		],
 		"result": {
-			"item": "minecraft:sandstone",
-			"data": 3,
+			"item": "minecraft:smooth_sandstone",
 			"count": 3
 		}
 	}

--- a/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/stairs/spruce_planks.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/stairs/spruce_planks.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:bb.stairs.spruce_planks"

--- a/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/stairs/stone.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/stairs/stone.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:bb.stairs.stone"
@@ -25,7 +25,6 @@
 		],
 		"result": {
 			"item": "minecraft:stone",
-			"data": 0,
 			"count": 3
 		}
 	}

--- a/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/stairs/stone_brick.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/stairs/stone_brick.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:bb.stairs.stone_brick"
@@ -24,8 +24,7 @@
 			}
 		],
 		"result": {
-			"item": "minecraft:stonebrick",
-			"data": 0,
+			"item": "minecraft:stone_bricks",
 			"count": 3
 		}
 	}

--- a/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/stairs/tuff.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/stairs/tuff.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:bb.stairs.tuff"

--- a/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/stairs/tuff_bricks.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/stairs/tuff_bricks.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:bb.stairs.tuff_bricks"

--- a/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/stairs/warped_planks.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/stairs/warped_planks.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:bb.stairs.warped_planks"

--- a/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/stairs/waxed_cut_copper.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/stairs/waxed_cut_copper.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:bb.stairs.waxed_cut_copper"

--- a/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/stairs/waxed_exposed_cut_copper.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/stairs/waxed_exposed_cut_copper.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:bb.stairs.waxed_exposed_cut_copper"

--- a/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/stairs/waxed_oxidized_cut_copper.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/stairs/waxed_oxidized_cut_copper.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:bb.stairs.waxed_oxidized_cut_copper"

--- a/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/stairs/waxed_weathered_cut_copper.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/stairs/waxed_weathered_cut_copper.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:bb.stairs.waxed_weathered_cut_copper"

--- a/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/stairs/weathered_cut_copper.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/stairs/weathered_cut_copper.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:bb.stairs.weathered_cut_copper"

--- a/crafting_tweaks/files/quality_of_life/charcoal_to_black_dye/recipes/charcoal_to_black_dye/charcoal_to_black_dye.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/charcoal_to_black_dye/recipes/charcoal_to_black_dye/charcoal_to_black_dye.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shapeless": {
 		"description": {
 			"identifier": "bt:chbd.charcoal_to_black_dye"

--- a/crafting_tweaks/files/quality_of_life/coal_to_black_dye/recipes/coal_to_black_dye/coal_to_black_dye.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/coal_to_black_dye/recipes/coal_to_black_dye/coal_to_black_dye.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shapeless": {
 		"description": {
 			"identifier": "bt:cbd.coal_to_black_dye"

--- a/crafting_tweaks/files/quality_of_life/copper_powered_rails/recipes/copper_powered_rails/powered_rail.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/copper_powered_rails/recipes/copper_powered_rails/powered_rail.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:ci.powered_rail"

--- a/crafting_tweaks/files/quality_of_life/double_slabs/recipes/double_slabs/andesite_slab.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/double_slabs/recipes/double_slabs/andesite_slab.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shapeless": {
 		"description": {
 			"identifier": "bt:ds.andesite_slab"
@@ -19,8 +19,7 @@
 			}
 		],
 		"result": {
-			"item": "minecraft:stone_block_slab3",
-			"data": 3,
+			"item": "minecraft:andesite_slab",
 			"count": 2
 		}
 	}

--- a/crafting_tweaks/files/quality_of_life/double_slabs/recipes/double_slabs/bamboo_mosaic_slab.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/double_slabs/recipes/double_slabs/bamboo_mosaic_slab.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shapeless": {
 		"description": {
 			"identifier": "bt:ds.bamboo_mosaic_slab"

--- a/crafting_tweaks/files/quality_of_life/double_slabs/recipes/double_slabs/blackstone_slab.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/double_slabs/recipes/double_slabs/blackstone_slab.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shapeless": {
 		"description": {
 			"identifier": "bt:ds.blackstone_slab"

--- a/crafting_tweaks/files/quality_of_life/double_slabs/recipes/double_slabs/brick_slab.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/double_slabs/recipes/double_slabs/brick_slab.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shapeless": {
 		"description": {
 			"identifier": "bt:ds.brick_slab"

--- a/crafting_tweaks/files/quality_of_life/double_slabs/recipes/double_slabs/cobbled_deepslate_slab.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/double_slabs/recipes/double_slabs/cobbled_deepslate_slab.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shapeless": {
 		"description": {
 			"identifier": "bt:ds.cobbled_deepslate_slab"

--- a/crafting_tweaks/files/quality_of_life/double_slabs/recipes/double_slabs/cobblestone_slab.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/double_slabs/recipes/double_slabs/cobblestone_slab.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shapeless": {
 		"description": {
 			"identifier": "bt:ds.cobblestone_slab"

--- a/crafting_tweaks/files/quality_of_life/double_slabs/recipes/double_slabs/cut_copper_slab.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/double_slabs/recipes/double_slabs/cut_copper_slab.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shapeless": {
 		"description": {
 			"identifier": "bt:ds.cut_copper_slab"

--- a/crafting_tweaks/files/quality_of_life/double_slabs/recipes/double_slabs/cut_red_sandstone_slab.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/double_slabs/recipes/double_slabs/cut_red_sandstone_slab.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shapeless": {
 		"description": {
 			"identifier": "bt:ds.cut_red_sandstone_slab"
@@ -10,19 +10,16 @@
 		"priority": -1,
 		"ingredients": [
 			{
-				"item": "minecraft:red_sandstone",
-				"data": 2
+				"item": "minecraft:cut_red_sandstone"
 			}
 		],
 		"unlock": [
 			{
-				"item": "minecraft:red_sandstone",
-				"data": 2
+				"item": "minecraft:cut_red_sandstone"
 			}
 		],
 		"result": {
-			"item": "minecraft:stone_block_slab4",
-			"data": 4,
+			"item": "minecraft:cut_red_sandstone_slab",
 			"count": 2
 		}
 	}

--- a/crafting_tweaks/files/quality_of_life/double_slabs/recipes/double_slabs/cut_sandstone_slab.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/double_slabs/recipes/double_slabs/cut_sandstone_slab.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shapeless": {
 		"description": {
 			"identifier": "bt:ds.cut_sandstone_slab"
@@ -10,19 +10,16 @@
 		"priority": -1,
 		"ingredients": [
 			{
-				"item": "minecraft:sandstone",
-				"data": 2
+				"item": "minecraft:cut_sandstone"
 			}
 		],
 		"unlock": [
 			{
-				"item": "minecraft:sandstone",
-				"data": 2
+				"item": "minecraft:cut_sandstone"
 			}
 		],
 		"result": {
-			"item": "minecraft:stone_block_slab4",
-			"data": 3,
+			"item": "minecraft:cut_sandstone_slab",
 			"count": 2
 		}
 	}

--- a/crafting_tweaks/files/quality_of_life/double_slabs/recipes/double_slabs/dark_prismarine_slab.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/double_slabs/recipes/double_slabs/dark_prismarine_slab.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shapeless": {
 		"description": {
 			"identifier": "bt:ds.dark_prismarine_slab"
@@ -10,19 +10,16 @@
 		"priority": -1,
 		"ingredients": [
 			{
-				"item": "minecraft:prismarine",
-				"data": 1
+				"item": "minecraft:dark_prismarine"
 			}
 		],
 		"unlock": [
 			{
-				"item": "minecraft:prismarine",
-				"data": 1
+				"item": "minecraft:dark_prismarine"
 			}
 		],
 		"result": {
-			"item": "minecraft:stone_block_slab2",
-			"data": 3,
+			"item": "minecraft:dark_prismarine_slab",
 			"count": 2
 		}
 	}

--- a/crafting_tweaks/files/quality_of_life/double_slabs/recipes/double_slabs/deepslate_brick_slab.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/double_slabs/recipes/double_slabs/deepslate_brick_slab.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shapeless": {
 		"description": {
 			"identifier": "bt:ds.deepslate_brick_slab"

--- a/crafting_tweaks/files/quality_of_life/double_slabs/recipes/double_slabs/deepslate_tile_slab.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/double_slabs/recipes/double_slabs/deepslate_tile_slab.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shapeless": {
 		"description": {
 			"identifier": "bt:ds.deepslate_tile_slab"

--- a/crafting_tweaks/files/quality_of_life/double_slabs/recipes/double_slabs/diorite_slab.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/double_slabs/recipes/double_slabs/diorite_slab.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shapeless": {
 		"description": {
 			"identifier": "bt:ds.diorite_slab"
@@ -19,8 +19,7 @@
 			}
 		],
 		"result": {
-			"item": "minecraft:stone_block_slab3",
-			"data": 4,
+			"item": "minecraft:diorite_slab",
 			"count": 2
 		}
 	}

--- a/crafting_tweaks/files/quality_of_life/double_slabs/recipes/double_slabs/end_brick_slab.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/double_slabs/recipes/double_slabs/end_brick_slab.recipe.json
@@ -1,8 +1,8 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shapeless": {
 		"description": {
-			"identifier": "bt:ds.end_brick_slab"
+			"identifier": "bt:ds.end_stone_brick_slab"
 		},
 		"tags": [
 			"crafting_table"
@@ -19,8 +19,7 @@
 			}
 		],
 		"result": {
-			"item": "minecraft:stone_block_slab3",
-			"data": 0,
+			"item": "minecraft:end_stone_brick_slab",
 			"count": 2
 		}
 	}

--- a/crafting_tweaks/files/quality_of_life/double_slabs/recipes/double_slabs/exposed_cut_copper_slab.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/double_slabs/recipes/double_slabs/exposed_cut_copper_slab.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shapeless": {
 		"description": {
 			"identifier": "bt:ds.exposed_cut_copper_slab"

--- a/crafting_tweaks/files/quality_of_life/double_slabs/recipes/double_slabs/granite_slab.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/double_slabs/recipes/double_slabs/granite_slab.recipe.json
@@ -1,8 +1,8 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shapeless": {
 		"description": {
-			"identifier": "bt:ds.granite"
+			"identifier": "bt:ds.granite_slab"
 		},
 		"tags": [
 			"crafting_table"
@@ -19,8 +19,7 @@
 			}
 		],
 		"result": {
-			"item": "minecraft:stone_block_slab3",
-			"data": 6,
+			"item": "minecraft:granite_slab",
 			"count": 2
 		}
 	}

--- a/crafting_tweaks/files/quality_of_life/double_slabs/recipes/double_slabs/mossy_cobblestone_slab.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/double_slabs/recipes/double_slabs/mossy_cobblestone_slab.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shapeless": {
 		"description": {
 			"identifier": "bt:ds.mossy_cobblestone_slab"
@@ -19,8 +19,7 @@
 			}
 		],
 		"result": {
-			"item": "minecraft:stone_block_slab2",
-			"data": 5,
+			"item": "minecraft:mossy_cobblestone_slab",
 			"count": 2
 		}
 	}

--- a/crafting_tweaks/files/quality_of_life/double_slabs/recipes/double_slabs/mossy_stone_brick_slab.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/double_slabs/recipes/double_slabs/mossy_stone_brick_slab.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shapeless": {
 		"description": {
 			"identifier": "bt:ds.mossy_stone_brick_slab"
@@ -10,19 +10,16 @@
 		"priority": -1,
 		"ingredients": [
 			{
-				"item": "minecraft:stonebrick",
-				"data": 1
+				"item": "minecraft:mossy_stone_brick"
 			}
 		],
 		"unlock": [
 			{
-				"item": "minecraft:stonebrick",
-				"data": 1
+				"item": "minecraft:mossy_stone_brick"
 			}
 		],
 		"result": {
-			"item": "minecraft:stone_block_slab4",
-			"data": 0,
+			"item": "minecraft:mossy_stone_brick_slab",
 			"count": 2
 		}
 	}

--- a/crafting_tweaks/files/quality_of_life/double_slabs/recipes/double_slabs/mossy_stone_brick_slab.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/double_slabs/recipes/double_slabs/mossy_stone_brick_slab.recipe.json
@@ -10,12 +10,12 @@
 		"priority": -1,
 		"ingredients": [
 			{
-				"item": "minecraft:mossy_stone_brick"
+				"item": "minecraft:mossy_stone_bricks"
 			}
 		],
 		"unlock": [
 			{
-				"item": "minecraft:mossy_stone_brick"
+				"item": "minecraft:mossy_stone_bricks"
 			}
 		],
 		"result": {

--- a/crafting_tweaks/files/quality_of_life/double_slabs/recipes/double_slabs/mud_brick_slab.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/double_slabs/recipes/double_slabs/mud_brick_slab.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shapeless": {
 		"description": {
 			"identifier": "bt:ds.mud_brick_slab"

--- a/crafting_tweaks/files/quality_of_life/double_slabs/recipes/double_slabs/nether_brick_slab.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/double_slabs/recipes/double_slabs/nether_brick_slab.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shapeless": {
 		"description": {
 			"identifier": "bt:ds.nether_brick_slab"

--- a/crafting_tweaks/files/quality_of_life/double_slabs/recipes/double_slabs/oxidized_cut_copper_slab.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/double_slabs/recipes/double_slabs/oxidized_cut_copper_slab.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shapeless": {
 		"description": {
 			"identifier": "bt:ds.oxidized_cut_copper_slab"

--- a/crafting_tweaks/files/quality_of_life/double_slabs/recipes/double_slabs/polished_andesite_slab.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/double_slabs/recipes/double_slabs/polished_andesite_slab.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shapeless": {
 		"description": {
 			"identifier": "bt:ds.polished_andesite_slab"
@@ -19,8 +19,7 @@
 			}
 		],
 		"result": {
-			"item": "minecraft:stone_block_slab3",
-			"data": 2,
+			"item": "minecraft:polished_andesite_slab",
 			"count": 2
 		}
 	}

--- a/crafting_tweaks/files/quality_of_life/double_slabs/recipes/double_slabs/polished_blackstone_brick_slab.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/double_slabs/recipes/double_slabs/polished_blackstone_brick_slab.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shapeless": {
 		"description": {
 			"identifier": "bt:ds.polished_blackstone_brick_slab"

--- a/crafting_tweaks/files/quality_of_life/double_slabs/recipes/double_slabs/polished_blackstone_slab.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/double_slabs/recipes/double_slabs/polished_blackstone_slab.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shapeless": {
 		"description": {
 			"identifier": "bt:ds.polished_blackstone_slab"

--- a/crafting_tweaks/files/quality_of_life/double_slabs/recipes/double_slabs/polished_deepslate_slab.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/double_slabs/recipes/double_slabs/polished_deepslate_slab.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shapeless": {
 		"description": {
 			"identifier": "bt:ds.polished_deepslate_slab"

--- a/crafting_tweaks/files/quality_of_life/double_slabs/recipes/double_slabs/polished_diorite_slab.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/double_slabs/recipes/double_slabs/polished_diorite_slab.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shapeless": {
 		"description": {
 			"identifier": "bt:ds.polished_diorite"
@@ -19,8 +19,7 @@
 			}
 		],
 		"result": {
-			"item": "minecraft:stone_block_slab3",
-			"data": 5,
+			"item": "minecraft:polished_andesite_slab",
 			"count": 2
 		}
 	}

--- a/crafting_tweaks/files/quality_of_life/double_slabs/recipes/double_slabs/polished_granite_slab.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/double_slabs/recipes/double_slabs/polished_granite_slab.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shapeless": {
 		"description": {
 			"identifier": "bt:ds.polished_granite_slab"
@@ -19,8 +19,7 @@
 			}
 		],
 		"result": {
-			"item": "minecraft:stone_block_slab3",
-			"data": 7,
+			"item": "minecraft:polished_granite_slab",
 			"count": 2
 		}
 	}

--- a/crafting_tweaks/files/quality_of_life/double_slabs/recipes/double_slabs/polished_tuff_slab.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/double_slabs/recipes/double_slabs/polished_tuff_slab.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shapeless": {
 		"description": {
 			"identifier": "bt:ds.polished_tuff_slab"

--- a/crafting_tweaks/files/quality_of_life/double_slabs/recipes/double_slabs/prismarine_brick_slab.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/double_slabs/recipes/double_slabs/prismarine_brick_slab.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shapeless": {
 		"description": {
 			"identifier": "bt:ds.prismarine_brick_slab"
@@ -10,19 +10,16 @@
 		"priority": -1,
 		"ingredients": [
 			{
-				"item": "minecraft:prismarine",
-				"data": 2
+				"item": "minecraft:prismarine_bricks"
 			}
 		],
 		"unlock": [
 			{
-				"item": "minecraft:prismarine",
-				"data": 2
+				"item": "minecraft:prismarine_bricks"
 			}
 		],
 		"result": {
-			"item": "minecraft:stone_block_slab2",
-			"data": 4,
+			"item": "minecraft:prismarine_brick_slab",
 			"count": 2
 		}
 	}

--- a/crafting_tweaks/files/quality_of_life/double_slabs/recipes/double_slabs/prismarine_slab.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/double_slabs/recipes/double_slabs/prismarine_slab.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shapeless": {
 		"description": {
 			"identifier": "bt:ds.prismarine_slab"
@@ -10,19 +10,16 @@
 		"priority": -1,
 		"ingredients": [
 			{
-				"item": "minecraft:prismarine",
-				"data": 0
+				"item": "minecraft:prismarine"
 			}
 		],
 		"unlock": [
 			{
-				"item": "minecraft:prismarine",
-				"data": 0
+				"item": "minecraft:prismarine"
 			}
 		],
 		"result": {
-			"item": "minecraft:stone_block_slab2",
-			"data": 2,
+			"item": "minecraft:prismarine_slab",
 			"count": 2
 		}
 	}

--- a/crafting_tweaks/files/quality_of_life/double_slabs/recipes/double_slabs/purpur_slab.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/double_slabs/recipes/double_slabs/purpur_slab.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shapeless": {
 		"description": {
 			"identifier": "bt:ds.purpur_slab"
@@ -19,8 +19,7 @@
 			}
 		],
 		"result": {
-			"item": "minecraft:stone_block_slab2",
-			"data": 1,
+			"item": "minecraft:purpur_slab",
 			"count": 2
 		}
 	}

--- a/crafting_tweaks/files/quality_of_life/double_slabs/recipes/double_slabs/quartz_slab.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/double_slabs/recipes/double_slabs/quartz_slab.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shapeless": {
 		"description": {
 			"identifier": "bt:ds.quartz_slab"
@@ -10,14 +10,12 @@
 		"priority": -1,
 		"ingredients": [
 			{
-				"item": "minecraft:quartz_block",
-				"data": 0
+				"item": "minecraft:quartz_block"
 			}
 		],
 		"unlock": [
 			{
-				"item": "minecraft:quartz_block",
-				"data": 0
+				"item": "minecraft:quartz_block"
 			}
 		],
 		"result": {

--- a/crafting_tweaks/files/quality_of_life/double_slabs/recipes/double_slabs/red_nether_brick_slab.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/double_slabs/recipes/double_slabs/red_nether_brick_slab.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shapeless": {
 		"description": {
 			"identifier": "bt:ds.red_nether_brick_slab"
@@ -19,8 +19,7 @@
 			}
 		],
 		"result": {
-			"item": "minecraft:stone_block_slab2",
-			"data": 7,
+			"item": "minecraft:red_nether_brick_slab",
 			"count": 2
 		}
 	}

--- a/crafting_tweaks/files/quality_of_life/double_slabs/recipes/double_slabs/red_sandstone_slab.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/double_slabs/recipes/double_slabs/red_sandstone_slab.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shapeless": {
 		"description": {
 			"identifier": "bt:ds.red_sandstone_slab"
@@ -21,8 +21,7 @@
 			}
 		],
 		"result": {
-			"item": "minecraft:stone_block_slab2",
-			"data": 0,
+			"item": "minecraft:red_sandstone_slab",
 			"count": 2
 		}
 	}

--- a/crafting_tweaks/files/quality_of_life/double_slabs/recipes/double_slabs/sandstone_slab.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/double_slabs/recipes/double_slabs/sandstone_slab.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shapeless": {
 		"description": {
 			"identifier": "bt:ds.sandstone_slab"
@@ -10,14 +10,12 @@
 		"priority": -1,
 		"ingredients": [
 			{
-				"item": "minecraft:sandstone",
-				"data": 0
+				"item": "minecraft:sandstone"
 			}
 		],
 		"unlock": [
 			{
-				"item": "minecraft:sandstone",
-				"data": 0
+				"item": "minecraft:sandstone"
 			}
 		],
 		"result": {

--- a/crafting_tweaks/files/quality_of_life/double_slabs/recipes/double_slabs/smooth_quartz_slab.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/double_slabs/recipes/double_slabs/smooth_quartz_slab.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shapeless": {
 		"description": {
 			"identifier": "bt:ds.smooth_quartz_slab"
@@ -10,19 +10,16 @@
 		"priority": -1,
 		"ingredients": [
 			{
-				"item": "minecraft:quartz_block",
-				"data": 3
+				"item": "minecraft:smooth_quartz"
 			}
 		],
 		"unlock": [
 			{
-				"item": "minecraft:quartz_block",
-				"data": 3
+				"item": "minecraft:smooth_quartz"
 			}
 		],
 		"result": {
-			"item": "minecraft:stone_block_slab4",
-			"data": 1,
+			"item": "minecraft:smooth_quartz_slab",
 			"count": 2
 		}
 	}

--- a/crafting_tweaks/files/quality_of_life/double_slabs/recipes/double_slabs/smooth_red_sandstone_slab.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/double_slabs/recipes/double_slabs/smooth_red_sandstone_slab.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shapeless": {
 		"description": {
 			"identifier": "bt:ds.smooth_red_sandstone_slab"
@@ -10,19 +10,16 @@
 		"priority": -1,
 		"ingredients": [
 			{
-				"item": "minecraft:red_sandstone",
-				"data": 3
+				"item": "minecraft:smooth_red_sandstone"
 			}
 		],
 		"unlock": [
 			{
-				"item": "minecraft:red_sandstone",
-				"data": 3
+				"item": "minecraft:smooth_red_sandstone"
 			}
 		],
 		"result": {
-			"item": "minecraft:stone_block_slab3",
-			"data": 1,
+			"item": "minecraft:smooth_red_sandstone_slab",
 			"count": 2
 		}
 	}

--- a/crafting_tweaks/files/quality_of_life/double_slabs/recipes/double_slabs/smooth_sandstone_slab.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/double_slabs/recipes/double_slabs/smooth_sandstone_slab.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shapeless": {
 		"description": {
 			"identifier": "bt:ds.smooth_sandstone_slab"
@@ -10,19 +10,16 @@
 		"priority": -1,
 		"ingredients": [
 			{
-				"item": "minecraft:sandstone",
-				"data": 3
+				"item": "minecraft:smooth_sandstone"
 			}
 		],
 		"unlock": [
 			{
-				"item": "minecraft:sandstone",
-				"data": 3
+				"item": "minecraft:smooth_sandstone"
 			}
 		],
 		"result": {
-			"item": "minecraft:stone_block_slab2",
-			"data": 6,
+			"item": "minecraft:smooth_sandstone_slab",
 			"count": 2
 		}
 	}

--- a/crafting_tweaks/files/quality_of_life/double_slabs/recipes/double_slabs/smooth_stone_slab.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/double_slabs/recipes/double_slabs/smooth_stone_slab.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shapeless": {
 		"description": {
 			"identifier": "bt:ds.smooth_stone_slab"

--- a/crafting_tweaks/files/quality_of_life/double_slabs/recipes/double_slabs/stone_brick_slab.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/double_slabs/recipes/double_slabs/stone_brick_slab.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shapeless": {
 		"description": {
 			"identifier": "bt:ds.stone_brick_slab"
@@ -10,14 +10,12 @@
 		"priority": -1,
 		"ingredients": [
 			{
-				"item": "minecraft:stonebrick",
-				"data": 0
+				"item": "minecraft:stone_bricks"
 			}
 		],
 		"unlock": [
 			{
-				"item": "minecraft:stonebrick",
-				"data": 0
+				"item": "minecraft:stone_bricks"
 			}
 		],
 		"result": {

--- a/crafting_tweaks/files/quality_of_life/double_slabs/recipes/double_slabs/tuff_brick_slab.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/double_slabs/recipes/double_slabs/tuff_brick_slab.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shapeless": {
 		"description": {
 			"identifier": "bt:ds.tuff_brick_slab"

--- a/crafting_tweaks/files/quality_of_life/double_slabs/recipes/double_slabs/tuff_slab.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/double_slabs/recipes/double_slabs/tuff_slab.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shapeless": {
 		"description": {
 			"identifier": "bt:ds.tuff_slab"

--- a/crafting_tweaks/files/quality_of_life/double_slabs/recipes/double_slabs/waxed_cut_copper_slab.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/double_slabs/recipes/double_slabs/waxed_cut_copper_slab.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shapeless": {
 		"description": {
 			"identifier": "bt:ds.waxed_cut_copper_slab"

--- a/crafting_tweaks/files/quality_of_life/double_slabs/recipes/double_slabs/waxed_exposed_cut_copper_slab.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/double_slabs/recipes/double_slabs/waxed_exposed_cut_copper_slab.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shapeless": {
 		"description": {
 			"identifier": "bt:ds.waxed_exposed_cut_copper_slab"

--- a/crafting_tweaks/files/quality_of_life/double_slabs/recipes/double_slabs/waxed_oxidized_cut_copper_slab.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/double_slabs/recipes/double_slabs/waxed_oxidized_cut_copper_slab.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shapeless": {
 		"description": {
 			"identifier": "bt:ds.waxed_oxidized_cut_copper_slab"

--- a/crafting_tweaks/files/quality_of_life/double_slabs/recipes/double_slabs/waxed_weathered_cut_copper_slab.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/double_slabs/recipes/double_slabs/waxed_weathered_cut_copper_slab.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shapeless": {
 		"description": {
 			"identifier": "bt:ds.waxed_weathered_cut_copper_slab"

--- a/crafting_tweaks/files/quality_of_life/double_slabs/recipes/double_slabs/weathered_cut_copper_slab.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/double_slabs/recipes/double_slabs/weathered_cut_copper_slab.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shapeless": {
 		"description": {
 			"identifier": "bt:ds.weathered_cut_copper_slab"

--- a/crafting_tweaks/files/quality_of_life/dropper_to_dispenser/recipes/dropper_to_dispenser/dispenser.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/dropper_to_dispenser/recipes/dropper_to_dispenser/dispenser.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:dd.dispenser"

--- a/crafting_tweaks/files/quality_of_life/dropper_to_dispenser/recipes/dropper_to_dispenser/dispenser_alternate.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/dropper_to_dispenser/recipes/dropper_to_dispenser/dispenser_alternate.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shapeless": {
 		"description": {
 			"identifier": "bt:dd.dispenser_alternate"

--- a/crafting_tweaks/files/quality_of_life/powder_to_glass/recipes/powder_to_glass/black_stained_glass.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/powder_to_glass/recipes/powder_to_glass/black_stained_glass.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_furnace": {
 		"description": {
 			"identifier": "bt:pg.black_stained_glass"
@@ -7,12 +7,7 @@
 		"tags": [
 			"furnace"
 		],
-		"group": "powder_to_glass",
-		"input": {
-			"item": "minecraft:black_concrete_powder"
-		},
-		"output": {
-			"item": "minecraft:black_stained_glass"
-		}
+		"input":"minecraft:black_concrete_powder",
+		"output": "minecraft:black_stained_glass"
 	}
 }

--- a/crafting_tweaks/files/quality_of_life/powder_to_glass/recipes/powder_to_glass/blue_stained_glass.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/powder_to_glass/recipes/powder_to_glass/blue_stained_glass.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_furnace": {
 		"description": {
 			"identifier": "bt:pg.blue_stained_glass"
@@ -7,12 +7,7 @@
 		"tags": [
 			"furnace"
 		],
-		"group": "powder_to_glass",
-		"input": {
-			"item": "minecraft:blue_concrete_powder"
-		},
-		"output": {
-			"item": "minecraft:blue_stained_glass"
-		}
+		"input":"minecraft:blue_concrete_powder",
+		"output": "minecraft:blue_stained_glass"
 	}
 }

--- a/crafting_tweaks/files/quality_of_life/powder_to_glass/recipes/powder_to_glass/brown_stained_glass.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/powder_to_glass/recipes/powder_to_glass/brown_stained_glass.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_furnace": {
 		"description": {
 			"identifier": "bt:pg.brown_stained_glass"
@@ -7,12 +7,7 @@
 		"tags": [
 			"furnace"
 		],
-		"group": "powder_to_glass",
-		"input": {
-			"item": "minecraft:brown_concrete_powder"
-		},
-		"output": {
-			"item": "minecraft:brown_stained_glass"
-		}
+		"input":"minecraft:brown_concrete_powder",
+		"output": "minecraft:brown_stained_glass"
 	}
 }

--- a/crafting_tweaks/files/quality_of_life/powder_to_glass/recipes/powder_to_glass/cyan_stained_glass.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/powder_to_glass/recipes/powder_to_glass/cyan_stained_glass.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_furnace": {
 		"description": {
 			"identifier": "bt:pg.cyan_stained_glass"
@@ -7,12 +7,7 @@
 		"tags": [
 			"furnace"
 		],
-		"group": "powder_to_glass",
-		"input": {
-			"item": "minecraft:cyan_concrete_powder"
-		},
-		"output": {
-			"item": "minecraft:cyan_stained_glass"
-		}
+		"input":"minecraft:cyan_concrete_powder",
+		"output": "minecraft:cyan_stained_glass"
 	}
 }

--- a/crafting_tweaks/files/quality_of_life/powder_to_glass/recipes/powder_to_glass/gray_stained_glass.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/powder_to_glass/recipes/powder_to_glass/gray_stained_glass.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_furnace": {
 		"description": {
 			"identifier": "bt:pg.gray_stained_glass"
@@ -7,12 +7,7 @@
 		"tags": [
 			"furnace"
 		],
-		"group": "powder_to_glass",
-		"input": {
-			"item": "minecraft:gray_concrete_powder"
-		},
-		"output": {
-			"item": "minecraft:gray_stained_glass"
-		}
+		"input":"minecraft:gray_concrete_powder",
+		"output": "minecraft:gray_stained_glass"
 	}
 }

--- a/crafting_tweaks/files/quality_of_life/powder_to_glass/recipes/powder_to_glass/green_stained_glass.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/powder_to_glass/recipes/powder_to_glass/green_stained_glass.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_furnace": {
 		"description": {
 			"identifier": "bt:pg.green_stained_glass"
@@ -7,12 +7,7 @@
 		"tags": [
 			"furnace"
 		],
-		"group": "powder_to_glass",
-		"input": {
-			"item": "minecraft:green_concrete_powder"
-		},
-		"output": {
-			"item": "minecraft:green_stained_glass"
-		}
+		"input":"minecraft:green_concrete_powder",
+		"output": "minecraft:green_stained_glass"
 	}
 }

--- a/crafting_tweaks/files/quality_of_life/powder_to_glass/recipes/powder_to_glass/light_blue_stained_glass.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/powder_to_glass/recipes/powder_to_glass/light_blue_stained_glass.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_furnace": {
 		"description": {
 			"identifier": "bt:pg.light_blue_stained_glass"
@@ -7,12 +7,7 @@
 		"tags": [
 			"furnace"
 		],
-		"group": "powder_to_glass",
-		"input": {
-			"item": "minecraft:light_blue_concrete_powder"
-		},
-		"output": {
-			"item": "minecraft:light_blue_stained_glass"
-		}
+		"input":"minecraft:light_blue_concrete_powder",
+		"output": "minecraft:light_blue_stained_glass"
 	}
 }

--- a/crafting_tweaks/files/quality_of_life/powder_to_glass/recipes/powder_to_glass/light_gray_stained_glass.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/powder_to_glass/recipes/powder_to_glass/light_gray_stained_glass.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_furnace": {
 		"description": {
 			"identifier": "bt:pg.light_gray_stained_glass"
@@ -7,12 +7,7 @@
 		"tags": [
 			"furnace"
 		],
-		"group": "powder_to_glass",
-		"input": {
-			"item": "minecraft:light_gray_concrete_powder"
-		},
-		"output": {
-			"item": "minecraft:light_gray_stained_glass"
-		}
+		"input":"minecraft:light_gray_concrete_powder",
+		"output": "minecraft:light_gray_stained_glass"
 	}
 }

--- a/crafting_tweaks/files/quality_of_life/powder_to_glass/recipes/powder_to_glass/lime_stained_glass.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/powder_to_glass/recipes/powder_to_glass/lime_stained_glass.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_furnace": {
 		"description": {
 			"identifier": "bt:pg.lime_stained_glass"
@@ -7,12 +7,7 @@
 		"tags": [
 			"furnace"
 		],
-		"group": "powder_to_glass",
-		"input": {
-			"item": "minecraft:lime_concrete_powder"
-		},
-		"output": {
-			"item": "minecraft:lime_stained_glass"
-		}
+		"input":"minecraft:lime_concrete_powder",
+		"output": "minecraft:lime_stained_glass"
 	}
 }

--- a/crafting_tweaks/files/quality_of_life/powder_to_glass/recipes/powder_to_glass/magenta_stained_glass.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/powder_to_glass/recipes/powder_to_glass/magenta_stained_glass.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_furnace": {
 		"description": {
 			"identifier": "bt:pg.magenta_stained_glass"
@@ -7,12 +7,7 @@
 		"tags": [
 			"furnace"
 		],
-		"group": "powder_to_glass",
-		"input": {
-			"item": "minecraft:magenta_concrete_powder"
-		},
-		"output": {
-			"item": "minecraft:magenta_stained_glass"
-		}
+		"input":"minecraft:magenta_concrete_powder",
+		"output": "minecraft:magenta_stained_glass"
 	}
 }

--- a/crafting_tweaks/files/quality_of_life/powder_to_glass/recipes/powder_to_glass/orange_stained_glass.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/powder_to_glass/recipes/powder_to_glass/orange_stained_glass.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_furnace": {
 		"description": {
 			"identifier": "bt:pg.orange_stained_glass"
@@ -7,12 +7,7 @@
 		"tags": [
 			"furnace"
 		],
-		"group": "powder_to_glass",
-		"input": {
-			"item": "minecraft:orange_concrete_powder"
-		},
-		"output": {
-			"item": "minecraft:orange_stained_glass"
-		}
+		"input":"minecraft:orange_concrete_powder",
+		"output": "minecraft:orange_stained_glass"
 	}
 }

--- a/crafting_tweaks/files/quality_of_life/powder_to_glass/recipes/powder_to_glass/pink_stained_glass.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/powder_to_glass/recipes/powder_to_glass/pink_stained_glass.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_furnace": {
 		"description": {
 			"identifier": "bt:pg.pink_stained_glass"
@@ -7,12 +7,7 @@
 		"tags": [
 			"furnace"
 		],
-		"group": "powder_to_glass",
-		"input": {
-			"item": "minecraft:pink_concrete_powder"
-		},
-		"output": {
-			"item": "minecraft:pink_stained_glass"
-		}
+		"input":"minecraft:pink_concrete_powder",
+		"output": "minecraft:pink_stained_glass"
 	}
 }

--- a/crafting_tweaks/files/quality_of_life/powder_to_glass/recipes/powder_to_glass/purple_stained_glass.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/powder_to_glass/recipes/powder_to_glass/purple_stained_glass.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_furnace": {
 		"description": {
 			"identifier": "bt:pg.purple_stained_glass"
@@ -7,12 +7,7 @@
 		"tags": [
 			"furnace"
 		],
-		"group": "powder_to_glass",
-		"input": {
-			"item": "minecraft:purple_concrete_powder"
-		},
-		"output": {
-			"item": "minecraft:purple_stained_glass"
-		}
+		"input":"minecraft:purple_concrete_powder",
+		"output": "minecraft:purple_stained_glass"
 	}
 }

--- a/crafting_tweaks/files/quality_of_life/powder_to_glass/recipes/powder_to_glass/red_stained_glass.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/powder_to_glass/recipes/powder_to_glass/red_stained_glass.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_furnace": {
 		"description": {
 			"identifier": "bt:pg.red_stained_glass"
@@ -7,12 +7,7 @@
 		"tags": [
 			"furnace"
 		],
-		"group": "powder_to_glass",
-		"input": {
-			"item": "minecraft:red_concrete_powder"
-		},
-		"output": {
-			"item": "minecraft:red_stained_glass"
-		}
+		"input":"minecraft:red_concrete_powder",
+		"output": "minecraft:red_stained_glass"
 	}
 }

--- a/crafting_tweaks/files/quality_of_life/powder_to_glass/recipes/powder_to_glass/white_stained_glass.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/powder_to_glass/recipes/powder_to_glass/white_stained_glass.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_furnace": {
 		"description": {
 			"identifier": "bt:pg.white_stained_glass"
@@ -7,12 +7,7 @@
 		"tags": [
 			"furnace"
 		],
-		"group": "powder_to_glass",
-		"input": {
-			"item": "minecraft:white_concrete_powder"
-		},
-		"output": {
-			"item": "minecraft:white_stained_glass"
-		}
+		"input":"minecraft:white_concrete_powder",
+		"output": "minecraft:white_stained_glass"
 	}
 }

--- a/crafting_tweaks/files/quality_of_life/powder_to_glass/recipes/powder_to_glass/yellow_stained_glass.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/powder_to_glass/recipes/powder_to_glass/yellow_stained_glass.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_furnace": {
 		"description": {
 			"identifier": "bt:pg.yellow_stained_glass"
@@ -7,12 +7,7 @@
 		"tags": [
 			"furnace"
 		],
-		"group": "powder_to_glass",
-		"input": {
-			"item": "minecraft:yellow_concrete_powder"
-		},
-		"output": {
-			"item": "minecraft:yellow_stained_glass"
-		}
+		"input":"minecraft:yellow_concrete_powder",
+		"output": "minecraft:yellow_stained_glass"
 	}
 }

--- a/crafting_tweaks/files/quality_of_life/rotten_flesh_to_leather/recipes/rotten_flesh_to_leather/rotten_flesh_to_leather.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/rotten_flesh_to_leather/recipes/rotten_flesh_to_leather/rotten_flesh_to_leather.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_furnace": {
 		"description": {
 			"identifier": "bt:rfl.leather"

--- a/crafting_tweaks/files/quality_of_life/sandstone_dyeing/recipes/sandstone_dyeing/red_sand.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/sandstone_dyeing/recipes/sandstone_dyeing/red_sand.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shapeless": {
 		"description": {
 			"identifier": "bt:sd.red_sand"
@@ -11,36 +11,28 @@
 		"priority": -1,
 		"ingredients": [
 			{
-				"item": "minecraft:sand",
-				"data": 0
+				"item": "minecraft:sand"
 			},
 			{
-				"item": "minecraft:sand",
-				"data": 0
+				"item": "minecraft:sand"
 			},
 			{
-				"item": "minecraft:sand",
-				"data": 0
+				"item": "minecraft:sand"
 			},
 			{
-				"item": "minecraft:sand",
-				"data": 0
+				"item": "minecraft:sand"
 			},
 			{
-				"item": "minecraft:sand",
-				"data": 0
+				"item": "minecraft:sand"
 			},
 			{
-				"item": "minecraft:sand",
-				"data": 0
+				"item": "minecraft:sand"
 			},
 			{
-				"item": "minecraft:sand",
-				"data": 0
+				"item": "minecraft:sand"
 			},
 			{
-				"item": "minecraft:sand",
-				"data": 0
+				"item": "minecraft:sand"
 			},
 			{
 				"item": "minecraft:red_dye"
@@ -55,8 +47,7 @@
 			}
 		],
 		"result": {
-			"item": "minecraft:sand",
-			"data": 1,
+			"item": "minecraft:red_sand",
 			"count": 8
 		}
 	}

--- a/crafting_tweaks/files/quality_of_life/sandstone_dyeing/recipes/sandstone_dyeing/red_sandstone.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/sandstone_dyeing/recipes/sandstone_dyeing/red_sandstone.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shapeless": {
 		"description": {
 			"identifier": "bt:sd.red_sandstone"
@@ -11,12 +11,10 @@
 		"priority": -1,
 		"ingredients": [
 			{
-				"item": "minecraft:sandstone",
-				"data": 0
+				"item": "minecraft:sandstone"
 			},
 			{
-				"item": "minecraft:sandstone",
-				"data": 0
+				"item": "minecraft:sandstone"
 			},
 			{
 				"item": "minecraft:red_dye"

--- a/crafting_tweaks/files/quality_of_life/sandstone_dyeing/recipes/sandstone_dyeing/smooth_red_sandstone.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/sandstone_dyeing/recipes/sandstone_dyeing/smooth_red_sandstone.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shapeless": {
 		"description": {
 			"identifier": "bt:sd.smooth_red_sandstone"
@@ -11,12 +11,10 @@
 		"priority": -1,
 		"ingredients": [
 			{
-				"item": "minecraft:sandstone",
-				"data": 3
+				"item": "minecraft:red_sandstone"
 			},
 			{
-				"item": "minecraft:sandstone",
-				"data": 3
+				"item": "minecraft:red_sandstone"
 			},
 			{
 				"item": "minecraft:red_dye"
@@ -31,8 +29,7 @@
 			}
 		],
 		"result": {
-			"item": "minecraft:red_sandstone",
-			"data": 3,
+			"item": "minecraft:smooth_red_sandstone",
 			"count": 2
 		}
 	}

--- a/crafting_tweaks/files/quality_of_life/straight_to_shapeless/recipes/straight_to_shapeless/bread.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/straight_to_shapeless/recipes/straight_to_shapeless/bread.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shapeless": {
 		"description": {
 			"identifier": "bt:ss.bread"

--- a/crafting_tweaks/files/quality_of_life/straight_to_shapeless/recipes/straight_to_shapeless/paper.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/straight_to_shapeless/recipes/straight_to_shapeless/paper.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shapeless": {
 		"description": {
 			"identifier": "bt:ss.paper"

--- a/crafting_tweaks/files/quality_of_life/straight_to_shapeless/recipes/straight_to_shapeless/shulker_box.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/straight_to_shapeless/recipes/straight_to_shapeless/shulker_box.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shapeless": {
 		"description": {
 			"identifier": "bt:ss.shulker_box"

--- a/crafting_tweaks/files/quality_of_life/universal_dyeing/recipes/universal_dyeing/concrete_powder/black_concrete_powder.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/universal_dyeing/recipes/universal_dyeing/concrete_powder/black_concrete_powder.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:ud.black_concrete_powder"

--- a/crafting_tweaks/files/quality_of_life/universal_dyeing/recipes/universal_dyeing/concrete_powder/blue_concrete_powder.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/universal_dyeing/recipes/universal_dyeing/concrete_powder/blue_concrete_powder.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:ud.blue_concrete_powder"

--- a/crafting_tweaks/files/quality_of_life/universal_dyeing/recipes/universal_dyeing/concrete_powder/brown_concrete_powder.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/universal_dyeing/recipes/universal_dyeing/concrete_powder/brown_concrete_powder.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:ud.brown_concrete_powder"

--- a/crafting_tweaks/files/quality_of_life/universal_dyeing/recipes/universal_dyeing/concrete_powder/cyan_concrete_powder.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/universal_dyeing/recipes/universal_dyeing/concrete_powder/cyan_concrete_powder.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:ud.cyan_concrete_powder"

--- a/crafting_tweaks/files/quality_of_life/universal_dyeing/recipes/universal_dyeing/concrete_powder/gray_concrete_powder.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/universal_dyeing/recipes/universal_dyeing/concrete_powder/gray_concrete_powder.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:ud.gray_concrete_powder"

--- a/crafting_tweaks/files/quality_of_life/universal_dyeing/recipes/universal_dyeing/concrete_powder/green_concrete_powder.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/universal_dyeing/recipes/universal_dyeing/concrete_powder/green_concrete_powder.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:ud.green_concrete_powder"

--- a/crafting_tweaks/files/quality_of_life/universal_dyeing/recipes/universal_dyeing/concrete_powder/light_blue_concrete_powder.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/universal_dyeing/recipes/universal_dyeing/concrete_powder/light_blue_concrete_powder.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:ud.light_blue_concrete_powder"

--- a/crafting_tweaks/files/quality_of_life/universal_dyeing/recipes/universal_dyeing/concrete_powder/light_gray_concrete_powder.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/universal_dyeing/recipes/universal_dyeing/concrete_powder/light_gray_concrete_powder.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:ud.light_gray_concrete_powder"

--- a/crafting_tweaks/files/quality_of_life/universal_dyeing/recipes/universal_dyeing/concrete_powder/lime_concrete_powder.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/universal_dyeing/recipes/universal_dyeing/concrete_powder/lime_concrete_powder.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:ud.lime_concrete_powder"

--- a/crafting_tweaks/files/quality_of_life/universal_dyeing/recipes/universal_dyeing/concrete_powder/magenta_concrete_powder.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/universal_dyeing/recipes/universal_dyeing/concrete_powder/magenta_concrete_powder.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:ud.magenta_concrete_powder"

--- a/crafting_tweaks/files/quality_of_life/universal_dyeing/recipes/universal_dyeing/concrete_powder/orange_concrete_powder.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/universal_dyeing/recipes/universal_dyeing/concrete_powder/orange_concrete_powder.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:ud.orange_concrete_powder"

--- a/crafting_tweaks/files/quality_of_life/universal_dyeing/recipes/universal_dyeing/concrete_powder/pink_concrete_powder.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/universal_dyeing/recipes/universal_dyeing/concrete_powder/pink_concrete_powder.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:ud.pink_concrete_powder"

--- a/crafting_tweaks/files/quality_of_life/universal_dyeing/recipes/universal_dyeing/concrete_powder/purple_concrete_powder.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/universal_dyeing/recipes/universal_dyeing/concrete_powder/purple_concrete_powder.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:ud.purple_concrete_powder"

--- a/crafting_tweaks/files/quality_of_life/universal_dyeing/recipes/universal_dyeing/concrete_powder/red_concrete_powder.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/universal_dyeing/recipes/universal_dyeing/concrete_powder/red_concrete_powder.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:ud.red_concrete_powder"

--- a/crafting_tweaks/files/quality_of_life/universal_dyeing/recipes/universal_dyeing/concrete_powder/white_concrete_powder.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/universal_dyeing/recipes/universal_dyeing/concrete_powder/white_concrete_powder.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:ud.white_concrete_powder"

--- a/crafting_tweaks/files/quality_of_life/universal_dyeing/recipes/universal_dyeing/concrete_powder/yellow_concrete_powder.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/universal_dyeing/recipes/universal_dyeing/concrete_powder/yellow_concrete_powder.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:ud.yellow_concrete_powder"

--- a/crafting_tweaks/files/quality_of_life/universal_dyeing/recipes/universal_dyeing/glass/black_stained_glass.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/universal_dyeing/recipes/universal_dyeing/glass/black_stained_glass.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:ud.black_stained_glass"

--- a/crafting_tweaks/files/quality_of_life/universal_dyeing/recipes/universal_dyeing/glass/blue_stained_glass.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/universal_dyeing/recipes/universal_dyeing/glass/blue_stained_glass.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:ud.blue_stained_glass"

--- a/crafting_tweaks/files/quality_of_life/universal_dyeing/recipes/universal_dyeing/glass/brown_stained_glass.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/universal_dyeing/recipes/universal_dyeing/glass/brown_stained_glass.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:ud.brown_stained_glass"

--- a/crafting_tweaks/files/quality_of_life/universal_dyeing/recipes/universal_dyeing/glass/cyan_stained_glass.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/universal_dyeing/recipes/universal_dyeing/glass/cyan_stained_glass.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:ud.cyan_stained_glass"

--- a/crafting_tweaks/files/quality_of_life/universal_dyeing/recipes/universal_dyeing/glass/glass.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/universal_dyeing/recipes/universal_dyeing/glass/glass.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:ud.glass"

--- a/crafting_tweaks/files/quality_of_life/universal_dyeing/recipes/universal_dyeing/glass/gray_stained_glass.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/universal_dyeing/recipes/universal_dyeing/glass/gray_stained_glass.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:ud.gray_stained_glass"

--- a/crafting_tweaks/files/quality_of_life/universal_dyeing/recipes/universal_dyeing/glass/green_stained_glass.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/universal_dyeing/recipes/universal_dyeing/glass/green_stained_glass.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:ud.green_stained_glass"

--- a/crafting_tweaks/files/quality_of_life/universal_dyeing/recipes/universal_dyeing/glass/light_blue_stained_glass.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/universal_dyeing/recipes/universal_dyeing/glass/light_blue_stained_glass.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:ud.light_blue_stained_glass"

--- a/crafting_tweaks/files/quality_of_life/universal_dyeing/recipes/universal_dyeing/glass/light_gray_stained_glass.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/universal_dyeing/recipes/universal_dyeing/glass/light_gray_stained_glass.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:ud.light_gray_stained_glass"

--- a/crafting_tweaks/files/quality_of_life/universal_dyeing/recipes/universal_dyeing/glass/lime_stained_glass.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/universal_dyeing/recipes/universal_dyeing/glass/lime_stained_glass.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:ud.lime_stained_glass"

--- a/crafting_tweaks/files/quality_of_life/universal_dyeing/recipes/universal_dyeing/glass/magenta_stained_glass.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/universal_dyeing/recipes/universal_dyeing/glass/magenta_stained_glass.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:ud.magenta_stained_glass"

--- a/crafting_tweaks/files/quality_of_life/universal_dyeing/recipes/universal_dyeing/glass/orange_stained_glass.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/universal_dyeing/recipes/universal_dyeing/glass/orange_stained_glass.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:ud.orange_stained_glass"

--- a/crafting_tweaks/files/quality_of_life/universal_dyeing/recipes/universal_dyeing/glass/pink_stained_glass.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/universal_dyeing/recipes/universal_dyeing/glass/pink_stained_glass.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:ud.pink_stained_glass"

--- a/crafting_tweaks/files/quality_of_life/universal_dyeing/recipes/universal_dyeing/glass/purple_stained_glass.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/universal_dyeing/recipes/universal_dyeing/glass/purple_stained_glass.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:ud.purple_stained_glass"

--- a/crafting_tweaks/files/quality_of_life/universal_dyeing/recipes/universal_dyeing/glass/red_stained_glass.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/universal_dyeing/recipes/universal_dyeing/glass/red_stained_glass.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:ud.red_stained_glass"

--- a/crafting_tweaks/files/quality_of_life/universal_dyeing/recipes/universal_dyeing/glass/white_stained_glass.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/universal_dyeing/recipes/universal_dyeing/glass/white_stained_glass.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:ud.white_stained_glass"

--- a/crafting_tweaks/files/quality_of_life/universal_dyeing/recipes/universal_dyeing/glass/yellow_stained_glass.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/universal_dyeing/recipes/universal_dyeing/glass/yellow_stained_glass.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:ud.yellow_stained_glass"

--- a/crafting_tweaks/files/quality_of_life/universal_dyeing/recipes/universal_dyeing/glass_pane/black_stained_glass_pane.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/universal_dyeing/recipes/universal_dyeing/glass_pane/black_stained_glass_pane.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:ud.black_stained_glass_pane"

--- a/crafting_tweaks/files/quality_of_life/universal_dyeing/recipes/universal_dyeing/glass_pane/blue_stained_glass_pane.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/universal_dyeing/recipes/universal_dyeing/glass_pane/blue_stained_glass_pane.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:ud.blue_stained_glass_pane"

--- a/crafting_tweaks/files/quality_of_life/universal_dyeing/recipes/universal_dyeing/glass_pane/brown_stained_glass_pane.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/universal_dyeing/recipes/universal_dyeing/glass_pane/brown_stained_glass_pane.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:ud.brown_stained_glass_pane"

--- a/crafting_tweaks/files/quality_of_life/universal_dyeing/recipes/universal_dyeing/glass_pane/cyan_stained_glass_pane.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/universal_dyeing/recipes/universal_dyeing/glass_pane/cyan_stained_glass_pane.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:ud.cyan_stained_glass_pane"

--- a/crafting_tweaks/files/quality_of_life/universal_dyeing/recipes/universal_dyeing/glass_pane/glass_pane.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/universal_dyeing/recipes/universal_dyeing/glass_pane/glass_pane.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:ud.glass_pane"

--- a/crafting_tweaks/files/quality_of_life/universal_dyeing/recipes/universal_dyeing/glass_pane/gray_stained_glass_pane.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/universal_dyeing/recipes/universal_dyeing/glass_pane/gray_stained_glass_pane.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:ud.gray_stained_glass_pane"

--- a/crafting_tweaks/files/quality_of_life/universal_dyeing/recipes/universal_dyeing/glass_pane/green_stained_glass_pane.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/universal_dyeing/recipes/universal_dyeing/glass_pane/green_stained_glass_pane.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:ud.green_stained_glass_pane"

--- a/crafting_tweaks/files/quality_of_life/universal_dyeing/recipes/universal_dyeing/glass_pane/light_blue_stained_glass_pane.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/universal_dyeing/recipes/universal_dyeing/glass_pane/light_blue_stained_glass_pane.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:ud.light_blue_stained_glass_pane"

--- a/crafting_tweaks/files/quality_of_life/universal_dyeing/recipes/universal_dyeing/glass_pane/light_gray_stained_glass_pane.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/universal_dyeing/recipes/universal_dyeing/glass_pane/light_gray_stained_glass_pane.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:ud.light_gray_stained_glass_pane"

--- a/crafting_tweaks/files/quality_of_life/universal_dyeing/recipes/universal_dyeing/glass_pane/lime_stained_glass_pane.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/universal_dyeing/recipes/universal_dyeing/glass_pane/lime_stained_glass_pane.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:ud.lime_stained_glass_pane"

--- a/crafting_tweaks/files/quality_of_life/universal_dyeing/recipes/universal_dyeing/glass_pane/magenta_stained_glass_pane.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/universal_dyeing/recipes/universal_dyeing/glass_pane/magenta_stained_glass_pane.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:ud.magenta_stained_glass_pane"

--- a/crafting_tweaks/files/quality_of_life/universal_dyeing/recipes/universal_dyeing/glass_pane/orange_stained_glass_pane.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/universal_dyeing/recipes/universal_dyeing/glass_pane/orange_stained_glass_pane.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:ud.orange_stained_glass_pane"

--- a/crafting_tweaks/files/quality_of_life/universal_dyeing/recipes/universal_dyeing/glass_pane/pink_stained_glass_pane.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/universal_dyeing/recipes/universal_dyeing/glass_pane/pink_stained_glass_pane.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:ud.pink_stained_glass_pane"

--- a/crafting_tweaks/files/quality_of_life/universal_dyeing/recipes/universal_dyeing/glass_pane/purple_stained_glass_pane.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/universal_dyeing/recipes/universal_dyeing/glass_pane/purple_stained_glass_pane.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:ud.purple_stained_glass_pane"

--- a/crafting_tweaks/files/quality_of_life/universal_dyeing/recipes/universal_dyeing/glass_pane/red_stained_glass_pane.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/universal_dyeing/recipes/universal_dyeing/glass_pane/red_stained_glass_pane.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:ud.red_stained_glass_pane"

--- a/crafting_tweaks/files/quality_of_life/universal_dyeing/recipes/universal_dyeing/glass_pane/white_stained_glass_pane.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/universal_dyeing/recipes/universal_dyeing/glass_pane/white_stained_glass_pane.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:ud.white_stained_glass_pane"

--- a/crafting_tweaks/files/quality_of_life/universal_dyeing/recipes/universal_dyeing/glass_pane/yellow_stained_glass_pane.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/universal_dyeing/recipes/universal_dyeing/glass_pane/yellow_stained_glass_pane.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:ud.yellow_stained_glass_pane"

--- a/crafting_tweaks/files/quality_of_life/universal_dyeing/recipes/universal_dyeing/terracotta/black_terracotta.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/universal_dyeing/recipes/universal_dyeing/terracotta/black_terracotta.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:ud.black_terracotta"

--- a/crafting_tweaks/files/quality_of_life/universal_dyeing/recipes/universal_dyeing/terracotta/blue_terracotta.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/universal_dyeing/recipes/universal_dyeing/terracotta/blue_terracotta.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:ud.blue_terracotta"

--- a/crafting_tweaks/files/quality_of_life/universal_dyeing/recipes/universal_dyeing/terracotta/brown_terracotta.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/universal_dyeing/recipes/universal_dyeing/terracotta/brown_terracotta.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:ud.brown_terracotta"

--- a/crafting_tweaks/files/quality_of_life/universal_dyeing/recipes/universal_dyeing/terracotta/cyan_terracotta.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/universal_dyeing/recipes/universal_dyeing/terracotta/cyan_terracotta.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:ud.cyan_terracotta"

--- a/crafting_tweaks/files/quality_of_life/universal_dyeing/recipes/universal_dyeing/terracotta/gray_terracotta.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/universal_dyeing/recipes/universal_dyeing/terracotta/gray_terracotta.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:ud.gray_terracotta"

--- a/crafting_tweaks/files/quality_of_life/universal_dyeing/recipes/universal_dyeing/terracotta/green_terracotta.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/universal_dyeing/recipes/universal_dyeing/terracotta/green_terracotta.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:ud.green_terracotta"

--- a/crafting_tweaks/files/quality_of_life/universal_dyeing/recipes/universal_dyeing/terracotta/light_blue_terracotta.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/universal_dyeing/recipes/universal_dyeing/terracotta/light_blue_terracotta.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:ud.light_blue_terracotta"

--- a/crafting_tweaks/files/quality_of_life/universal_dyeing/recipes/universal_dyeing/terracotta/light_gray_terracotta.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/universal_dyeing/recipes/universal_dyeing/terracotta/light_gray_terracotta.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:ud.light_gray_terracotta"

--- a/crafting_tweaks/files/quality_of_life/universal_dyeing/recipes/universal_dyeing/terracotta/lime_terracotta.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/universal_dyeing/recipes/universal_dyeing/terracotta/lime_terracotta.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:ud.lime_terracotta"

--- a/crafting_tweaks/files/quality_of_life/universal_dyeing/recipes/universal_dyeing/terracotta/magenta_terracotta.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/universal_dyeing/recipes/universal_dyeing/terracotta/magenta_terracotta.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:ud.magenta_terracotta"

--- a/crafting_tweaks/files/quality_of_life/universal_dyeing/recipes/universal_dyeing/terracotta/orange_terracotta.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/universal_dyeing/recipes/universal_dyeing/terracotta/orange_terracotta.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:ud.orange_terracotta"

--- a/crafting_tweaks/files/quality_of_life/universal_dyeing/recipes/universal_dyeing/terracotta/pink_terracotta.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/universal_dyeing/recipes/universal_dyeing/terracotta/pink_terracotta.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:ud.pink_terracotta"

--- a/crafting_tweaks/files/quality_of_life/universal_dyeing/recipes/universal_dyeing/terracotta/purple_terracotta.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/universal_dyeing/recipes/universal_dyeing/terracotta/purple_terracotta.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:ud.purple_terracotta"

--- a/crafting_tweaks/files/quality_of_life/universal_dyeing/recipes/universal_dyeing/terracotta/red_terracotta.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/universal_dyeing/recipes/universal_dyeing/terracotta/red_terracotta.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:ud.red_terracotta"

--- a/crafting_tweaks/files/quality_of_life/universal_dyeing/recipes/universal_dyeing/terracotta/terracotta.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/universal_dyeing/recipes/universal_dyeing/terracotta/terracotta.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:ud.terracotta"

--- a/crafting_tweaks/files/quality_of_life/universal_dyeing/recipes/universal_dyeing/terracotta/white_terracotta.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/universal_dyeing/recipes/universal_dyeing/terracotta/white_terracotta.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:ud.white_terracotta"

--- a/crafting_tweaks/files/quality_of_life/universal_dyeing/recipes/universal_dyeing/terracotta/yellow_terracotta.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/universal_dyeing/recipes/universal_dyeing/terracotta/yellow_terracotta.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
 			"identifier": "bt:ud.yellow_terracotta"

--- a/crafting_tweaks/files/unpackables/unpackable_ice/recipes/unpackable_ice/ice.recipe.json.json
+++ b/crafting_tweaks/files/unpackables/unpackable_ice/recipes/unpackable_ice/ice.recipe.json.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shapeless": {
 		"description": {
 			"identifier": "bt:ui.ice_from_packed_ice"

--- a/crafting_tweaks/files/unpackables/unpackable_ice/recipes/unpackable_ice/packed_ice.recipe.json
+++ b/crafting_tweaks/files/unpackables/unpackable_ice/recipes/unpackable_ice/packed_ice.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shapeless": {
 		"description": {
 			"identifier": "bt:ui.packed_ice_from_blue_ice"

--- a/crafting_tweaks/files/unpackables/unpackable_magma/recipes/unpackable_magma/magma_block_to_magma_cream.recipe.json
+++ b/crafting_tweaks/files/unpackables/unpackable_magma/recipes/unpackable_magma/magma_block_to_magma_cream.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shapeless": {
 		"description": {
 			"identifier": "bt:um.magma_block_to_magma_cream"

--- a/crafting_tweaks/files/unpackables/unpackable_nether_wart/recipes/unpackable_nether_wart_block/nether_wart_from_block.recipe.json
+++ b/crafting_tweaks/files/unpackables/unpackable_nether_wart/recipes/unpackable_nether_wart_block/nether_wart_from_block.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shapeless": {
 		"description": {
 			"identifier": "bt:unw.nether_wart_from_block"

--- a/crafting_tweaks/files/unpackables/unpackable_wool/recipes/unpackable_wool/wool_to_string.recipe.json
+++ b/crafting_tweaks/files/unpackables/unpackable_wool/recipes/unpackable_wool/wool_to_string.recipe.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.0",
+	"format_version": "1.21.50",
 	"minecraft:recipe_shapeless": {
 		"description": {
 			"identifier": "bt:uw.wool_to_string"

--- a/crafting_tweaks/packs.json
+++ b/crafting_tweaks/packs.json
@@ -3,7 +3,7 @@
 	"version": [
 		1,
 		21,
-		0
+		50
 	],
 	"categories": [
 		{
@@ -14,73 +14,73 @@
 					"id": "back_to_blocks",
 					"name": "Back to Blocks",
 					"description": "Allows you to craft full blocks from stairs and slabs",
-					"version": "1.21 - 1.0.0"
+					"version": "1.21.50 - 1.0.0"
 				},
 				{
 					"id": "double_slabs",
 					"name": "Double Slabs",
 					"description": "Allows you to craft 2 slabs from a single block",
-					"version": "1.21 - 1.0.0"
+					"version": "1.21.50 - 1.0.0"
 				},
 				{
 					"id": "dropper_to_dispenser",
 					"name": "Dropper to Dispenser",
 					"description": "Allows you to convert a Dropper to a Dispenser using a Bow, or by using String and Sticks",
-					"version": "1.21 - 1.0.0"
+					"version": "1.21.50 - 1.0.0"
 				},
 				{
 					"id": "rotten_flesh_to_leather",
 					"name": "Rotten Flesh to Leather",
 					"description": "Allows you to smelt Rotten Flesh into Leather",
-					"version": "1.21 - 1.0.0"
+					"version": "1.21.50 - 1.0.0"
 				},
 				{
 					"id": "copper_powered_rails",
 					"name": "Copper Powered Rails",
 					"description": "Lets you craft powered rails from copper (But you can still craft them from gold!)",
-					"version": "1.21 - 1.0.0"
+					"version": "1.21.50 - 1.0.0"
 				},
 				{
 					"id": "charcoal_to_black_dye",
 					"name": "Charcoal to Black Dye",
 					"description": "Allows you to craft Charcoal into Black Dye",
-					"version": "1.21 - 1.0.0"
+					"version": "1.21.50 - 1.0.0"
 				},
 				{
 					"id": "coal_to_black_dye",
 					"name": "Coal to Black Dye",
 					"description": "Allows you to craft Coal into Black Dye",
-					"version": "1.21 - 1.0.0"
+					"version": "1.21.50 - 1.0.0"
 				},
 				{
 					"id": "sandstone_dyeing",
 					"name": "Sandstone Dyeing",
 					"description": "Allows you to craft Sandstone with Red Dye to get Red Sandstone",
-					"version": "1.21 - 1.0.0"
+					"version": "1.21.50 - 1.0.0"
 				},
 				{
 					"id": "universal_dyeing",
 					"name": "Universal Dyeing",
 					"description": "Allows you to dye any dyeable block to another color, no matter what color it is (does not include, Concrete, Candles or Glazed Terracotta)",
-					"version": "1.21 - 1.0.0"
+					"version": "1.21.50 - 1.0.0"
 				},
 				{
 					"id": "straight_to_shapeless",
 					"name": "Straight to Shapeless",
 					"description": "Craft items such as Paper, Bread and Shulker Boxes directly in your 2x2",
-					"version": "1.21 - 1.0.0"
+					"version": "1.21.50 - 1.0.0"
 				},
 				{
 					"id": "alternate_cobblestone",
 					"name": "Alternate Cobblestone",
 					"description": "Craft all items that require Cobblestone, using Blackstone or Cobbled Deepslate",
-					"version": "1.21 - 1.0.0"
+					"version": "1.21.50 - 1.0.0"
 				},
 				{
 					"id": "powder_to_glass",
 					"name": "Powder to Glass",
 					"description": "Smelt all colors of Concrete Powder into their respective Stained Glass color",
-					"version": "1.21 - 1.0.0"
+					"version": "1.21.50 - 1.0.0"
 				}
 			]
 		},
@@ -92,25 +92,25 @@
 					"id": "more_trapdoors",
 					"name": "More Trapdoors",
 					"description": "Creates 12 Trapdoors instead of 2",
-					"version": "1.21 - 1.0.0"
+					"version": "1.21.50 - 1.0.0"
 				},
 				{
 					"id": "more_bark",
 					"name": "More Bark",
 					"description": "Creates 4 Bark instead of 3",
-					"version": "1.21 - 1.0.0"
+					"version": "1.21.50 - 1.0.0"
 				},
 				{
 					"id": "more_stairs",
 					"name": "More Stairs",
 					"description": "Creates 8 Stairs instead of 4",
-					"version": "1.21 - 1.0.0"
+					"version": "1.21.50 - 1.0.0"
 				},
 				{
 					"id": "more_bricks",
 					"name": "More Bricks",
 					"description": "Creates 4 Bricks, Nether Bricks and Red Nether Bricks instead of 1",
-					"version": "1.21 - 1.0.0"
+					"version": "1.21.50 - 1.0.0"
 				}
 			]
 		},
@@ -122,43 +122,43 @@
 					"id": "craftable_gravel",
 					"name": "Craftable Gravel",
 					"description": "Allows you to craft Gravel from Flint",
-					"version": "1.21 - 1.0.0"
+					"version": "1.21.50 - 1.0.0"
 				},
 				{
 					"id": "craftable_horse_armor",
 					"name": "Craftable Horse Armor",
 					"description": "Allows you to craft Horse Armor",
-					"version": "1.21 - 1.0.0"
+					"version": "1.21.50 - 1.0.0"
 				},
 				{
 					"id": "craftable_coral_blocks_2x2",
 					"name": "Craftable Coral Blocks 2x2",
 					"description": "Allows you to craft Coral Blocks and their dead variants from their Coral Plant or Coral Tube in a 2x2. Tubes and Fans are not interchangeable",
-					"version": "1.21 - 1.0.0"
+					"version": "1.21.50 - 1.0.0"
 				},
 				{
 					"id": "craftable_coral_blocks_3x3",
 					"name": "Craftable Coral Blocks 3x3",
 					"description": "Allows you to craft Coral Blocks and their dead variants from their Coral Plant or Coral Tube in a 3x3. Tubes and Fans are not interchangeable",
-					"version": "1.21 - 1.0.0"
+					"version": "1.21.50 - 1.0.0"
 				},
 				{
 					"id": "craftable_enchanted_golden_apple",
 					"name": "Craftable Enchanted Golden Apple",
 					"description": "Allows you to craft Enchanted Golden Apples",
-					"version": "1.21 - 1.0.0"
+					"version": "1.21.50 - 1.0.0"
 				},
 				{
 					"id": "craftable_name_tags",
 					"name": "Craftable Name Tags",
 					"description": "Allows you to craft Name Tags",
-					"version": "1.21 - 1.0.0"
+					"version": "1.21.50 - 1.0.0"
 				},
 				{
 					"id": "craftable_blackstone",
 					"name": "Craftable Blackstone",
 					"description": "Allows you to craft Blackstone or Polished Blackstone, using Basalt & Coal/Charcoal",
-					"version": "1.21 - 1.0.0"
+					"version": "1.21.50 - 1.0.0"
 				}
 			]
 		},
@@ -170,25 +170,25 @@
 					"id": "unpackable_ice",
 					"name": "Unpackable Ice",
 					"description": "Allows you to break down Ice into 9 pieces. 1 Blue Ice to 9 Packed Ice to 81 Ice",
-					"version": "1.21 - 1.0.0"
+					"version": "1.21.50 - 1.0.0"
 				},
 				{
 					"id": "unpackable_nether_wart",
 					"name": "Unpackable Nether Wart",
 					"description": "Allows you to break down Nether Wart Blocks into 9 Nether Wart",
-					"version": "1.21 - 1.0.0"
+					"version": "1.21.50 - 1.0.0"
 				},
 				{
 					"id": "unpackable_wool",
 					"name": "Unpackable Wool",
 					"description": "Allows you to break down Wool into 4 String",
-					"version": "1.21 - 1.0.0"
+					"version": "1.21.50 - 1.0.0"
 				},
 				{
 					"id": "unpackable_magma",
 					"name": "Unpackable Magma",
 					"description": "Allows you to break down Magma Blocks into 4 Magma Creams",
-					"version": "1.21 - 1.0.0"
+					"version": "1.21.50 - 1.0.0"
 				}
 			]
 		}


### PR DESCRIPTION
- add pale_oak_* recipes
- flatten any non flattened entries
- removed extra entries (in Powder to Glass)
- updated all instances of 1.21.x to 1.21.50

By checking the following boxes with an X, you ensure that:

- [x] The pack was tested ingame in at least one device.
- [x] The pack is an existing BT pack, is a missing pack from VT or is an accepted pack/change in a discussion.
- [x] The pack code follows the style guide.
- [x] The commits follow the contribution guidelines.
- [x] The PR follows the contribution guidelines.

- [x] (Optional) Tested in Windows
- [ ] (Optional) Tested in Android
- [ ] (Optional) Tested in iOS
- [ ] (Optional) Tested in any console
- [ ] (Optional) Tested in BDS
