### PR TITLE
fix(files): Fix various Peace and Quiet packs not quieting few sound events

### DIFF
--- a/resource_packs/files/peace_and_quiet/quieter_consumables/sounds.json
+++ b/resource_packs/files/peace_and_quiet/quieter_consumables/sounds.json
@@ -14,8 +14,14 @@
 						0.055
 					]
 				}
-			},
-			"volume": 0.05
+			}
+		}
+	},
+	"individual_event_sounds": {
+		"events": {
+			"burp": {
+				"volume": 0.025
+			}
 		}
 	}
 }

--- a/resource_packs/files/peace_and_quiet/quieter_fire/sounds.json
+++ b/resource_packs/files/peace_and_quiet/quieter_fire/sounds.json
@@ -22,6 +22,9 @@
 					0.075
 				]
 			},
+			"block.furnace.lit": {
+				"volume": 0.15
+			},
 			"mob.player.hurt_on_fire": {
 				"volume": 0.05
 			}

--- a/resource_packs/files/peace_and_quiet/quieter_rain/sounds/sound_definitions.json
+++ b/resource_packs/files/peace_and_quiet/quieter_rain/sounds/sound_definitions.json
@@ -2,7 +2,7 @@
 	"format_version": "1.20.20",
 	"sound_definitions": {
 		"ambient.weather.rain": {
-			"__use_legacy_max_distance": true,
+			"__use_legacy_max_distance": "true",
 			"category": "weather",
 			"max_distance": null,
 			"min_distance": 100.0,
@@ -10,19 +10,19 @@
 				{
 					"load_on_low_memory": true,
 					"name": "sounds/ambient/weather/rain1",
-					"volume": 0.01
+					"volume": 0.001
 				},
 				{
 					"name": "sounds/ambient/weather/rain2",
-					"volume": 0.01
+					"volume": 0.001
 				},
 				{
 					"name": "sounds/ambient/weather/rain3",
-					"volume": 0.01
+					"volume": 0.001
 				},
 				{
 					"name": "sounds/ambient/weather/rain4",
-					"volume": 0.01
+					"volume": 0.001
 				}
 			]
 		}

--- a/resource_packs/files/peace_and_quiet/quieter_thunder/sounds.json
+++ b/resource_packs/files/peace_and_quiet/quieter_thunder/sounds.json
@@ -5,5 +5,12 @@
 				"volume": 50.0
 			}
 		}
+	},
+	"individual_event_sounds": {
+		"events": {
+			"item.trident.thunder": {
+				"volume": 0.25
+			}
+		}
 	}
 }


### PR DESCRIPTION
1. Quieter Consumables now quietens the burp sound made by the player and removed the universal volume reduced for all the player's sound events because someone mistakenly did it *i wonder who*
2. Quieter Fire now quietens the lit sounds made by the furnace
3. Fixed Quieter Rain only reducing the rain sound by 50% and not 95%
4. Quieter Thunders now quietens the thunder sound made by the trident use with channeling enchantment

By checking the following boxes with an X, you ensure that:

- [X] The pack was tested ingame in at least one device.
- [X] The pack is an existing BT pack, is a missing pack from VT or is an accepted pack/change in a discussion.
- [X] The pack code follows the style guide.
- [X] The commits follow the contribution guidelines.
- [X] The PR follows the contribution guidelines.

- [X] (Optional) Tested in Windows
- [ ] (Optional) Tested in Android
- [ ] (Optional) Tested in iOS
- [ ] (Optional) Tested in any console
- [ ] (Optional) Tested in BDS
