### PR TITLE
fix(files): Fix Clearer Water and Old Water issues with incorrect foliage/grass colors in modern biomes, missing surface opacity, and some biomes lacking Clearer Water

### DIFF
--- a/resource_packs/extras/terrain/old_clearer_water/biomes/birch_forest_hills_mutated.client_biome.json
+++ b/resource_packs/extras/terrain/old_clearer_water/biomes/birch_forest_hills_mutated.client_biome.json
@@ -1,0 +1,16 @@
+{
+	"format_version": "1.21.40",
+	"minecraft:client_biome": {
+		"description": {
+			"identifier": "birch_forest_hills_mutated"
+		},
+		"components": {
+			"minecraft:fog_appearance": {
+				"fog_identifier": "bt:fog_default"
+			},
+			"minecraft:water_appearance": {
+				"surface_color": "#0056FF"
+			}
+		}
+	}
+}

--- a/resource_packs/extras/terrain/old_clearer_water/biomes/birch_forest_mutated.client_biome.json
+++ b/resource_packs/extras/terrain/old_clearer_water/biomes/birch_forest_mutated.client_biome.json
@@ -1,0 +1,16 @@
+{
+	"format_version": "1.21.40",
+	"minecraft:client_biome": {
+		"description": {
+			"identifier": "birch_forest_mutated"
+		},
+		"components": {
+			"minecraft:fog_appearance": {
+				"fog_identifier": "bt:fog_default"
+			},
+			"minecraft:water_appearance": {
+				"surface_color": "#0056FF"
+			}
+		}
+	}
+}

