### PR TITLE
feat(files): add pale_oak to crafting tweaks

### DIFF
--- a/crafting_tweaks/files/more_blocks/more_bark/recipes/more_bark/stripped_wood/stripped_pale_oak_wood.recipe.json
+++ b/crafting_tweaks/files/more_blocks/more_bark/recipes/more_bark/stripped_wood/stripped_pale_oak_wood.recipe.json
@@ -1,0 +1,31 @@
+{
+	"format_version": "1.21.50",
+	"minecraft:recipe_shaped": {
+		"description": {
+			"identifier": "bt:mb.pale_oak_wood_stripped"
+		},
+		"tags": [
+			"crafting_table"
+		],
+		"group": "wood",
+		"priority": -1,
+		"pattern": [
+			"##",
+			"##"
+		],
+		"key": {
+			"#": {
+				"item": "minecraft:pale_stripped_oak_log"
+			}
+		},
+		"unlock": [
+			{
+				"item": "minecraft:pale_stripped_oak_log"
+			}
+		],
+		"result": {
+			"item": "minecraft:pale_stripped_oak_wood",
+			"count": 4
+		}
+	}
+}

--- a/crafting_tweaks/files/more_blocks/more_bark/recipes/more_bark/stripped_wood/stripped_pale_oak_wood.recipe.json
+++ b/crafting_tweaks/files/more_blocks/more_bark/recipes/more_bark/stripped_wood/stripped_pale_oak_wood.recipe.json
@@ -2,7 +2,7 @@
 	"format_version": "1.21.50",
 	"minecraft:recipe_shaped": {
 		"description": {
-			"identifier": "bt:mb.pale_oak_wood_stripped"
+			"identifier": "bt:mb.stripped_pale_oak_wood"
 		},
 		"tags": [
 			"crafting_table"
@@ -15,16 +15,16 @@
 		],
 		"key": {
 			"#": {
-				"item": "minecraft:pale_stripped_oak_log"
+				"item": "minecraft:stripped_pale_oak_log"
 			}
 		},
 		"unlock": [
 			{
-				"item": "minecraft:pale_stripped_oak_log"
+				"item": "minecraft:stripped_pale_oak_log"
 			}
 		],
 		"result": {
-			"item": "minecraft:pale_stripped_oak_wood",
+			"item": "minecraft:stripped_pale_oak_wood",
 			"count": 4
 		}
 	}

--- a/crafting_tweaks/files/more_blocks/more_bark/recipes/more_bark/wood/pale_oak_wood.recipe.json
+++ b/crafting_tweaks/files/more_blocks/more_bark/recipes/more_bark/wood/pale_oak_wood.recipe.json
@@ -1,0 +1,31 @@
+{
+	"format_version": "1.21.50",
+	"minecraft:recipe_shaped": {
+		"description": {
+			"identifier": "bt:mb.pale_oak_wood"
+		},
+		"tags": [
+			"crafting_table"
+		],
+		"group": "wood",
+		"priority": -1,
+		"pattern": [
+			"##",
+			"##"
+		],
+		"key": {
+			"#": {
+				"item": "minecraft:pale_oak_log"
+			}
+		},
+		"unlock": [
+			{
+				"item": "minecraft:pale_oak_log"
+			}
+		],
+		"result": {
+			"item": "minecraft:pale_oak_wood",
+			"count": 4
+		}
+	}
+}

--- a/crafting_tweaks/files/more_blocks/more_bricks/recipes/more_bricks/resin_bricks.recipe.json
+++ b/crafting_tweaks/files/more_blocks/more_bricks/recipes/more_bricks/resin_bricks.recipe.json
@@ -1,0 +1,30 @@
+{
+	"format_version": "1.21.50",
+	"minecraft:recipe_shaped": {
+		"description": {
+			"identifier": "bt:mb.resin_bricks"
+		},
+		"tags": [
+			"crafting_table"
+		],
+		"priority": -1,
+		"pattern": [
+			"##",
+			"##"
+		],
+		"key": {
+			"#": {
+				"item": "minecraft:resin_brick"
+			}
+		},
+		"unlock": [
+			{
+				"item": "minecraft:resin_brick"
+			}
+		],
+		"result": {
+			"item": "minecraft:resin_bricks",
+			"count": 4
+		}
+	}
+}

