### PR TITLE
update(files): Improve the position and animation of Totem of Undying in 3rd or 2nd person mode and fixed a bug where Totem of Undying is in inverse when in 3rd or 2nd person mode in Invisible Totem

### DIFF
--- a/resource_packs/files/unobtrusive/invisible_totem/animations/totem_of_undying.animation.json
+++ b/resource_packs/files/unobtrusive/invisible_totem/animations/totem_of_undying.animation.json
@@ -1,0 +1,23 @@
+{
+	"format_version": "1.10.0",
+	"animations": {
+		"animation.rp.bt.totem_hold_third_person": {
+			"loop": true,
+			"bones": {
+				"totem": {
+					"rotation": [
+						270,
+						"c.item_slot == 'main_hand' ? 15 : -15",
+						"c.item_slot == 'main_hand' ? 190 : 180"
+					],
+					"position": [
+						"c.item_slot == 'main_hand' ? 3.2 : -1.7",
+						"c.item_slot == 'main_hand' ? 22.1 : 22.3",
+						"c.item_slot == 'main_hand' ? -9.3 : -8.6"
+					],
+					"scale": 0.56
+				}
+			}
+		}
+	}
+}

--- a/resource_packs/files/unobtrusive/invisible_totem/attachables/totem_of_undying.attachable.json
+++ b/resource_packs/files/unobtrusive/invisible_totem/attachables/totem_of_undying.attachable.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.16.0",
+	"format_version": "1.21.0",
 	"minecraft:attachable": {
 		"description": {
 			"identifier": "minecraft:totem_of_undying",
@@ -12,25 +12,26 @@
 				"enchanted": "textures/misc/enchanted_item_glint"
 			},
 			"geometry": {
-				"default": "geometry.totem"
+				"default": "geometry.bt_totem_of_undying"
+			},
+			"animations": {
+				"totem_hold_third_person": "animation.rp.bt.totem_hold_third_person"
+			},
+			"scripts": {
+				"animate": [
+					{
+						"totem_hold_third_person": "!c.is_first_person"
+					}
+				]
 			},
 			"render_controllers": [
 				{
-					"controller.render.bt.totem.first_person": "c.is_first_person"
+					"controller.render.bt.totem_first_person": "c.is_first_person"
 				},
 				{
-					"controller.render.bt.totem.any_person": "!c.is_first_person"
+					"controller.render.bt.totem_third_person": "!c.is_first_person"
 				}
 			]
-			// "scripts": {
-			//   "pre_animation": [
-			//     "v.main_hand = c.item_slot == 'main_hand';",
-			//     "v.off_hand = c.item_slot == 'off_hand';",
-			//     "v.head = c.item_slot == 'head';"
-			//     //in theory, you could obviously apply this to any slot
-			//     //I've chosen these because they are what java displays 3D items in
-			//   ]
-			// }
 		}
 	}
 }