--- a/resource_packs/extras/terrain/old_clearer_water/biomes/cherry_grove.client_biome.json
+++ b/resource_packs/extras/terrain/old_clearer_water/biomes/cherry_grove.client_biome.json
@@ -5,6 +5,12 @@
 			"identifier": "cherry_grove"
 		},
 		"components": {
+			"minecraft:foliage_appearance": {
+				"color": "#b6db61"
+			},
+			"minecraft:grass_appearance": {
+				"color": "#b6db61"
+			},
 			"minecraft:fog_appearance": {
 				"fog_identifier": "bt:fog_cherry_grove"
 			},

--- a/resource_packs/extras/terrain/old_clearer_water/biomes/deep_dark.client_biome.json
+++ b/resource_packs/extras/terrain/old_clearer_water/biomes/deep_dark.client_biome.json
@@ -1,0 +1,16 @@
+{
+	"format_version": "1.21.40",
+	"minecraft:client_biome": {
+		"description": {
+			"identifier": "deep_dark"
+		},
+		"components": {
+			"minecraft:fog_appearance": {
+				"fog_identifier": "bt:fog_default"
+			},
+			"minecraft:water_appearance": {
+				"surface_color": "#0056FF"
+			}
+		}
+	}
+}

--- a/resource_packs/extras/terrain/old_clearer_water/biomes/desert_mutated.client_biome.json
+++ b/resource_packs/extras/terrain/old_clearer_water/biomes/desert_mutated.client_biome.json
@@ -1,0 +1,16 @@
+{
+	"format_version": "1.21.40",
+	"minecraft:client_biome": {
+		"description": {
+			"identifier": "desert_mutated"
+		},
+		"components": {
+			"minecraft:fog_appearance": {
+				"fog_identifier": "bt:fog_default"
+			},
+			"minecraft:water_appearance": {
+				"surface_color": "#0056FF"
+			}
+		}
+	}
+}

--- a/resource_packs/extras/terrain/old_clearer_water/biomes/dripstone_caves.client_biome.json
+++ b/resource_packs/extras/terrain/old_clearer_water/biomes/dripstone_caves.client_biome.json
@@ -1,0 +1,16 @@
+{
+	"format_version": "1.21.40",
+	"minecraft:client_biome": {
+		"description": {
+			"identifier": "dripstone_caves"
+		},
+		"components": {
+			"minecraft:fog_appearance": {
+				"fog_identifier": "bt:fog_default"
+			},
+			"minecraft:water_appearance": {
+				"surface_color": "#0056FF"
+			}
+		}
+	}
+}

--- a/resource_packs/extras/terrain/old_clearer_water/biomes/frozen_peaks.client_biome.json
+++ b/resource_packs/extras/terrain/old_clearer_water/biomes/frozen_peaks.client_biome.json
@@ -1,0 +1,16 @@
+{
+	"format_version": "1.21.40",
+	"minecraft:client_biome": {
+		"description": {
+			"identifier": "frozen_peaks"
+		},
+		"components": {
+			"minecraft:fog_appearance": {
+				"fog_identifier": "bt:fog_default"
+			},
+			"minecraft:water_appearance": {
+				"surface_color": "#0056FF"
+			}
+		}
+	}
+}

--- a/resource_packs/extras/terrain/old_clearer_water/biomes/grove.client_biome.json
+++ b/resource_packs/extras/terrain/old_clearer_water/biomes/grove.client_biome.json
@@ -1,0 +1,16 @@
+{
+	"format_version": "1.21.40",
+	"minecraft:client_biome": {
+		"description": {
+			"identifier": "grove"
+		},
+		"components": {
+			"minecraft:fog_appearance": {
+				"fog_identifier": "bt:fog_default"
+			},
+			"minecraft:water_appearance": {
+				"surface_color": "#0056FF"
+			}
+		}
+	}
+}

--- a/resource_packs/extras/terrain/old_clearer_water/biomes/jagged_peaks.client_biome.json
+++ b/resource_packs/extras/terrain/old_clearer_water/biomes/jagged_peaks.client_biome.json
@@ -1,0 +1,16 @@
+{
+	"format_version": "1.21.40",
+	"minecraft:client_biome": {
+		"description": {
+			"identifier": "jagged_peaks"
+		},
+		"components": {
+			"minecraft:fog_appearance": {
+				"fog_identifier": "bt:fog_default"
+			},
+			"minecraft:water_appearance": {
+				"surface_color": "#0056FF"
+			}
+		}
+	}
+}

--- a/resource_packs/extras/terrain/old_clearer_water/biomes/jungle_edge_mutated.client_biome.json
+++ b/resource_packs/extras/terrain/old_clearer_water/biomes/jungle_edge_mutated.client_biome.json
@@ -1,0 +1,16 @@
+{
+	"format_version": "1.21.40",
+	"minecraft:client_biome": {
+		"description": {
+			"identifier": "jungle_edge_mutated"
+		},
+		"components": {
+			"minecraft:fog_appearance": {
+				"fog_identifier": "bt:fog_default"
+			},
+			"minecraft:water_appearance": {
+				"surface_color": "#0056FF"
+			}
+		}
+	}
+}

--- a/resource_packs/extras/terrain/old_clearer_water/biomes/legacy_frozen_ocean.client_biome.json
+++ b/resource_packs/extras/terrain/old_clearer_water/biomes/legacy_frozen_ocean.client_biome.json
@@ -1,0 +1,16 @@
+{
+	"format_version": "1.21.40",
+	"minecraft:client_biome": {
+		"description": {
+			"identifier": "legacy_frozen_ocean"
+		},
+		"components": {
+			"minecraft:fog_appearance": {
+				"fog_identifier": "bt:fog_default"
+			},
+			"minecraft:water_appearance": {
+				"surface_color": "#0056FF"
+			}
+		}
+	}
+}

--- a/resource_packs/extras/terrain/old_clearer_water/biomes/lush_caves.client_biome.json
+++ b/resource_packs/extras/terrain/old_clearer_water/biomes/lush_caves.client_biome.json
@@ -1,0 +1,16 @@
+{
+	"format_version": "1.21.40",
+	"minecraft:client_biome": {
+		"description": {
+			"identifier": "lush_caves"
+		},
+		"components": {
+			"minecraft:fog_appearance": {
+				"fog_identifier": "bt:fog_default"
+			},
+			"minecraft:water_appearance": {
+				"surface_color": "#0056FF"
+			}
+		}
+	}
+}

--- a/resource_packs/extras/terrain/old_clearer_water/biomes/mangrove_swamp.client_biome.json
+++ b/resource_packs/extras/terrain/old_clearer_water/biomes/mangrove_swamp.client_biome.json
@@ -5,6 +5,16 @@
 			"identifier": "mangrove_swamp"
 		},
 		"components": {
+			"minecraft:foliage_appearance": {
+				"color": {
+					"color_map": "mangrove_swamp_foliage"
+				}
+			},
+			"minecraft:grass_appearance": {
+				"color": {
+					"color_map": "swamp_grass"
+				}
+			},
 			"minecraft:fog_appearance": {
 				"fog_identifier": "bt:fog_mangrove_swamp"
 			},

--- a/resource_packs/extras/terrain/old_clearer_water/biomes/meadow.client_biome.json
+++ b/resource_packs/extras/terrain/old_clearer_water/biomes/meadow.client_biome.json
@@ -1,0 +1,16 @@
+{
+	"format_version": "1.21.40",
+	"minecraft:client_biome": {
+		"description": {
+			"identifier": "meadow"
+		},
+		"components": {
+			"minecraft:fog_appearance": {
+				"fog_identifier": "bt:fog_default"
+			},
+			"minecraft:water_appearance": {
+				"surface_color": "#0056FF"
+			}
+		}
+	}
+}

--- a/resource_packs/extras/terrain/old_clearer_water/biomes/mesa.client_biome.json
+++ b/resource_packs/extras/terrain/old_clearer_water/biomes/mesa.client_biome.json
@@ -5,6 +5,12 @@
 			"identifier": "mesa"
 		},
 		"components": {
+			"minecraft:foliage_appearance": {
+				"color": "#aea42a"
+			},
+			"minecraft:grass_appearance": {
+				"color": "#90814d"
+			},
 			"minecraft:fog_appearance": {
 				"fog_identifier": "bt:fog_mesa"
 			},

--- a/resource_packs/extras/terrain/old_clearer_water/biomes/mesa_bryce.client_biome.json
+++ b/resource_packs/extras/terrain/old_clearer_water/biomes/mesa_bryce.client_biome.json
@@ -5,6 +5,12 @@
 			"identifier": "mesa_bryce"
 		},
 		"components": {
+			"minecraft:foliage_appearance": {
+				"color": "#aea42a"
+			},
+			"minecraft:grass_appearance": {
+				"color": "#90814d"
+			},
 			"minecraft:fog_appearance": {
 				"fog_identifier": "bt:fog_mesa_bryce"
 			},

--- a/resource_packs/extras/terrain/old_clearer_water/biomes/mesa_plateau_mutated.client_biome.json
+++ b/resource_packs/extras/terrain/old_clearer_water/biomes/mesa_plateau_mutated.client_biome.json
@@ -1,0 +1,22 @@
+{
+	"format_version": "1.21.40",
+	"minecraft:client_biome": {
+		"description": {
+			"identifier": "mesa_plateau_mutated"
+		},
+		"components": {
+			"minecraft:foliage_appearance": {
+				"color": "#aea42a"
+			},
+			"minecraft:grass_appearance": {
+				"color": "#90814d"
+			},
+			"minecraft:fog_appearance": {
+				"fog_identifier": "bt:fog_default"
+			},
+			"minecraft:water_appearance": {
+				"surface_color": "#0056FF"
+			}
+		}
+	}
+}

--- a/resource_packs/extras/terrain/old_clearer_water/biomes/mesa_plateau_stone.client_biome.json
+++ b/resource_packs/extras/terrain/old_clearer_water/biomes/mesa_plateau_stone.client_biome.json
@@ -5,6 +5,12 @@
 			"identifier": "mesa_plateau_stone"
 		},
 		"components": {
+			"minecraft:foliage_appearance": {
+				"color": "#aea42a"
+			},
+			"minecraft:grass_appearance": {
+				"color": "#90814d"
+			},
 			"minecraft:fog_appearance": {
 				"fog_identifier": "bt:fog_mesa_plateau_stone"
 			},

--- a/resource_packs/extras/terrain/old_clearer_water/biomes/mesa_plateau_stone_mutated.client_biome.json
+++ b/resource_packs/extras/terrain/old_clearer_water/biomes/mesa_plateau_stone_mutated.client_biome.json
@@ -1,0 +1,22 @@
+{
+	"format_version": "1.21.40",
+	"minecraft:client_biome": {
+		"description": {
+			"identifier": "mesa_plateau_stone_mutated"
+		},
+		"components": {
+			"minecraft:foliage_appearance": {
+				"color": "#aea42a"
+			},
+			"minecraft:grass_appearance": {
+				"color": "#90814d"
+			},
+			"minecraft:fog_appearance": {
+				"fog_identifier": "bt:fog_default"
+			},
+			"minecraft:water_appearance": {
+				"surface_color": "#0056FF"
+			}
+		}
+	}
+}

--- a/resource_packs/extras/terrain/old_clearer_water/biomes/pale_garden.client_biome.json
+++ b/resource_packs/extras/terrain/old_clearer_water/biomes/pale_garden.client_biome.json
@@ -16,6 +16,12 @@
 			},
 			"minecraft:biome_music": {
 				"volume_multiplier": 0
+			},
+			"minecraft:foliage_appearance": {
+				"color": "#878d76"
+			},
+			"minecraft:grass_appearance": {
+				"color": "#778272"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/old_clearer_water/biomes/redwood_taiga_hills_mutated.client_biome.json
+++ b/resource_packs/extras/terrain/old_clearer_water/biomes/redwood_taiga_hills_mutated.client_biome.json
@@ -1,0 +1,16 @@
+{
+	"format_version": "1.21.40",
+	"minecraft:client_biome": {
+		"description": {
+			"identifier": "redwood_taiga_hills_mutated"
+		},
+		"components": {
+			"minecraft:fog_appearance": {
+				"fog_identifier": "bt:fog_default"
+			},
+			"minecraft:water_appearance": {
+				"surface_color": "#0056FF"
+			}
+		}
+	}
+}

--- a/resource_packs/extras/terrain/old_clearer_water/biomes/redwood_taiga_mutated.client_biome.json
+++ b/resource_packs/extras/terrain/old_clearer_water/biomes/redwood_taiga_mutated.client_biome.json
@@ -1,0 +1,16 @@
+{
+	"format_version": "1.21.40",
+	"minecraft:client_biome": {
+		"description": {
+			"identifier": "redwood_taiga_mutated"
+		},
+		"components": {
+			"minecraft:fog_appearance": {
+				"fog_identifier": "bt:fog_default"
+			},
+			"minecraft:water_appearance": {
+				"surface_color": "#0056FF"
+			}
+		}
+	}
+}

--- a/resource_packs/extras/terrain/old_clearer_water/biomes/roofed_forest_mutated.client_biome.json
+++ b/resource_packs/extras/terrain/old_clearer_water/biomes/roofed_forest_mutated.client_biome.json
@@ -1,0 +1,16 @@
+{
+	"format_version": "1.21.40",
+	"minecraft:client_biome": {
+		"description": {
+			"identifier": "roofed_forest_mutated"
+		},
+		"components": {
+			"minecraft:fog_appearance": {
+				"fog_identifier": "bt:fog_default"
+			},
+			"minecraft:water_appearance": {
+				"surface_color": "#0056FF"
+			}
+		}
+	}
+}

--- a/resource_packs/extras/terrain/old_clearer_water/biomes/savanna_plateau_mutated.client_biome.json
+++ b/resource_packs/extras/terrain/old_clearer_water/biomes/savanna_plateau_mutated.client_biome.json
@@ -1,0 +1,16 @@
+{
+	"format_version": "1.21.40",
+	"minecraft:client_biome": {
+		"description": {
+			"identifier": "savanna_plateau_mutated"
+		},
+		"components": {
+			"minecraft:fog_appearance": {
+				"fog_identifier": "bt:fog_default"
+			},
+			"minecraft:water_appearance": {
+				"surface_color": "#0056FF"
+			}
+		}
+	}
+}

--- a/resource_packs/extras/terrain/old_clearer_water/biomes/snowy_slopes.client_biome.json
+++ b/resource_packs/extras/terrain/old_clearer_water/biomes/snowy_slopes.client_biome.json
@@ -1,0 +1,16 @@
+{
+	"format_version": "1.21.40",
+	"minecraft:client_biome": {
+		"description": {
+			"identifier": "snowy_slopes"
+		},
+		"components": {
+			"minecraft:fog_appearance": {
+				"fog_identifier": "bt:fog_default"
+			},
+			"minecraft:water_appearance": {
+				"surface_color": "#0056FF"
+			}
+		}
+	}
+}

--- a/resource_packs/extras/terrain/old_clearer_water/biomes/stony_peaks.client_biome.json
+++ b/resource_packs/extras/terrain/old_clearer_water/biomes/stony_peaks.client_biome.json
@@ -1,0 +1,16 @@
+{
+	"format_version": "1.21.40",
+	"minecraft:client_biome": {
+		"description": {
+			"identifier": "stony_peaks"
+		},
+		"components": {
+			"minecraft:fog_appearance": {
+				"fog_identifier": "bt:fog_default"
+			},
+			"minecraft:water_appearance": {
+				"surface_color": "#0056FF"
+			}
+		}
+	}
+}

--- a/resource_packs/extras/terrain/old_clearer_water/biomes/swampland.client_biome.json
+++ b/resource_packs/extras/terrain/old_clearer_water/biomes/swampland.client_biome.json
@@ -5,11 +5,22 @@
 			"identifier": "swampland"
 		},
 		"components": {
+			"minecraft:foliage_appearance": {
+				"color": {
+					"color_map": "swamp_foliage"
+				}
+			},
+			"minecraft:grass_appearance": {
+				"color": {
+					"color_map": "swamp_grass"
+				}
+			},
 			"minecraft:fog_appearance": {
 				"fog_identifier": "bt:fog_swampland"
 			},
 			"minecraft:water_appearance": {
-				"surface_color": "#0056FF"
+				"surface_color": "#0056FF",
+				"surface_opacity": 1.0
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/old_clearer_water/biomes/swampland_mutated.client_biome.json
+++ b/resource_packs/extras/terrain/old_clearer_water/biomes/swampland_mutated.client_biome.json
@@ -5,11 +5,22 @@
 			"identifier": "swampland_mutated"
 		},
 		"components": {
+			"minecraft:foliage_appearance": {
+				"color": {
+					"color_map": "swamp_foliage"
+				}
+			},
+			"minecraft:grass_appearance": {
+				"color": {
+					"color_map": "swamp_grass"
+				}
+			},
 			"minecraft:fog_appearance": {
 				"fog_identifier": "bt:fog_swampland_mutated"
 			},
 			"minecraft:water_appearance": {
-				"surface_color": "#0056FF"
+				"surface_color": "#0056FF",
+				"surface_opacity": 1.0
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/old_clearer_water/biomes/warm_ocean.client_biome.json
+++ b/resource_packs/extras/terrain/old_clearer_water/biomes/warm_ocean.client_biome.json
@@ -9,7 +9,8 @@
 				"fog_identifier": "bt:fog_warm_ocean"
 			},
 			"minecraft:water_appearance": {
-				"surface_color": "#0056FF"
+				"surface_color": "#0056FF",
+				"surface_opacity": 0.55
 			}
 		}
 	}