--- a/crafting_tweaks/files/more_blocks/more_stairs/recipes/more_stairs/pale_oak_stairs.recipe.json
+++ b/crafting_tweaks/files/more_blocks/more_stairs/recipes/more_stairs/pale_oak_stairs.recipe.json
@@ -1,0 +1,32 @@
+{
+	"format_version": "1.21.50",
+	"minecraft:recipe_shaped": {
+		"description": {
+			"identifier": "bt:ms.pale_oak_stairs"
+		},
+		"tags": [
+			"crafting_table"
+		],
+		"group": "wooden_stairs",
+		"priority": -1,
+		"pattern": [
+			"#",
+			"##",
+			"###"
+		],
+		"key": {
+			"#": {
+				"item": "minecraft:pale_oak_planks"
+			}
+		},
+		"unlock": [
+			{
+				"item": "minecraft:pale_oak_planks"
+			}
+		],
+		"result": {
+			"item": "minecraft:pale_oak_stairs",
+			"count": 8
+		}
+	}
+}

--- a/crafting_tweaks/files/more_blocks/more_stairs/recipes/more_stairs/resin_brick_stairs.recipe.json
+++ b/crafting_tweaks/files/more_blocks/more_stairs/recipes/more_stairs/resin_brick_stairs.recipe.json
@@ -1,0 +1,31 @@
+{
+	"format_version": "1.21.50",
+	"minecraft:recipe_shaped": {
+		"description": {
+			"identifier": "bt:ms.resin_brick_stairs"
+		},
+		"tags": [
+			"crafting_table"
+		],
+		"priority": -1,
+		"pattern": [
+			"#",
+			"##",
+			"###"
+		],
+		"key": {
+			"#": {
+				"item": "minecraft:resin_bricks"
+			}
+		},
+		"unlock": [
+			{
+				"item": "minecraft:resin_bricks"
+			}
+		],
+		"result": {
+			"item": "minecraft:resin_brick_stairs",
+			"count": 8
+		}
+	}
+}

--- a/crafting_tweaks/files/more_blocks/more_trapdoors/recipes/more_trapdoors/pale_oak_trapdoor.recipe.json
+++ b/crafting_tweaks/files/more_blocks/more_trapdoors/recipes/more_trapdoors/pale_oak_trapdoor.recipe.json
@@ -1,0 +1,31 @@
+{
+	"format_version": "1.21.0",
+	"minecraft:recipe_shaped": {
+		"description": {
+			"identifier": "bt:mt.pale_oak_trapdoor"
+		},
+		"tags": [
+			"crafting_table"
+		],
+		"group": "wooden_trap_door",
+		"priority": -1,
+		"pattern": [
+			"###",
+			"###"
+		],
+		"key": {
+			"#": {
+				"item": "minecraft:pale_oak_planks"
+			}
+		},
+		"unlock": [
+			{
+				"item": "minecraft:pale_oak_planks"
+			}
+		],
+		"result": {
+			"item": "minecraft:pale_oak_trapdoor",
+			"count": 12
+		}
+	}
+}

--- a/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/slabs/pale_oak_planks.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/slabs/pale_oak_planks.recipe.json
@@ -1,0 +1,30 @@
+{
+	"format_version": "1.21.0",
+	"minecraft:recipe_shaped": {
+		"description": {
+			"identifier": "bt:bb.slabs.pale_oak_planks"
+		},
+		"tags": [
+			"crafting_table"
+		],
+		"group": "slabs_to_blocks",
+		"priority": -1,
+		"pattern": [
+			"##"
+		],
+		"key": {
+			"#": {
+				"item": "minecraft:pale_oak_slab"
+			}
+		},
+		"unlock": [
+			{
+				"item": "minecraft:pale_oak_slab"
+			}
+		],
+		"result": {
+			"item": "minecraft:pale_oak_planks",
+			"count": 1
+		}
+	}
+}