--- a/resource_packs/files/unobtrusive/invisible_totem/models/entity/totem_of_undying.geo.json
+++ b/resource_packs/files/unobtrusive/invisible_totem/models/entity/totem_of_undying.geo.json
@@ -1,75 +1,41 @@
 {
-	"format_version": "1.12.0",
+	"format_version": "1.21.0",
 	"minecraft:geometry": [
 		{
 			"description": {
-				"identifier": "geometry.totem",
-				"texture_width": 64,
-				"texture_height": 64,
-				"visible_bounds_width": 3,
-				"visible_bounds_height": 3.5,
+				"identifier": "geometry.bt_totem_of_undying",
+				"texture_width": 16,
+				"texture_height": 16,
+				"visible_bounds_width": 2,
+				"visible_bounds_height": 1.5,
 				"visible_bounds_offset": [
 					0,
-					1.25,
+					0.25,
 					0
 				]
 			},
 			"bones": [
 				{
-					"name": "rightitem",
+					"name": "totem",
+					"pivot": [
+						0,
+						0,
+						0
+					],
 					"binding": "q.item_slot_to_bone_name(c.item_slot)",
 					"texture_meshes": [
 						{
-							"local_pivot": [
-								3.8,
-								-1.0,
-								10.9
-							],
+							"texture": "default",
 							"position": [
-								0.0,
-								0.0,
-								0.0
+								-8,
+								1,
+								0
 							],
 							"rotation": [
-								-10.0,
-								-15.0,
-								10.0
-							],
-							"scale": [
-								0.15,
-								0.15,
-								0.15
-							],
-							"texture": "default"
-						}
-					]
-				},
-				{
-					"name": "leftitem",
-					"binding": "q.item_slot_to_bone_name(c.item_slot)",
-					"texture_meshes": [
-						{
-							"local_pivot": [
-								4.0,
-								-1.5,
-								9.5
-							],
-							"position": [
-								0.0,
-								0.0,
-								0.0
-							],
-							"rotation": [
-								-10.0,
-								17,
-								0.0
-							],
-							"scale": [
-								0.15,
-								0.15,
-								0.15
-							],
-							"texture": "default"
+								90,
+								0,
+								0
+							]
 						}
 					]
 				}

--- a/resource_packs/files/unobtrusive/invisible_totem/render_controllers/totem_of_undying.rc.json
+++ b/resource_packs/files/unobtrusive/invisible_totem/render_controllers/totem_of_undying.rc.json
@@ -1,43 +1,32 @@
 {
 	"format_version": "1.10.0",
 	"render_controllers": {
-		"controller.render.bt.totem.any_person": {
-			"geometry": "geometry.default",
+		"controller.render.bt.totem_third_person": {
+			"geometry": "Geometry.default",
 			"materials": [
 				{
-					"*": "variable.is_enchanted ? material.enchanted : material.default"
+					"*": "variable.is_enchanted ? Material.enchanted : Material.default"
 				}
 			],
 			"textures": [
-				"texture.default",
-				"texture.enchanted"
-			],
-			"part_visibility": [
-				{
-					"rightitem": "q.get_equipped_item_name('main_hand') == 'totem_of_undying'"
-				},
-				{
-					"leftitem": "q.get_equipped_item_name('off_hand') == 'totem_of_undying'"
-				}
+				"Texture.default",
+				"Texture.enchanted"
 			]
 		},
-		"controller.render.bt.totem.first_person": {
-			"geometry": "geometry.default",
+		"controller.render.bt.totem_first_person": {
+			"geometry": "Geometry.default",
 			"materials": [
 				{
-					"*": "variable.is_enchanted ? material.enchanted : material.default"
+					"*": "variable.is_enchanted ? Material.enchanted : Material.default"
 				}
 			],
 			"textures": [
-				"texture.default",
-				"texture.enchanted"
+				"Texture.default",
+				"Texture.enchanted"
 			],
 			"part_visibility": [
 				{
-					"rightitem": false
-				},
-				{
-					"leftitem": false
+					"totem": false
 				}
 			]
 		}


### PR DESCRIPTION
1. Rewrote the entire pack to use animations instead of positioning the Totem of Undying using geometry files
2. Fixed some naming inconsistencies which didn't follow the style guide
3. Fixed a bug where the Totem of Undying is in inverse when in 3rd or 2nd person mode
4. Updated all the files to use the latest format version

![image](https://github.com/user-attachments/assets/58c93364-2243-458d-9d90-d9ddbd7d6a9e)
![image](https://github.com/user-attachments/assets/ac14bdba-0b13-44d1-b1a4-81837cd2a8e1)

Resolves #531 

By checking the following boxes with an X, you ensure that:

- [X] The pack was tested ingame in at least one device.
- [X] The pack is an existing BT pack, is a missing pack from VT or is an accepted pack/change in a discussion.
- [X] The pack code follows the style guide.
- [X] The commits follow the contribution guidelines.
- [X] The PR follows the contribution guidelines.

- [X] (Optional) Tested in Windows
- [ ] (Optional) Tested in Android
- [ ] (Optional) Tested in iOS
- [ ] (Optional) Tested in any console
- [ ] (Optional) Tested in BDS