--- a/resource_packs/files/retro/old_water/biomes/cherry_grove.client_biome.json
+++ b/resource_packs/files/retro/old_water/biomes/cherry_grove.client_biome.json
@@ -5,6 +5,12 @@
 			"identifier": "cherry_grove"
 		},
 		"components": {
+			"minecraft:foliage_appearance": {
+				"color": "#b6db61"
+			},
+			"minecraft:grass_appearance": {
+				"color": "#b6db61"
+			},
 			"minecraft:fog_appearance": {
 				"fog_identifier": "minecraft:fog_cherry_grove"
 			},

--- a/resource_packs/files/retro/old_water/biomes/mangrove_swamp.client_biome.json
+++ b/resource_packs/files/retro/old_water/biomes/mangrove_swamp.client_biome.json
@@ -5,6 +5,16 @@
 			"identifier": "mangrove_swamp"
 		},
 		"components": {
+			"minecraft:foliage_appearance": {
+				"color": {
+					"color_map": "mangrove_swamp_foliage"
+				}
+			},
+			"minecraft:grass_appearance": {
+				"color": {
+					"color_map": "swamp_grass"
+				}
+			},
 			"minecraft:fog_appearance": {
 				"fog_identifier": "minecraft:fog_mangrove_swamp"
 			},

--- a/resource_packs/files/retro/old_water/biomes/mesa.client_biome.json
+++ b/resource_packs/files/retro/old_water/biomes/mesa.client_biome.json
@@ -5,6 +5,12 @@
 			"identifier": "mesa"
 		},
 		"components": {
+			"minecraft:foliage_appearance": {
+				"color": "#aea42a"
+			},
+			"minecraft:grass_appearance": {
+				"color": "#90814d"
+			},
 			"minecraft:fog_appearance": {
 				"fog_identifier": "minecraft:fog_mesa"
 			},

--- a/resource_packs/files/retro/old_water/biomes/mesa_bryce.client_biome.json
+++ b/resource_packs/files/retro/old_water/biomes/mesa_bryce.client_biome.json
@@ -5,6 +5,12 @@
 			"identifier": "mesa_bryce"
 		},
 		"components": {
+			"minecraft:foliage_appearance": {
+				"color": "#aea42a"
+			},
+			"minecraft:grass_appearance": {
+				"color": "#90814d"
+			},
 			"minecraft:fog_appearance": {
 				"fog_identifier": "minecraft:fog_mesa_bryce"
 			},

--- a/resource_packs/files/retro/old_water/biomes/mesa_plateau_mutated.client_biome.json
+++ b/resource_packs/files/retro/old_water/biomes/mesa_plateau_mutated.client_biome.json
@@ -5,6 +5,12 @@
 			"identifier": "mesa_plateau_mutated"
 		},
 		"components": {
+			"minecraft:foliage_appearance": {
+				"color": "#aea42a"
+			},
+			"minecraft:grass_appearance": {
+				"color": "#90814d"
+			},
 			"minecraft:fog_appearance": {
 				"fog_identifier": "minecraft:fog_default"
 			},

--- a/resource_packs/files/retro/old_water/biomes/mesa_plateau_stone.client_biome.json
+++ b/resource_packs/files/retro/old_water/biomes/mesa_plateau_stone.client_biome.json
@@ -5,6 +5,12 @@
 			"identifier": "mesa_plateau_stone"
 		},
 		"components": {
+			"minecraft:foliage_appearance": {
+				"color": "#aea42a"
+			},
+			"minecraft:grass_appearance": {
+				"color": "#90814d"
+			},
 			"minecraft:fog_appearance": {
 				"fog_identifier": "minecraft:fog_mesa_plateau_stone"
 			},

--- a/resource_packs/files/retro/old_water/biomes/mesa_plateau_stone_mutated.client_biome.json
+++ b/resource_packs/files/retro/old_water/biomes/mesa_plateau_stone_mutated.client_biome.json
@@ -5,6 +5,12 @@
 			"identifier": "mesa_plateau_stone_mutated"
 		},
 		"components": {
+			"minecraft:foliage_appearance": {
+				"color": "#aea42a"
+			},
+			"minecraft:grass_appearance": {
+				"color": "#90814d"
+			},
 			"minecraft:fog_appearance": {
 				"fog_identifier": "minecraft:fog_default"
 			},

--- a/resource_packs/files/retro/old_water/biomes/pale_garden.client_biome.json
+++ b/resource_packs/files/retro/old_water/biomes/pale_garden.client_biome.json
@@ -16,6 +16,12 @@
 			},
 			"minecraft:biome_music": {
 				"volume_multiplier": 0
+			},
+			"minecraft:foliage_appearance": {
+				"color": "#878d76"
+			},
+			"minecraft:grass_appearance": {
+				"color": "#778272"
 			}
 		}
 	}