--- a/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/slabs/resin_bricks.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/slabs/resin_bricks.recipe.json
@@ -1,0 +1,30 @@
+{
+	"format_version": "1.21.50",
+	"minecraft:recipe_shaped": {
+		"description": {
+			"identifier": "bt:bb.slabs.resin_bricks"
+		},
+		"tags": [
+			"crafting_table"
+		],
+		"group": "slabs_to_blocks",
+		"priority": -1,
+		"pattern": [
+			"##"
+		],
+		"key": {
+			"#": {
+				"item": "minecraft:resin_brick_slab"
+			}
+		},
+		"unlock": [
+			{
+				"item": "minecraft:resin_brick_slab"
+			}
+		],
+		"result": {
+			"item": "minecraft:resin_bricks",
+			"count": 1
+		}
+	}
+}

--- a/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/stairs/pale_oak_planks.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/stairs/pale_oak_planks.recipe.json
@@ -1,0 +1,31 @@
+{
+	"format_version": "1.21.0",
+	"minecraft:recipe_shaped": {
+		"description": {
+			"identifier": "bt:bb.stairs.pale_oak_planks"
+		},
+		"tags": [
+			"crafting_table"
+		],
+		"group": "stairs_to_blocks",
+		"priority": -1,
+		"pattern": [
+			"##",
+			"##"
+		],
+		"key": {
+			"#": {
+				"item": "minecraft:pale_oak_stairs"
+			}
+		},
+		"unlock": [
+			{
+				"item": "minecraft:pale_oak_stairs"
+			}
+		],
+		"result": {
+			"item": "minecraft:pale_oak_planks",
+			"count": 3
+		}
+	}
+}

--- a/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/stairs/resin_bricks.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/back_to_blocks/recipes/back_to_blocks/stairs/resin_bricks.recipe.json
@@ -1,0 +1,31 @@
+{
+	"format_version": "1.21.50",
+	"minecraft:recipe_shaped": {
+		"description": {
+			"identifier": "bt:bb.stairs.resin_bricks"
+		},
+		"tags": [
+			"crafting_table"
+		],
+		"group": "stairs_to_blocks",
+		"priority": -1,
+		"pattern": [
+			"##",
+			"##"
+		],
+		"key": {
+			"#": {
+				"item": "minecraft:resin_brick_stairs"
+			}
+		},
+		"unlock": [
+			{
+				"item": "minecraft:resin_brick_stairs"
+			}
+		],
+		"result": {
+			"item": "minecraft:resin_bricks",
+			"count": 3
+		}
+	}
+}

--- a/crafting_tweaks/files/quality_of_life/double_slabs/recipes/double_slabs/resin_brick_slab.recipe.json
+++ b/crafting_tweaks/files/quality_of_life/double_slabs/recipes/double_slabs/resin_brick_slab.recipe.json
@@ -1,0 +1,26 @@
+{
+	"format_version": "1.21.50",
+	"minecraft:recipe_shapeless": {
+		"description": {
+			"identifier": "bt:ds.resin_brick_slab"
+		},
+		"tags": [
+			"crafting_table"
+		],
+		"priority": -1,
+		"ingredients": [
+			{
+				"item": "minecraft:resin_bricks"
+			}
+		],
+		"unlock": [
+			{
+				"item": "minecraft:resin_bricks"
+			}
+		],
+		"result": {
+			"item": "minecraft:resin_brick_slab",
+			"count": 2
+		}
+	}
+}


### PR DESCRIPTION
- add pale_oak to the following packs
  - more_bark
  - more_stairs
  - more_trapdoors
  - back-to-blocks
- add resin_bricks related recipes
  - add resin_bricks to more_bricks
  - add resin_bricks to back-to-blocks
  - add resin_brick_slabs to double slabs
  - add resin_brick_stairs to more stairs

By checking the following boxes with an X, you ensure that:

- [x] The pack was tested ingame in at least one device.
- [x] The pack is an existing BT pack, is a missing pack from VT or is an accepted pack/change in a discussion.
- [x] The pack code follows the style guide.
- [x] The commits follow the contribution guidelines.
- [x] The PR follows the contribution guidelines.

- [x] (Optional) Tested in Windows
- [ ] (Optional) Tested in Android
- [ ] (Optional) Tested in iOS
- [ ] (Optional) Tested in any console
- [ ] (Optional) Tested in BDS
