### PR TITLE
chore(files): Minor fixes to packs.json and docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -105,7 +105,7 @@ If there is need to scale the template use closest neighbor instead of other sam
 
 JSON files should be formatted using 1 tab with size 4 for indentation.
 
-TS files should be formatted using 2 spaces for indentation.
+TS files should be formatted using 4 spaces for indentation.
 
 ### Addons
 
@@ -155,6 +155,7 @@ When making an addon from the template you should look for these keys and replac
 ```
 <pack_name>
 <pack_category>
+<description>
 <author name/username>
 <bp_uuid>
 <data_module_uuid>

--- a/resource_packs/packs.json
+++ b/resource_packs/packs.json
@@ -13,12 +13,7 @@
 				{
 					"id": "alternate_block_destruction",
 					"name": "Alternate Block Destruction",
-					"description": "Changes the breaking texture of blocks to a messy ring around the outside",
-					"message": {
-						"text": "This pack is disabled because of reason",
-						"severity": "success"
-					},
-					"disabled": true
+					"description": "Changes the breaking texture of blocks to a messy ring around the outside"
 				},
 				{
 					"id": "black_nether_bricks",

--- a/templates/addon/packs/BP/manifest.json
+++ b/templates/addon/packs/BP/manifest.json
@@ -9,7 +9,7 @@
 			0,
 			0
 		],
-		// Update to lastest minecraft release
+		// Update to latest minecraft release
 		"min_engine_version": [
 			1,
 			21,

--- a/templates/addon/packs/RP/manifest.json
+++ b/templates/addon/packs/RP/manifest.json
@@ -9,7 +9,7 @@
 			0,
 			0
 		],
-		// Update to lastest minecraft release
+		// Update to latest minecraft release
 		"min_engine_version": [
 			1,
 			21,


### PR DESCRIPTION
1. Fixed an accidental disabling of alternate block destruction pack
2. Fixed a typo "lastest" in both rp and bp manifest.json in addon template
3. Added a missing description tag to the contribution guidelines
4. Fixed contribution guidelines saying typescript files should be formatted using 2 spaces, but it should be 4 spaces