--- a/resource_packs/files/retro/old_water/biomes/swampland.client_biome.json
+++ b/resource_packs/files/retro/old_water/biomes/swampland.client_biome.json
@@ -5,11 +5,22 @@
 			"identifier": "swampland"
 		},
 		"components": {
+			"minecraft:foliage_appearance": {
+				"color": {
+					"color_map": "swamp_foliage"
+				}
+			},
+			"minecraft:grass_appearance": {
+				"color": {
+					"color_map": "swamp_grass"
+				}
+			},
 			"minecraft:fog_appearance": {
 				"fog_identifier": "minecraft:fog_swampland"
 			},
 			"minecraft:water_appearance": {
-				"surface_color": "#0056FF"
+				"surface_color": "#0056FF",
+				"surface_opacity": 1.0
 			}
 		}
 	}

--- a/resource_packs/files/retro/old_water/biomes/swampland_mutated.client_biome.json
+++ b/resource_packs/files/retro/old_water/biomes/swampland_mutated.client_biome.json
@@ -5,11 +5,22 @@
 			"identifier": "swampland_mutated"
 		},
 		"components": {
+			"minecraft:foliage_appearance": {
+				"color": {
+					"color_map": "swamp_foliage"
+				}
+			},
+			"minecraft:grass_appearance": {
+				"color": {
+					"color_map": "swamp_grass"
+				}
+			},
 			"minecraft:fog_appearance": {
 				"fog_identifier": "minecraft:fog_swampland_mutated"
 			},
 			"minecraft:water_appearance": {
-				"surface_color": "#0056FF"
+				"surface_color": "#0056FF",
+				"surface_opacity": 1.0
 			}
 		}
 	}

