### PR TITLE
update(files): Adjusted the volume of Quieter Blazes to be 95% quieter from vanilla blaze sounds as blaze sounds volume was updated in 1.21.90

### DIFF
--- a/resource_packs/files/peace_and_quiet/mobs/quieter_blazes/sounds.json
+++ b/resource_packs/files/peace_and_quiet/mobs/quieter_blazes/sounds.json
@@ -2,7 +2,7 @@
 	"entity_sounds": {
 		"entities": {
 			"blaze": {
-				"volume": 0.05
+				"volume": 0.1
 			}
 		}
 	}


### PR DESCRIPTION
1. In 1.21.90, vanilla blaze sounds volume was increased from 1 to 2 so I adjusted the volume in Quieter Blazes to account for that

By checking the following boxes with an X, you ensure that:

- [X] The pack was tested ingame in at least one device.
- [X] The pack is an existing BT pack, is a missing pack from VT or is an accepted pack/change in a discussion.
- [X] The pack code follows the style guide.
- [X] The commits follow the contribution guidelines.
- [X] The PR follows the contribution guidelines.

- [X] (Optional) Tested in Windows
- [ ] (Optional) Tested in Android
- [ ] (Optional) Tested in iOS
- [ ] (Optional) Tested in any console
- [ ] (Optional) Tested in BDS