--- a/resource_packs/files/retro/old_water/biomes/warm_ocean.client_biome.json
+++ b/resource_packs/files/retro/old_water/biomes/warm_ocean.client_biome.json
@@ -9,7 +9,8 @@
 				"fog_identifier": "minecraft:fog_warm_ocean"
 			},
 			"minecraft:water_appearance": {
-				"surface_color": "#0056FF"
+				"surface_color": "#0056FF",
+				"surface_opacity": 0.55
 			}
 		}
 	}

--- a/resource_packs/files/terrain/clearer_water/biomes/birch_forest_hills_mutated.client_biome.json
+++ b/resource_packs/files/terrain/clearer_water/biomes/birch_forest_hills_mutated.client_biome.json
@@ -1,0 +1,16 @@
+{
+	"format_version": "1.21.40",
+	"minecraft:client_biome": {
+		"description": {
+			"identifier": "birch_forest_hills_mutated"
+		},
+		"components": {
+			"minecraft:fog_appearance": {
+				"fog_identifier": "bt:fog_default"
+			},
+			"minecraft:water_appearance": {
+				"surface_color": "#44AFF5"
+			}
+		}
+	}
+}

--- a/resource_packs/files/terrain/clearer_water/biomes/birch_forest_mutated.client_biome.json
+++ b/resource_packs/files/terrain/clearer_water/biomes/birch_forest_mutated.client_biome.json
@@ -1,0 +1,16 @@
+{
+	"format_version": "1.21.40",
+	"minecraft:client_biome": {
+		"description": {
+			"identifier": "birch_forest_mutated"
+		},
+		"components": {
+			"minecraft:fog_appearance": {
+				"fog_identifier": "bt:fog_default"
+			},
+			"minecraft:water_appearance": {
+				"surface_color": "#44AFF5"
+			}
+		}
+	}
+}

--- a/resource_packs/files/terrain/clearer_water/biomes/cherry_grove.client_biome.json
+++ b/resource_packs/files/terrain/clearer_water/biomes/cherry_grove.client_biome.json
@@ -5,6 +5,12 @@
 			"identifier": "cherry_grove"
 		},
 		"components": {
+			"minecraft:foliage_appearance": {
+				"color": "#b6db61"
+			},
+			"minecraft:grass_appearance": {
+				"color": "#b6db61"
+			},
 			"minecraft:fog_appearance": {
 				"fog_identifier": "bt:fog_cherry_grove"
 			},

--- a/resource_packs/files/terrain/clearer_water/biomes/deep_dark.client_biome.json
+++ b/resource_packs/files/terrain/clearer_water/biomes/deep_dark.client_biome.json
@@ -1,0 +1,16 @@
+{
+	"format_version": "1.21.40",
+	"minecraft:client_biome": {
+		"description": {
+			"identifier": "deep_dark"
+		},
+		"components": {
+			"minecraft:fog_appearance": {
+				"fog_identifier": "bt:fog_default"
+			},
+			"minecraft:water_appearance": {
+				"surface_color": "#44AFF5"
+			}
+		}
+	}
+}

--- a/resource_packs/files/terrain/clearer_water/biomes/desert_mutated.client_biome.json
+++ b/resource_packs/files/terrain/clearer_water/biomes/desert_mutated.client_biome.json
@@ -1,0 +1,16 @@
+{
+	"format_version": "1.21.40",
+	"minecraft:client_biome": {
+		"description": {
+			"identifier": "desert_mutated"
+		},
+		"components": {
+			"minecraft:fog_appearance": {
+				"fog_identifier": "bt:fog_default"
+			},
+			"minecraft:water_appearance": {
+				"surface_color": "#44AFF5"
+			}
+		}
+	}
+}

--- a/resource_packs/files/terrain/clearer_water/biomes/dripstone_caves.client_biome.json
+++ b/resource_packs/files/terrain/clearer_water/biomes/dripstone_caves.client_biome.json
@@ -1,0 +1,16 @@
+{
+	"format_version": "1.21.40",
+	"minecraft:client_biome": {
+		"description": {
+			"identifier": "dripstone_caves"
+		},
+		"components": {
+			"minecraft:fog_appearance": {
+				"fog_identifier": "bt:fog_default"
+			},
+			"minecraft:water_appearance": {
+				"surface_color": "#44AFF5"
+			}
+		}
+	}
+}

--- a/resource_packs/files/terrain/clearer_water/biomes/frozen_peaks.client_biome.json
+++ b/resource_packs/files/terrain/clearer_water/biomes/frozen_peaks.client_biome.json
@@ -1,0 +1,16 @@
+{
+	"format_version": "1.21.40",
+	"minecraft:client_biome": {
+		"description": {
+			"identifier": "frozen_peaks"
+		},
+		"components": {
+			"minecraft:fog_appearance": {
+				"fog_identifier": "bt:fog_default"
+			},
+			"minecraft:water_appearance": {
+				"surface_color": "#44AFF5"
+			}
+		}
+	}
+}

--- a/resource_packs/files/terrain/clearer_water/biomes/grove.client_biome.json
+++ b/resource_packs/files/terrain/clearer_water/biomes/grove.client_biome.json
@@ -1,0 +1,16 @@
+{
+	"format_version": "1.21.40",
+	"minecraft:client_biome": {
+		"description": {
+			"identifier": "grove"
+		},
+		"components": {
+			"minecraft:fog_appearance": {
+				"fog_identifier": "bt:fog_default"
+			},
+			"minecraft:water_appearance": {
+				"surface_color": "#44AFF5"
+			}
+		}
+	}
+}

--- a/resource_packs/files/terrain/clearer_water/biomes/jagged_peaks.client_biome.json
+++ b/resource_packs/files/terrain/clearer_water/biomes/jagged_peaks.client_biome.json
@@ -1,0 +1,16 @@
+{
+	"format_version": "1.21.40",
+	"minecraft:client_biome": {
+		"description": {
+			"identifier": "jagged_peaks"
+		},
+		"components": {
+			"minecraft:fog_appearance": {
+				"fog_identifier": "bt:fog_default"
+			},
+			"minecraft:water_appearance": {
+				"surface_color": "#44AFF5"
+			}
+		}
+	}
+}

--- a/resource_packs/files/terrain/clearer_water/biomes/jungle_edge_mutated.client_biome.json
+++ b/resource_packs/files/terrain/clearer_water/biomes/jungle_edge_mutated.client_biome.json
@@ -1,0 +1,16 @@
+{
+	"format_version": "1.21.40",
+	"minecraft:client_biome": {
+		"description": {
+			"identifier": "jungle_edge_mutated"
+		},
+		"components": {
+			"minecraft:fog_appearance": {
+				"fog_identifier": "bt:fog_default"
+			},
+			"minecraft:water_appearance": {
+				"surface_color": "#44AFF5"
+			}
+		}
+	}
+}

--- a/resource_packs/files/terrain/clearer_water/biomes/legacy_frozen_ocean.client_biome.json
+++ b/resource_packs/files/terrain/clearer_water/biomes/legacy_frozen_ocean.client_biome.json
@@ -1,0 +1,16 @@
+{
+	"format_version": "1.21.40",
+	"minecraft:client_biome": {
+		"description": {
+			"identifier": "legacy_frozen_ocean"
+		},
+		"components": {
+			"minecraft:fog_appearance": {
+				"fog_identifier": "bt:fog_default"
+			},
+			"minecraft:water_appearance": {
+				"surface_color": "#44AFF5"
+			}
+		}
+	}
+}

--- a/resource_packs/files/terrain/clearer_water/biomes/lush_caves.client_biome.json
+++ b/resource_packs/files/terrain/clearer_water/biomes/lush_caves.client_biome.json
@@ -1,0 +1,16 @@
+{
+	"format_version": "1.21.40",
+	"minecraft:client_biome": {
+		"description": {
+			"identifier": "lush_caves"
+		},
+		"components": {
+			"minecraft:fog_appearance": {
+				"fog_identifier": "bt:fog_default"
+			},
+			"minecraft:water_appearance": {
+				"surface_color": "#44AFF5"
+			}
+		}
+	}
+}

--- a/resource_packs/files/terrain/clearer_water/biomes/mangrove_swamp.client_biome.json
+++ b/resource_packs/files/terrain/clearer_water/biomes/mangrove_swamp.client_biome.json
@@ -5,6 +5,16 @@
 			"identifier": "mangrove_swamp"
 		},
 		"components": {
+			"minecraft:foliage_appearance": {
+				"color": {
+					"color_map": "mangrove_swamp_foliage"
+				}
+			},
+			"minecraft:grass_appearance": {
+				"color": {
+					"color_map": "swamp_grass"
+				}
+			},
 			"minecraft:fog_appearance": {
 				"fog_identifier": "bt:fog_mangrove_swamp"
 			},

--- a/resource_packs/files/terrain/clearer_water/biomes/meadow.client_biome.json
+++ b/resource_packs/files/terrain/clearer_water/biomes/meadow.client_biome.json
@@ -1,0 +1,16 @@
+{
+	"format_version": "1.21.40",
+	"minecraft:client_biome": {
+		"description": {
+			"identifier": "meadow"
+		},
+		"components": {
+			"minecraft:fog_appearance": {
+				"fog_identifier": "bt:fog_default"
+			},
+			"minecraft:water_appearance": {
+				"surface_color": "#44AFF5"
+			}
+		}
+	}
+}

--- a/resource_packs/files/terrain/clearer_water/biomes/mesa.client_biome.json
+++ b/resource_packs/files/terrain/clearer_water/biomes/mesa.client_biome.json
@@ -5,6 +5,12 @@
 			"identifier": "mesa"
 		},
 		"components": {
+			"minecraft:foliage_appearance": {
+				"color": "#aea42a"
+			},
+			"minecraft:grass_appearance": {
+				"color": "#90814d"
+			},
 			"minecraft:fog_appearance": {
 				"fog_identifier": "bt:fog_mesa"
 			},

--- a/resource_packs/files/terrain/clearer_water/biomes/mesa_bryce.client_biome.json
+++ b/resource_packs/files/terrain/clearer_water/biomes/mesa_bryce.client_biome.json
@@ -5,6 +5,12 @@
 			"identifier": "mesa_bryce"
 		},
 		"components": {
+			"minecraft:foliage_appearance": {
+				"color": "#aea42a"
+			},
+			"minecraft:grass_appearance": {
+				"color": "#90814d"
+			},
 			"minecraft:fog_appearance": {
 				"fog_identifier": "bt:fog_mesa_bryce"
 			},

--- a/resource_packs/files/terrain/clearer_water/biomes/mesa_plateau_mutated.client_biome.json
+++ b/resource_packs/files/terrain/clearer_water/biomes/mesa_plateau_mutated.client_biome.json
@@ -1,0 +1,22 @@
+{
+	"format_version": "1.21.40",
+	"minecraft:client_biome": {
+		"description": {
+			"identifier": "mesa_plateau_mutated"
+		},
+		"components": {
+			"minecraft:foliage_appearance": {
+				"color": "#aea42a"
+			},
+			"minecraft:grass_appearance": {
+				"color": "#90814d"
+			},
+			"minecraft:fog_appearance": {
+				"fog_identifier": "bt:fog_default"
+			},
+			"minecraft:water_appearance": {
+				"surface_color": "#44AFF5"
+			}
+		}
+	}
+}

--- a/resource_packs/files/terrain/clearer_water/biomes/mesa_plateau_stone.client_biome.json
+++ b/resource_packs/files/terrain/clearer_water/biomes/mesa_plateau_stone.client_biome.json
@@ -5,6 +5,12 @@
 			"identifier": "mesa_plateau_stone"
 		},
 		"components": {
+			"minecraft:foliage_appearance": {
+				"color": "#aea42a"
+			},
+			"minecraft:grass_appearance": {
+				"color": "#90814d"
+			},
 			"minecraft:fog_appearance": {
 				"fog_identifier": "bt:fog_mesa_plateau_stone"
 			},

--- a/resource_packs/files/terrain/clearer_water/biomes/mesa_plateau_stone_mutated.client_biome.json
+++ b/resource_packs/files/terrain/clearer_water/biomes/mesa_plateau_stone_mutated.client_biome.json
@@ -1,0 +1,22 @@
+{
+	"format_version": "1.21.40",
+	"minecraft:client_biome": {
+		"description": {
+			"identifier": "mesa_plateau_stone_mutated"
+		},
+		"components": {
+			"minecraft:foliage_appearance": {
+				"color": "#aea42a"
+			},
+			"minecraft:grass_appearance": {
+				"color": "#90814d"
+			},
+			"minecraft:fog_appearance": {
+				"fog_identifier": "bt:fog_default"
+			},
+			"minecraft:water_appearance": {
+				"surface_color": "#44AFF5"
+			}
+		}
+	}
+}

--- a/resource_packs/files/terrain/clearer_water/biomes/pale_garden.client_biome.json
+++ b/resource_packs/files/terrain/clearer_water/biomes/pale_garden.client_biome.json
@@ -16,6 +16,12 @@
 			},
 			"minecraft:biome_music": {
 				"volume_multiplier": 0
+			},
+			"minecraft:foliage_appearance": {
+				"color": "#878d76"
+			},
+			"minecraft:grass_appearance": {
+				"color": "#778272"
 			}
 		}
 	}

--- a/resource_packs/files/terrain/clearer_water/biomes/redwood_taiga_hills_mutated.client_biome.json
+++ b/resource_packs/files/terrain/clearer_water/biomes/redwood_taiga_hills_mutated.client_biome.json
@@ -1,0 +1,16 @@
+{
+	"format_version": "1.21.40",
+	"minecraft:client_biome": {
+		"description": {
+			"identifier": "redwood_taiga_hills_mutated"
+		},
+		"components": {
+			"minecraft:fog_appearance": {
+				"fog_identifier": "bt:fog_default"
+			},
+			"minecraft:water_appearance": {
+				"surface_color": "#44AFF5"
+			}
+		}
+	}
+}

--- a/resource_packs/files/terrain/clearer_water/biomes/redwood_taiga_mutated.client_biome.json
+++ b/resource_packs/files/terrain/clearer_water/biomes/redwood_taiga_mutated.client_biome.json
@@ -1,0 +1,16 @@
+{
+	"format_version": "1.21.40",
+	"minecraft:client_biome": {
+		"description": {
+			"identifier": "redwood_taiga_mutated"
+		},
+		"components": {
+			"minecraft:fog_appearance": {
+				"fog_identifier": "bt:fog_default"
+			},
+			"minecraft:water_appearance": {
+				"surface_color": "#44AFF5"
+			}
+		}
+	}
+}

--- a/resource_packs/files/terrain/clearer_water/biomes/roofed_forest_mutated.client_biome.json
+++ b/resource_packs/files/terrain/clearer_water/biomes/roofed_forest_mutated.client_biome.json
@@ -1,0 +1,16 @@
+{
+	"format_version": "1.21.40",
+	"minecraft:client_biome": {
+		"description": {
+			"identifier": "roofed_forest_mutated"
+		},
+		"components": {
+			"minecraft:fog_appearance": {
+				"fog_identifier": "bt:fog_default"
+			},
+			"minecraft:water_appearance": {
+				"surface_color": "#44AFF5"
+			}
+		}
+	}
+}

--- a/resource_packs/files/terrain/clearer_water/biomes/savanna_plateau_mutated.client_biome.json
+++ b/resource_packs/files/terrain/clearer_water/biomes/savanna_plateau_mutated.client_biome.json
@@ -1,0 +1,16 @@
+{
+	"format_version": "1.21.40",
+	"minecraft:client_biome": {
+		"description": {
+			"identifier": "savanna_plateau_mutated"
+		},
+		"components": {
+			"minecraft:fog_appearance": {
+				"fog_identifier": "bt:fog_default"
+			},
+			"minecraft:water_appearance": {
+				"surface_color": "#44AFF5"
+			}
+		}
+	}
+}

--- a/resource_packs/files/terrain/clearer_water/biomes/snowy_slopes.client_biome.json
+++ b/resource_packs/files/terrain/clearer_water/biomes/snowy_slopes.client_biome.json
@@ -1,0 +1,16 @@
+{
+	"format_version": "1.21.40",
+	"minecraft:client_biome": {
+		"description": {
+			"identifier": "snowy_slopes"
+		},
+		"components": {
+			"minecraft:fog_appearance": {
+				"fog_identifier": "bt:fog_default"
+			},
+			"minecraft:water_appearance": {
+				"surface_color": "#44AFF5"
+			}
+		}
+	}
+}

--- a/resource_packs/files/terrain/clearer_water/biomes/stony_peaks.client_biome.json
+++ b/resource_packs/files/terrain/clearer_water/biomes/stony_peaks.client_biome.json
@@ -1,0 +1,16 @@
+{
+	"format_version": "1.21.40",
+	"minecraft:client_biome": {
+		"description": {
+			"identifier": "stony_peaks"
+		},
+		"components": {
+			"minecraft:fog_appearance": {
+				"fog_identifier": "bt:fog_default"
+			},
+			"minecraft:water_appearance": {
+				"surface_color": "#44AFF5"
+			}
+		}
+	}
+}

--- a/resource_packs/files/terrain/clearer_water/biomes/swampland.client_biome.json
+++ b/resource_packs/files/terrain/clearer_water/biomes/swampland.client_biome.json
@@ -5,11 +5,22 @@
 			"identifier": "swampland"
 		},
 		"components": {
+			"minecraft:foliage_appearance": {
+				"color": {
+					"color_map": "swamp_foliage"
+				}
+			},
+			"minecraft:grass_appearance": {
+				"color": {
+					"color_map": "swamp_grass"
+				}
+			},
 			"minecraft:fog_appearance": {
 				"fog_identifier": "bt:fog_swampland"
 			},
 			"minecraft:water_appearance": {
-				"surface_color": "#4c6559"
+				"surface_color": "#4c6559",
+				"surface_opacity": 1.0
 			}
 		}
 	}

--- a/resource_packs/files/terrain/clearer_water/biomes/swampland_mutated.client_biome.json
+++ b/resource_packs/files/terrain/clearer_water/biomes/swampland_mutated.client_biome.json
@@ -5,11 +5,22 @@
 			"identifier": "swampland_mutated"
 		},
 		"components": {
+			"minecraft:foliage_appearance": {
+				"color": {
+					"color_map": "swamp_foliage"
+				}
+			},
+			"minecraft:grass_appearance": {
+				"color": {
+					"color_map": "swamp_grass"
+				}
+			},
 			"minecraft:fog_appearance": {
 				"fog_identifier": "bt:fog_swampland_mutated"
 			},
 			"minecraft:water_appearance": {
-				"surface_color": "#4c6156"
+				"surface_color": "#4c6156",
+				"surface_opacity": 1.0
 			}
 		}
 	}

--- a/resource_packs/files/terrain/clearer_water/biomes/warm_ocean.client_biome.json
+++ b/resource_packs/files/terrain/clearer_water/biomes/warm_ocean.client_biome.json
@@ -9,7 +9,8 @@
 				"fog_identifier": "bt:fog_warm_ocean"
 			},
 			"minecraft:water_appearance": {
-				"surface_color": "#02B0E5"
+				"surface_color": "#02B0E5",
+				"surface_opacity": 0.55
 			}
 		}
 	}

--- a/resource_packs/files/terrain/clearer_water/fogs/default_fog_setting.json
+++ b/resource_packs/files/terrain/clearer_water/fogs/default_fog_setting.json
@@ -1,0 +1,40 @@
+{
+	"format_version": "1.16.100",
+	"minecraft:fog_settings": {
+		"description": {
+			"identifier": "bt:fog_default"
+		},
+		"distance": {
+			"air": {
+				"fog_start": 0.92,
+				"fog_end": 1.0,
+				"fog_color": "#ABD2FF",
+				"render_distance_type": "render"
+			},
+			"water": {
+				"fog_start": 32.0,
+				"fog_end": 64.0,
+				"fog_color": "#44AFF5",
+				"render_distance_type": "fixed"
+			},
+			"weather": {
+				"fog_start": 0.23,
+				"fog_end": 0.7,
+				"fog_color": "#666666",
+				"render_distance_type": "render"
+			},
+			"lava": {
+				"fog_start": 0.0,
+				"fog_end": 0.64,
+				"fog_color": "#991A00",
+				"render_distance_type": "fixed"
+			},
+			"lava_resistance": {
+				"fog_start": 2.0,
+				"fog_end": 4.0,
+				"fog_color": "#991A00",
+				"render_distance_type": "fixed"
+			}
+		}
+	}
+}


### PR DESCRIPTION
1. Added `minecraft:foliage_appearance` and `minecraft:grass_appearance` components from the vanilla files which fixes modern biomes having wrong foliage and grass color
2. Added `surface_opacity` field to `minecraft:water_appearance` component from the vanilla files which fixes there is no surface opacity of water from the outside
3. Added all the client biome files which uses `minecraft:fog_default` as they were skipped before and added `bt:fog_default` fog in Clearer Water and old_clearer_water combination

Resolves #492 

By checking the following boxes with an X, you ensure that:

- [X] The pack was tested ingame in at least one device.
- [X] The pack is an existing BT pack, is a missing pack from VT or is an accepted pack/change in a discussion.
- [X] The pack code follows the style guide.
- [X] The commits follow the contribution guidelines.
- [X] The PR follows the contribution guidelines.

- [X] (Optional) Tested in Windows
- [ ] (Optional) Tested in Android
- [ ] (Optional) Tested in iOS
- [ ] (Optional) Tested in any console
- [ ] (Optional) Tested in BDS
