### PR TITLE
update(files): Update Clearer Water, Old Water and Lush Grass All 'Round! to support 1.21.90 and Vibrant Visuals

### DIFF
--- a/resource_packs/extras/terrain/lush_grass_clearer_water/biomes/cherry_grove.client_biome.json
+++ b/resource_packs/extras/terrain/lush_grass_clearer_water/biomes/cherry_grove.client_biome.json
@@ -1,21 +1,33 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "cherry_grove"
 		},
 		"components": {
+			"minecraft:fog_appearance": {
+				"fog_identifier": "bt:fog_cherry_grove"
+			},
+			"minecraft:water_appearance": {
+				"surface_color": "#5db7ef"
+			},
 			"minecraft:foliage_appearance": {
 				"color": "#2abb0e"
 			},
 			"minecraft:grass_appearance": {
 				"color": "#2abb0e"
 			},
-			"minecraft:fog_appearance": {
-				"fog_identifier": "bt:fog_cherry_grove"
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:default_atmospherics"
 			},
-			"minecraft:water_appearance": {
-				"surface_color": "#5db7ef"
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:default_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:default_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/lush_grass_clearer_water/biomes/mesa.client_biome.json
+++ b/resource_packs/extras/terrain/lush_grass_clearer_water/biomes/mesa.client_biome.json
@@ -1,21 +1,33 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "mesa"
 		},
 		"components": {
+			"minecraft:fog_appearance": {
+				"fog_identifier": "bt:fog_mesa"
+			},
+			"minecraft:water_appearance": {
+				"surface_color": "#4E7F81"
+			},
 			"minecraft:foliage_appearance": {
 				"color": "#2abb0e"
 			},
 			"minecraft:grass_appearance": {
 				"color": "#2abb0e"
 			},
-			"minecraft:fog_appearance": {
-				"fog_identifier": "bt:fog_mesa"
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:mesa_atmospherics"
 			},
-			"minecraft:water_appearance": {
-				"surface_color": "#4E7F81"
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:mesa_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:mesa_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/lush_grass_clearer_water/biomes/mesa_bryce.client_biome.json
+++ b/resource_packs/extras/terrain/lush_grass_clearer_water/biomes/mesa_bryce.client_biome.json
@@ -1,21 +1,33 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "mesa_bryce"
 		},
 		"components": {
+			"minecraft:fog_appearance": {
+				"fog_identifier": "bt:fog_mesa_bryce"
+			},
+			"minecraft:water_appearance": {
+				"surface_color": "#497F99"
+			},
 			"minecraft:foliage_appearance": {
 				"color": "#2abb0e"
 			},
 			"minecraft:grass_appearance": {
 				"color": "#2abb0e"
 			},
-			"minecraft:fog_appearance": {
-				"fog_identifier": "bt:fog_mesa_bryce"
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:mesa_atmospherics"
 			},
-			"minecraft:water_appearance": {
-				"surface_color": "#497F99"
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:mesa_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:mesa_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/lush_grass_clearer_water/biomes/mesa_plateau_mutated.client_biome.json
+++ b/resource_packs/extras/terrain/lush_grass_clearer_water/biomes/mesa_plateau_mutated.client_biome.json
@@ -1,21 +1,33 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "mesa_plateau_mutated"
 		},
 		"components": {
+			"minecraft:fog_appearance": {
+				"fog_identifier": "bt:fog_dry"
+			},
+			"minecraft:water_appearance": {
+				"surface_color": "#44AFF5"
+			},
 			"minecraft:foliage_appearance": {
 				"color": "#2abb0e"
 			},
 			"minecraft:grass_appearance": {
 				"color": "#2abb0e"
 			},
-			"minecraft:fog_appearance": {
-				"fog_identifier": "bt:fog_default"
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:mesa_atmospherics"
 			},
-			"minecraft:water_appearance": {
-				"surface_color": "#44AFF5"
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:mesa_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:mesa_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/lush_grass_clearer_water/biomes/mesa_plateau_stone.client_biome.json
+++ b/resource_packs/extras/terrain/lush_grass_clearer_water/biomes/mesa_plateau_stone.client_biome.json
@@ -1,21 +1,33 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "mesa_plateau_stone"
 		},
 		"components": {
+			"minecraft:fog_appearance": {
+				"fog_identifier": "bt:fog_mesa_plateau_stone"
+			},
+			"minecraft:water_appearance": {
+				"surface_color": "#55809E"
+			},
 			"minecraft:foliage_appearance": {
 				"color": "#2abb0e"
 			},
 			"minecraft:grass_appearance": {
 				"color": "#2abb0e"
 			},
-			"minecraft:fog_appearance": {
-				"fog_identifier": "bt:fog_mesa_plateau_stone"
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:mesa_atmospherics"
 			},
-			"minecraft:water_appearance": {
-				"surface_color": "#55809E"
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:mesa_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:mesa_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/lush_grass_clearer_water/biomes/mesa_plateau_stone_mutated.client_biome.json
+++ b/resource_packs/extras/terrain/lush_grass_clearer_water/biomes/mesa_plateau_stone_mutated.client_biome.json
@@ -1,21 +1,33 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "mesa_plateau_stone_mutated"
 		},
 		"components": {
+			"minecraft:fog_appearance": {
+				"fog_identifier": "bt:fog_dry"
+			},
+			"minecraft:water_appearance": {
+				"surface_color": "#44AFF5"
+			},
 			"minecraft:foliage_appearance": {
 				"color": "#2abb0e"
 			},
 			"minecraft:grass_appearance": {
 				"color": "#2abb0e"
 			},
-			"minecraft:fog_appearance": {
-				"fog_identifier": "bt:fog_default"
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:mesa_atmospherics"
 			},
-			"minecraft:water_appearance": {
-				"surface_color": "#44AFF5"
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:mesa_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:mesa_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/lush_grass_clearer_water/biomes/pale_garden.client_biome.json
+++ b/resource_packs/extras/terrain/lush_grass_clearer_water/biomes/pale_garden.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "pale_garden"
@@ -22,6 +22,18 @@
 			},
 			"minecraft:grass_appearance": {
 				"color": "#2abb0e"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:pale_garden_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:coolish_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:pale_garden_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/bamboo_jungle.client_biome.json
+++ b/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/bamboo_jungle.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "bamboo_jungle"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:warmish_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:warmish_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:warmish_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/bamboo_jungle_hills.client_biome.json
+++ b/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/bamboo_jungle_hills.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "bamboo_jungle_hills"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:warmish_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:warmish_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:warmish_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/basalt_deltas.client_biome.json
+++ b/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/basalt_deltas.client_biome.json
@@ -1,20 +1,32 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "basalt_deltas"
 		},
 		"components": {
-			"minecraft:ambient_sounds": {
-				"mood": "ambient.basalt_deltas.mood",
-				"addition": "ambient.basalt_deltas.additions",
-				"loop": "ambient.basalt_deltas.loop"
-			},
 			"minecraft:fog_appearance": {
 				"fog_identifier": "bt:fog_basalt_deltas"
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:ambient_sounds": {
+				"addition": "ambient.basalt_deltas.additions",
+				"loop": "ambient.basalt_deltas.loop",
+				"mood": "ambient.basalt_deltas.mood"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:basalt_deltas_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:default_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:nether_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/beach.client_biome.json
+++ b/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/beach.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "beach"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:default_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:default_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:default_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/birch_forest.client_biome.json
+++ b/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/birch_forest.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "birch_forest"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:default_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:default_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:default_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/birch_forest_hills.client_biome.json
+++ b/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/birch_forest_hills.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "birch_forest_hills"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:default_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:default_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:default_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/birch_forest_hills_mutated.client_biome.json
+++ b/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/birch_forest_hills_mutated.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "birch_forest_hills_mutated"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:default_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:default_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:default_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/birch_forest_mutated.client_biome.json
+++ b/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/birch_forest_mutated.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "birch_forest_mutated"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:default_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:default_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:default_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/cherry_grove.client_biome.json
+++ b/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/cherry_grove.client_biome.json
@@ -1,21 +1,33 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "cherry_grove"
 		},
 		"components": {
+			"minecraft:fog_appearance": {
+				"fog_identifier": "bt:fog_cherry_grove"
+			},
+			"minecraft:water_appearance": {
+				"surface_color": "#0056FF"
+			},
 			"minecraft:foliage_appearance": {
 				"color": "#2abb0e"
 			},
 			"minecraft:grass_appearance": {
 				"color": "#2abb0e"
 			},
-			"minecraft:fog_appearance": {
-				"fog_identifier": "bt:fog_cherry_grove"
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:default_atmospherics"
 			},
-			"minecraft:water_appearance": {
-				"surface_color": "#0056FF"
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:default_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:default_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/cold_beach.client_biome.json
+++ b/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/cold_beach.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "cold_beach"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:default_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:cold_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:default_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/cold_ocean.client_biome.json
+++ b/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/cold_ocean.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "cold_ocean"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:default_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:coolish_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:default_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/cold_taiga.client_biome.json
+++ b/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/cold_taiga.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "cold_taiga"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:default_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:cold_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:default_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/cold_taiga_hills.client_biome.json
+++ b/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/cold_taiga_hills.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "cold_taiga_hills"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:default_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:cold_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:default_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/cold_taiga_mutated.client_biome.json
+++ b/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/cold_taiga_mutated.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "cold_taiga_mutated"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:default_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:cold_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:default_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/crimson_forest.client_biome.json
+++ b/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/crimson_forest.client_biome.json
@@ -1,20 +1,32 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "crimson_forest"
 		},
 		"components": {
-			"minecraft:ambient_sounds": {
-				"mood": "ambient.crimson_forest.mood",
-				"addition": "ambient.crimson_forest.additions",
-				"loop": "ambient.crimson_forest.loop"
-			},
 			"minecraft:fog_appearance": {
 				"fog_identifier": "bt:fog_crimson_forest"
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:ambient_sounds": {
+				"addition": "ambient.crimson_forest.additions",
+				"loop": "ambient.crimson_forest.loop",
+				"mood": "ambient.crimson_forest.mood"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:crimson_forest_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:default_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:nether_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/deep_cold_ocean.client_biome.json
+++ b/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/deep_cold_ocean.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "deep_cold_ocean"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:default_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:coolish_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:default_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/deep_dark.client_biome.json
+++ b/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/deep_dark.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "deep_dark"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:default_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:default_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:default_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/deep_frozen_ocean.client_biome.json
+++ b/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/deep_frozen_ocean.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "deep_frozen_ocean"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:default_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:cold_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:default_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/deep_lukewarm_ocean.client_biome.json
+++ b/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/deep_lukewarm_ocean.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "deep_lukewarm_ocean"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:warmish_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:warmish_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:warmish_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/deep_ocean.client_biome.json
+++ b/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/deep_ocean.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "deep_ocean"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:default_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:default_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:default_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/deep_warm_ocean.client_biome.json
+++ b/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/deep_warm_ocean.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "deep_warm_ocean"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:warmish_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:warmish_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:warmish_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/desert.client_biome.json
+++ b/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/desert.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "desert"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:desert_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:desert_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:desert_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/desert_hills.client_biome.json
+++ b/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/desert_hills.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "desert_hills"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:desert_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:desert_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:desert_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/desert_mutated.client_biome.json
+++ b/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/desert_mutated.client_biome.json
@@ -1,15 +1,27 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "desert_mutated"
 		},
 		"components": {
 			"minecraft:fog_appearance": {
-				"fog_identifier": "bt:fog_default"
+				"fog_identifier": "bt:fog_dry"
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:desert_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:desert_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:desert_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/dripstone_caves.client_biome.json
+++ b/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/dripstone_caves.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "dripstone_caves"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:default_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:default_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:default_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/extreme_hills.client_biome.json
+++ b/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/extreme_hills.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "extreme_hills"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:default_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:coolish_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:default_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/extreme_hills_edge.client_biome.json
+++ b/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/extreme_hills_edge.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "extreme_hills_edge"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:default_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:coolish_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:default_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/extreme_hills_mutated.client_biome.json
+++ b/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/extreme_hills_mutated.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "extreme_hills_mutated"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:default_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:coolish_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:default_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/extreme_hills_plus_trees.client_biome.json
+++ b/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/extreme_hills_plus_trees.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "extreme_hills_plus_trees"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:default_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:coolish_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:default_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/extreme_hills_plus_trees_mutated.client_biome.json
+++ b/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/extreme_hills_plus_trees_mutated.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "extreme_hills_plus_trees_mutated"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:default_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:coolish_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:default_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/flower_forest.client_biome.json
+++ b/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/flower_forest.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "flower_forest"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:default_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:default_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:default_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/forest.client_biome.json
+++ b/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/forest.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "forest"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:default_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:default_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:default_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/forest_hills.client_biome.json
+++ b/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/forest_hills.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "forest_hills"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:default_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:default_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:default_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/frozen_ocean.client_biome.json
+++ b/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/frozen_ocean.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "frozen_ocean"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:default_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:cold_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:default_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/frozen_peaks.client_biome.json
+++ b/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/frozen_peaks.client_biome.json
@@ -1,15 +1,27 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "frozen_peaks"
 		},
 		"components": {
 			"minecraft:fog_appearance": {
-				"fog_identifier": "bt:fog_default"
+				"fog_identifier": "bt:fog_dry"
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:default_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:cold_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:default_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/frozen_river.client_biome.json
+++ b/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/frozen_river.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "frozen_river"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:default_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:cold_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:default_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/grove.client_biome.json
+++ b/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/grove.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "grove"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:default_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:coolish_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:default_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/hell.client_biome.json
+++ b/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/hell.client_biome.json
@@ -1,20 +1,32 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "hell"
 		},
 		"components": {
-			"minecraft:ambient_sounds": {
-				"mood": "ambient.nether_wastes.mood",
-				"addition": "ambient.nether_wastes.additions",
-				"loop": "ambient.nether_wastes.loop"
-			},
 			"minecraft:fog_appearance": {
 				"fog_identifier": "bt:fog_hell"
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:ambient_sounds": {
+				"addition": "ambient.nether_wastes.additions",
+				"loop": "ambient.nether_wastes.loop",
+				"mood": "ambient.nether_wastes.mood"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:hell_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:default_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:nether_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/ice_mountains.client_biome.json
+++ b/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/ice_mountains.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "ice_mountains"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:default_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:cold_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:default_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/ice_plains.client_biome.json
+++ b/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/ice_plains.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "ice_plains"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:default_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:cold_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:default_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/ice_plains_spikes.client_biome.json
+++ b/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/ice_plains_spikes.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "ice_plains_spikes"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:ice_plains_spikes_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:ice_plains_spikes_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:ice_plains_spikes_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/jagged_peaks.client_biome.json
+++ b/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/jagged_peaks.client_biome.json
@@ -1,15 +1,27 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "jagged_peaks"
 		},
 		"components": {
 			"minecraft:fog_appearance": {
-				"fog_identifier": "bt:fog_default"
+				"fog_identifier": "bt:fog_dry"
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:default_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:coolish_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:default_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/jungle.client_biome.json
+++ b/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/jungle.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "jungle"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:warmish_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:warmish_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:warmish_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/jungle_edge.client_biome.json
+++ b/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/jungle_edge.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "jungle_edge"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:warmish_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:warmish_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:warmish_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/jungle_edge_mutated.client_biome.json
+++ b/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/jungle_edge_mutated.client_biome.json
@@ -1,15 +1,27 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "jungle_edge_mutated"
 		},
 		"components": {
 			"minecraft:fog_appearance": {
-				"fog_identifier": "bt:fog_default"
+				"fog_identifier": "bt:fog_humid"
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:warmish_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:warmish_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:warmish_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/jungle_hills.client_biome.json
+++ b/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/jungle_hills.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "jungle_hills"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:warmish_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:warmish_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:warmish_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/jungle_mutated.client_biome.json
+++ b/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/jungle_mutated.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "jungle_mutated"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:warmish_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:warmish_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:warmish_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/legacy_frozen_ocean.client_biome.json
+++ b/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/legacy_frozen_ocean.client_biome.json
@@ -1,15 +1,27 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "legacy_frozen_ocean"
 		},
 		"components": {
 			"minecraft:fog_appearance": {
-				"fog_identifier": "bt:fog_default"
+				"fog_identifier": "bt:fog_dry"
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:default_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:cold_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:default_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/lukewarm_ocean.client_biome.json
+++ b/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/lukewarm_ocean.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "lukewarm_ocean"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:warmish_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:warmish_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:warmish_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/lush_caves.client_biome.json
+++ b/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/lush_caves.client_biome.json
@@ -1,15 +1,27 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "lush_caves"
 		},
 		"components": {
 			"minecraft:fog_appearance": {
-				"fog_identifier": "bt:fog_default"
+				"fog_identifier": "bt:fog_lush_caves"
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:default_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:lush_caves_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:default_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/mangrove_swamp.client_biome.json
+++ b/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/mangrove_swamp.client_biome.json
@@ -1,10 +1,16 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "mangrove_swamp"
 		},
 		"components": {
+			"minecraft:fog_appearance": {
+				"fog_identifier": "bt:fog_mangrove_swamp"
+			},
+			"minecraft:water_appearance": {
+				"surface_color": "#0056FF"
+			},
 			"minecraft:foliage_appearance": {
 				"color": {
 					"color_map": "mangrove_swamp_foliage"
@@ -15,11 +21,20 @@
 					"color_map": "swamp_grass"
 				}
 			},
-			"minecraft:fog_appearance": {
-				"fog_identifier": "bt:fog_mangrove_swamp"
+			"minecraft:dry_foliage_color": {
+				"color": "#7B5334"
 			},
-			"minecraft:water_appearance": {
-				"surface_color": "#0056FF"
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:mangrove_swamp_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:mangrove_swamp_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:mangrove_swamp_lighting"
+			},
+			"minecraft:biome_music": {
+				"music_definition": "mangrove_swamp"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/meadow.client_biome.json
+++ b/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/meadow.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "meadow"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:default_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:default_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:default_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/mega_taiga.client_biome.json
+++ b/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/mega_taiga.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "mega_taiga"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:default_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:coolish_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:default_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/mega_taiga_hills.client_biome.json
+++ b/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/mega_taiga_hills.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "mega_taiga_hills"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:default_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:coolish_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:default_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/mesa.client_biome.json
+++ b/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/mesa.client_biome.json
@@ -1,21 +1,33 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "mesa"
 		},
 		"components": {
+			"minecraft:fog_appearance": {
+				"fog_identifier": "bt:fog_mesa"
+			},
+			"minecraft:water_appearance": {
+				"surface_color": "#0056FF"
+			},
 			"minecraft:foliage_appearance": {
 				"color": "#2abb0e"
 			},
 			"minecraft:grass_appearance": {
 				"color": "#2abb0e"
 			},
-			"minecraft:fog_appearance": {
-				"fog_identifier": "bt:fog_mesa"
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:mesa_atmospherics"
 			},
-			"minecraft:water_appearance": {
-				"surface_color": "#0056FF"
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:mesa_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:mesa_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/mesa_bryce.client_biome.json
+++ b/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/mesa_bryce.client_biome.json
@@ -1,21 +1,33 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "mesa_bryce"
 		},
 		"components": {
+			"minecraft:fog_appearance": {
+				"fog_identifier": "bt:fog_mesa_bryce"
+			},
+			"minecraft:water_appearance": {
+				"surface_color": "#0056FF"
+			},
 			"minecraft:foliage_appearance": {
 				"color": "#2abb0e"
 			},
 			"minecraft:grass_appearance": {
 				"color": "#2abb0e"
 			},
-			"minecraft:fog_appearance": {
-				"fog_identifier": "bt:fog_mesa_bryce"
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:mesa_atmospherics"
 			},
-			"minecraft:water_appearance": {
-				"surface_color": "#0056FF"
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:mesa_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:mesa_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/mesa_plateau.client_biome.json
+++ b/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/mesa_plateau.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "mesa_plateau"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:mesa_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:mesa_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:mesa_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/mesa_plateau_mutated.client_biome.json
+++ b/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/mesa_plateau_mutated.client_biome.json
@@ -1,21 +1,33 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "mesa_plateau_mutated"
 		},
 		"components": {
+			"minecraft:fog_appearance": {
+				"fog_identifier": "bt:fog_dry"
+			},
+			"minecraft:water_appearance": {
+				"surface_color": "#0056FF"
+			},
 			"minecraft:foliage_appearance": {
 				"color": "#2abb0e"
 			},
 			"minecraft:grass_appearance": {
 				"color": "#2abb0e"
 			},
-			"minecraft:fog_appearance": {
-				"fog_identifier": "bt:fog_default"
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:mesa_atmospherics"
 			},
-			"minecraft:water_appearance": {
-				"surface_color": "#0056FF"
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:mesa_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:mesa_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/mesa_plateau_stone.client_biome.json
+++ b/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/mesa_plateau_stone.client_biome.json
@@ -1,21 +1,33 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "mesa_plateau_stone"
 		},
 		"components": {
+			"minecraft:fog_appearance": {
+				"fog_identifier": "bt:fog_mesa_plateau_stone"
+			},
+			"minecraft:water_appearance": {
+				"surface_color": "#0056FF"
+			},
 			"minecraft:foliage_appearance": {
 				"color": "#2abb0e"
 			},
 			"minecraft:grass_appearance": {
 				"color": "#2abb0e"
 			},
-			"minecraft:fog_appearance": {
-				"fog_identifier": "bt:fog_mesa_plateau_stone"
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:mesa_atmospherics"
 			},
-			"minecraft:water_appearance": {
-				"surface_color": "#0056FF"
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:mesa_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:mesa_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/mesa_plateau_stone_mutated.client_biome.json
+++ b/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/mesa_plateau_stone_mutated.client_biome.json
@@ -1,21 +1,33 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "mesa_plateau_stone_mutated"
 		},
 		"components": {
+			"minecraft:fog_appearance": {
+				"fog_identifier": "bt:fog_dry"
+			},
+			"minecraft:water_appearance": {
+				"surface_color": "#0056FF"
+			},
 			"minecraft:foliage_appearance": {
 				"color": "#2abb0e"
 			},
 			"minecraft:grass_appearance": {
 				"color": "#2abb0e"
 			},
-			"minecraft:fog_appearance": {
-				"fog_identifier": "bt:fog_default"
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:mesa_atmospherics"
 			},
-			"minecraft:water_appearance": {
-				"surface_color": "#0056FF"
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:mesa_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:mesa_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/mushroom_island.client_biome.json
+++ b/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/mushroom_island.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "mushroom_island"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:mushroom_island_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:mushroom_island_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:mushroom_island_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/mushroom_island_shore.client_biome.json
+++ b/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/mushroom_island_shore.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "mushroom_island_shore"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:mushroom_island_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:mushroom_island_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:mushroom_island_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/ocean.client_biome.json
+++ b/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/ocean.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "ocean"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:default_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:default_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:default_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/pale_garden.client_biome.json
+++ b/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/pale_garden.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "pale_garden"
@@ -22,6 +22,18 @@
 			},
 			"minecraft:grass_appearance": {
 				"color": "#2abb0e"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:pale_garden_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:coolish_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:pale_garden_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/plains.client_biome.json
+++ b/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/plains.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "plains"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:default_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:default_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:default_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/redwood_taiga_hills_mutated.client_biome.json
+++ b/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/redwood_taiga_hills_mutated.client_biome.json
@@ -1,15 +1,27 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "redwood_taiga_hills_mutated"
 		},
 		"components": {
 			"minecraft:fog_appearance": {
-				"fog_identifier": "bt:fog_default"
+				"fog_identifier": "bt:fog_semi_humid"
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:default_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:coolish_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:default_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/redwood_taiga_mutated.client_biome.json
+++ b/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/redwood_taiga_mutated.client_biome.json
@@ -1,15 +1,27 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "redwood_taiga_mutated"
 		},
 		"components": {
 			"minecraft:fog_appearance": {
-				"fog_identifier": "bt:fog_default"
+				"fog_identifier": "bt:fog_semi_humid"
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:default_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:coolish_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:default_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/river.client_biome.json
+++ b/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/river.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "river"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:default_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:default_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:default_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/roofed_forest.client_biome.json
+++ b/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/roofed_forest.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "roofed_forest"
@@ -10,6 +10,21 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:dry_foliage_color": {
+				"color": "#7B5334"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:default_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:default_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:default_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/roofed_forest_mutated.client_biome.json
+++ b/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/roofed_forest_mutated.client_biome.json
@@ -1,15 +1,30 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "roofed_forest_mutated"
 		},
 		"components": {
 			"minecraft:fog_appearance": {
-				"fog_identifier": "bt:fog_default"
+				"fog_identifier": "bt:fog_semi_humid"
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:dry_foliage_color": {
+				"color": "#7B5334"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:default_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:default_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:default_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/savanna.client_biome.json
+++ b/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/savanna.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "savanna"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:warmish_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:warmish_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:warmish_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/savanna_mutated.client_biome.json
+++ b/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/savanna_mutated.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "savanna_mutated"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:warmish_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:warmish_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:warmish_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/savanna_plateau.client_biome.json
+++ b/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/savanna_plateau.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "savanna_plateau"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:warmish_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:warmish_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:warmish_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/savanna_plateau_mutated.client_biome.json
+++ b/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/savanna_plateau_mutated.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "savanna_plateau_mutated"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:warmish_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:warmish_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:warmish_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/snowy_slopes.client_biome.json
+++ b/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/snowy_slopes.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "snowy_slopes"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:default_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:coolish_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:default_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/soulsand_valley.client_biome.json
+++ b/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/soulsand_valley.client_biome.json
@@ -1,20 +1,32 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "soulsand_valley"
 		},
 		"components": {
-			"minecraft:ambient_sounds": {
-				"mood": "ambient.soulsand_valley.mood",
-				"addition": "ambient.soulsand_valley.additions",
-				"loop": "ambient.soulsand_valley.loop"
-			},
 			"minecraft:fog_appearance": {
 				"fog_identifier": "bt:fog_soulsand_valley"
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:ambient_sounds": {
+				"addition": "ambient.soulsand_valley.additions",
+				"loop": "ambient.soulsand_valley.loop",
+				"mood": "ambient.soulsand_valley.mood"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:soulsand_valley_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:default_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:nether_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/stone_beach.client_biome.json
+++ b/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/stone_beach.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "stone_beach"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:default_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:default_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:default_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/stony_peaks.client_biome.json
+++ b/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/stony_peaks.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "stony_peaks"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:warmish_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:warmish_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:warmish_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/sunflower_plains.client_biome.json
+++ b/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/sunflower_plains.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "sunflower_plains"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:default_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:default_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:default_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/swampland.client_biome.json
+++ b/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/swampland.client_biome.json
@@ -1,10 +1,17 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "swampland"
 		},
 		"components": {
+			"minecraft:fog_appearance": {
+				"fog_identifier": "bt:fog_swampland"
+			},
+			"minecraft:water_appearance": {
+				"surface_color": "#0056FF",
+				"surface_opacity": 1.0
+			},
 			"minecraft:foliage_appearance": {
 				"color": {
 					"color_map": "swamp_foliage"
@@ -15,12 +22,20 @@
 					"color_map": "swamp_grass"
 				}
 			},
-			"minecraft:fog_appearance": {
-				"fog_identifier": "bt:fog_swampland"
+			"minecraft:dry_foliage_color": {
+				"color": "#7B5334"
 			},
-			"minecraft:water_appearance": {
-				"surface_color": "#0056FF",
-				"surface_opacity": 1.0
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:swampland_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:swampland_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:swampland_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/swampland_mutated.client_biome.json
+++ b/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/swampland_mutated.client_biome.json
@@ -1,10 +1,17 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "swampland_mutated"
 		},
 		"components": {
+			"minecraft:fog_appearance": {
+				"fog_identifier": "bt:fog_swampland_mutated"
+			},
+			"minecraft:water_appearance": {
+				"surface_color": "#0056FF",
+				"surface_opacity": 1.0
+			},
 			"minecraft:foliage_appearance": {
 				"color": {
 					"color_map": "swamp_foliage"
@@ -15,12 +22,20 @@
 					"color_map": "swamp_grass"
 				}
 			},
-			"minecraft:fog_appearance": {
-				"fog_identifier": "bt:fog_swampland_mutated"
+			"minecraft:dry_foliage_color": {
+				"color": "#7B5334"
 			},
-			"minecraft:water_appearance": {
-				"surface_color": "#0056FF",
-				"surface_opacity": 1.0
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:swampland_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:swampland_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:swampland_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/taiga.client_biome.json
+++ b/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/taiga.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "taiga"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:default_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:coolish_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:default_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/taiga_hills.client_biome.json
+++ b/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/taiga_hills.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "taiga_hills"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:default_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:coolish_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:default_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/taiga_mutated.client_biome.json
+++ b/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/taiga_mutated.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "taiga_mutated"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:default_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:coolish_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:default_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/the_end.client_biome.json
+++ b/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/the_end.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "the_end"
@@ -13,6 +13,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:end_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:default_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:end_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/warm_ocean.client_biome.json
+++ b/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/warm_ocean.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "warm_ocean"
@@ -11,6 +11,18 @@
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF",
 				"surface_opacity": 0.55
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:warmish_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:warmish_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:warmish_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/warped_forest.client_biome.json
+++ b/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/warped_forest.client_biome.json
@@ -1,20 +1,32 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "warped_forest"
 		},
 		"components": {
-			"minecraft:ambient_sounds": {
-				"mood": "ambient.warped_forest.mood",
-				"addition": "ambient.warped_forest.additions",
-				"loop": "ambient.warped_forest.loop"
-			},
 			"minecraft:fog_appearance": {
 				"fog_identifier": "bt:fog_warped_forest"
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:ambient_sounds": {
+				"addition": "ambient.warped_forest.additions",
+				"loop": "ambient.warped_forest.loop",
+				"mood": "ambient.warped_forest.mood"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:warped_forest_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:default_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:nether_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/lush_grass_old_water/biomes/cherry_grove.client_biome.json
+++ b/resource_packs/extras/terrain/lush_grass_old_water/biomes/cherry_grove.client_biome.json
@@ -1,21 +1,33 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "cherry_grove"
 		},
 		"components": {
+			"minecraft:fog_appearance": {
+				"fog_identifier": "minecraft:fog_cherry_grove"
+			},
+			"minecraft:water_appearance": {
+				"surface_color": "#0056FF"
+			},
 			"minecraft:foliage_appearance": {
 				"color": "#2abb0e"
 			},
 			"minecraft:grass_appearance": {
 				"color": "#2abb0e"
 			},
-			"minecraft:fog_appearance": {
-				"fog_identifier": "minecraft:fog_cherry_grove"
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:default_atmospherics"
 			},
-			"minecraft:water_appearance": {
-				"surface_color": "#0056FF"
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:default_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:default_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/lush_grass_old_water/biomes/mesa.client_biome.json
+++ b/resource_packs/extras/terrain/lush_grass_old_water/biomes/mesa.client_biome.json
@@ -1,21 +1,33 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "mesa"
 		},
 		"components": {
+			"minecraft:fog_appearance": {
+				"fog_identifier": "minecraft:fog_mesa"
+			},
+			"minecraft:water_appearance": {
+				"surface_color": "#0056FF"
+			},
 			"minecraft:foliage_appearance": {
 				"color": "#2abb0e"
 			},
 			"minecraft:grass_appearance": {
 				"color": "#2abb0e"
 			},
-			"minecraft:fog_appearance": {
-				"fog_identifier": "minecraft:fog_mesa"
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:mesa_atmospherics"
 			},
-			"minecraft:water_appearance": {
-				"surface_color": "#0056FF"
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:mesa_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:mesa_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/lush_grass_old_water/biomes/mesa_bryce.client_biome.json
+++ b/resource_packs/extras/terrain/lush_grass_old_water/biomes/mesa_bryce.client_biome.json
@@ -1,21 +1,33 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "mesa_bryce"
 		},
 		"components": {
+			"minecraft:fog_appearance": {
+				"fog_identifier": "minecraft:fog_mesa_bryce"
+			},
+			"minecraft:water_appearance": {
+				"surface_color": "#0056FF"
+			},
 			"minecraft:foliage_appearance": {
 				"color": "#2abb0e"
 			},
 			"minecraft:grass_appearance": {
 				"color": "#2abb0e"
 			},
-			"minecraft:fog_appearance": {
-				"fog_identifier": "minecraft:fog_mesa_bryce"
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:mesa_atmospherics"
 			},
-			"minecraft:water_appearance": {
-				"surface_color": "#0056FF"
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:mesa_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:mesa_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/lush_grass_old_water/biomes/mesa_plateau_mutated.client_biome.json
+++ b/resource_packs/extras/terrain/lush_grass_old_water/biomes/mesa_plateau_mutated.client_biome.json
@@ -1,21 +1,33 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "mesa_plateau_mutated"
 		},
 		"components": {
+			"minecraft:fog_appearance": {
+				"fog_identifier": "minecraft:fog_dry"
+			},
+			"minecraft:water_appearance": {
+				"surface_color": "#0056FF"
+			},
 			"minecraft:foliage_appearance": {
 				"color": "#2abb0e"
 			},
 			"minecraft:grass_appearance": {
 				"color": "#2abb0e"
 			},
-			"minecraft:fog_appearance": {
-				"fog_identifier": "minecraft:fog_default"
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:mesa_atmospherics"
 			},
-			"minecraft:water_appearance": {
-				"surface_color": "#0056FF"
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:mesa_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:mesa_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/lush_grass_old_water/biomes/mesa_plateau_stone.client_biome.json
+++ b/resource_packs/extras/terrain/lush_grass_old_water/biomes/mesa_plateau_stone.client_biome.json
@@ -1,21 +1,33 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "mesa_plateau_stone"
 		},
 		"components": {
+			"minecraft:fog_appearance": {
+				"fog_identifier": "minecraft:fog_mesa_plateau_stone"
+			},
+			"minecraft:water_appearance": {
+				"surface_color": "#0056FF"
+			},
 			"minecraft:foliage_appearance": {
 				"color": "#2abb0e"
 			},
 			"minecraft:grass_appearance": {
 				"color": "#2abb0e"
 			},
-			"minecraft:fog_appearance": {
-				"fog_identifier": "minecraft:fog_mesa_plateau_stone"
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:mesa_atmospherics"
 			},
-			"minecraft:water_appearance": {
-				"surface_color": "#0056FF"
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:mesa_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:mesa_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/lush_grass_old_water/biomes/mesa_plateau_stone_mutated.client_biome.json
+++ b/resource_packs/extras/terrain/lush_grass_old_water/biomes/mesa_plateau_stone_mutated.client_biome.json
@@ -1,21 +1,33 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "mesa_plateau_stone_mutated"
 		},
 		"components": {
+			"minecraft:fog_appearance": {
+				"fog_identifier": "minecraft:fog_dry"
+			},
+			"minecraft:water_appearance": {
+				"surface_color": "#0056FF"
+			},
 			"minecraft:foliage_appearance": {
 				"color": "#2abb0e"
 			},
 			"minecraft:grass_appearance": {
 				"color": "#2abb0e"
 			},
-			"minecraft:fog_appearance": {
-				"fog_identifier": "minecraft:fog_default"
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:mesa_atmospherics"
 			},
-			"minecraft:water_appearance": {
-				"surface_color": "#0056FF"
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:mesa_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:mesa_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/lush_grass_old_water/biomes/pale_garden.client_biome.json
+++ b/resource_packs/extras/terrain/lush_grass_old_water/biomes/pale_garden.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "pale_garden"
@@ -22,6 +22,18 @@
 			},
 			"minecraft:grass_appearance": {
 				"color": "#2abb0e"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:pale_garden_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:coolish_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:pale_garden_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/old_clearer_water/biomes/bamboo_jungle.client_biome.json
+++ b/resource_packs/extras/terrain/old_clearer_water/biomes/bamboo_jungle.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "bamboo_jungle"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:warmish_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:warmish_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:warmish_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/old_clearer_water/biomes/bamboo_jungle_hills.client_biome.json
+++ b/resource_packs/extras/terrain/old_clearer_water/biomes/bamboo_jungle_hills.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "bamboo_jungle_hills"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:warmish_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:warmish_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:warmish_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/old_clearer_water/biomes/basalt_deltas.client_biome.json
+++ b/resource_packs/extras/terrain/old_clearer_water/biomes/basalt_deltas.client_biome.json
@@ -1,20 +1,32 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "basalt_deltas"
 		},
 		"components": {
-			"minecraft:ambient_sounds": {
-				"mood": "ambient.basalt_deltas.mood",
-				"addition": "ambient.basalt_deltas.additions",
-				"loop": "ambient.basalt_deltas.loop"
-			},
 			"minecraft:fog_appearance": {
 				"fog_identifier": "bt:fog_basalt_deltas"
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:ambient_sounds": {
+				"addition": "ambient.basalt_deltas.additions",
+				"loop": "ambient.basalt_deltas.loop",
+				"mood": "ambient.basalt_deltas.mood"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:basalt_deltas_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:default_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:nether_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/old_clearer_water/biomes/beach.client_biome.json
+++ b/resource_packs/extras/terrain/old_clearer_water/biomes/beach.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "beach"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:default_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:default_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:default_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/old_clearer_water/biomes/birch_forest.client_biome.json
+++ b/resource_packs/extras/terrain/old_clearer_water/biomes/birch_forest.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "birch_forest"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:default_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:default_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:default_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/old_clearer_water/biomes/birch_forest_hills.client_biome.json
+++ b/resource_packs/extras/terrain/old_clearer_water/biomes/birch_forest_hills.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "birch_forest_hills"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:default_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:default_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:default_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/old_clearer_water/biomes/birch_forest_hills_mutated.client_biome.json
+++ b/resource_packs/extras/terrain/old_clearer_water/biomes/birch_forest_hills_mutated.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "birch_forest_hills_mutated"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:default_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:default_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:default_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/old_clearer_water/biomes/birch_forest_mutated.client_biome.json
+++ b/resource_packs/extras/terrain/old_clearer_water/biomes/birch_forest_mutated.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "birch_forest_mutated"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:default_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:default_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:default_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/old_clearer_water/biomes/cherry_grove.client_biome.json
+++ b/resource_packs/extras/terrain/old_clearer_water/biomes/cherry_grove.client_biome.json
@@ -1,21 +1,33 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "cherry_grove"
 		},
 		"components": {
+			"minecraft:fog_appearance": {
+				"fog_identifier": "bt:fog_cherry_grove"
+			},
+			"minecraft:water_appearance": {
+				"surface_color": "#0056FF"
+			},
 			"minecraft:foliage_appearance": {
 				"color": "#b6db61"
 			},
 			"minecraft:grass_appearance": {
 				"color": "#b6db61"
 			},
-			"minecraft:fog_appearance": {
-				"fog_identifier": "bt:fog_cherry_grove"
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:default_atmospherics"
 			},
-			"minecraft:water_appearance": {
-				"surface_color": "#0056FF"
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:default_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:default_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/old_clearer_water/biomes/cold_beach.client_biome.json
+++ b/resource_packs/extras/terrain/old_clearer_water/biomes/cold_beach.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "cold_beach"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:default_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:cold_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:default_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/old_clearer_water/biomes/cold_ocean.client_biome.json
+++ b/resource_packs/extras/terrain/old_clearer_water/biomes/cold_ocean.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "cold_ocean"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:default_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:coolish_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:default_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/old_clearer_water/biomes/cold_taiga.client_biome.json
+++ b/resource_packs/extras/terrain/old_clearer_water/biomes/cold_taiga.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "cold_taiga"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:default_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:cold_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:default_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/old_clearer_water/biomes/cold_taiga_hills.client_biome.json
+++ b/resource_packs/extras/terrain/old_clearer_water/biomes/cold_taiga_hills.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "cold_taiga_hills"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:default_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:cold_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:default_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/old_clearer_water/biomes/cold_taiga_mutated.client_biome.json
+++ b/resource_packs/extras/terrain/old_clearer_water/biomes/cold_taiga_mutated.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "cold_taiga_mutated"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:default_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:cold_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:default_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/old_clearer_water/biomes/crimson_forest.client_biome.json
+++ b/resource_packs/extras/terrain/old_clearer_water/biomes/crimson_forest.client_biome.json
@@ -1,20 +1,32 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "crimson_forest"
 		},
 		"components": {
-			"minecraft:ambient_sounds": {
-				"mood": "ambient.crimson_forest.mood",
-				"addition": "ambient.crimson_forest.additions",
-				"loop": "ambient.crimson_forest.loop"
-			},
 			"minecraft:fog_appearance": {
 				"fog_identifier": "bt:fog_crimson_forest"
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:ambient_sounds": {
+				"addition": "ambient.crimson_forest.additions",
+				"loop": "ambient.crimson_forest.loop",
+				"mood": "ambient.crimson_forest.mood"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:crimson_forest_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:default_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:nether_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/old_clearer_water/biomes/deep_cold_ocean.client_biome.json
+++ b/resource_packs/extras/terrain/old_clearer_water/biomes/deep_cold_ocean.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "deep_cold_ocean"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:default_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:coolish_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:default_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/old_clearer_water/biomes/deep_dark.client_biome.json
+++ b/resource_packs/extras/terrain/old_clearer_water/biomes/deep_dark.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "deep_dark"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:default_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:default_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:default_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/old_clearer_water/biomes/deep_frozen_ocean.client_biome.json
+++ b/resource_packs/extras/terrain/old_clearer_water/biomes/deep_frozen_ocean.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "deep_frozen_ocean"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:default_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:cold_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:default_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/old_clearer_water/biomes/deep_lukewarm_ocean.client_biome.json
+++ b/resource_packs/extras/terrain/old_clearer_water/biomes/deep_lukewarm_ocean.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "deep_lukewarm_ocean"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:warmish_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:warmish_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:warmish_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/old_clearer_water/biomes/deep_ocean.client_biome.json
+++ b/resource_packs/extras/terrain/old_clearer_water/biomes/deep_ocean.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "deep_ocean"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:default_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:default_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:default_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/old_clearer_water/biomes/deep_warm_ocean.client_biome.json
+++ b/resource_packs/extras/terrain/old_clearer_water/biomes/deep_warm_ocean.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "deep_warm_ocean"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:warmish_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:warmish_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:warmish_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/old_clearer_water/biomes/desert.client_biome.json
+++ b/resource_packs/extras/terrain/old_clearer_water/biomes/desert.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "desert"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:desert_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:desert_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:desert_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/old_clearer_water/biomes/desert_hills.client_biome.json
+++ b/resource_packs/extras/terrain/old_clearer_water/biomes/desert_hills.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "desert_hills"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:desert_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:desert_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:desert_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/old_clearer_water/biomes/desert_mutated.client_biome.json
+++ b/resource_packs/extras/terrain/old_clearer_water/biomes/desert_mutated.client_biome.json
@@ -1,15 +1,27 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "desert_mutated"
 		},
 		"components": {
 			"minecraft:fog_appearance": {
-				"fog_identifier": "bt:fog_default"
+				"fog_identifier": "bt:fog_dry"
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:desert_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:desert_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:desert_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/old_clearer_water/biomes/dripstone_caves.client_biome.json
+++ b/resource_packs/extras/terrain/old_clearer_water/biomes/dripstone_caves.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "dripstone_caves"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:default_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:default_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:default_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/old_clearer_water/biomes/extreme_hills.client_biome.json
+++ b/resource_packs/extras/terrain/old_clearer_water/biomes/extreme_hills.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "extreme_hills"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:default_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:coolish_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:default_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/old_clearer_water/biomes/extreme_hills_edge.client_biome.json
+++ b/resource_packs/extras/terrain/old_clearer_water/biomes/extreme_hills_edge.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "extreme_hills_edge"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:default_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:coolish_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:default_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/old_clearer_water/biomes/extreme_hills_mutated.client_biome.json
+++ b/resource_packs/extras/terrain/old_clearer_water/biomes/extreme_hills_mutated.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "extreme_hills_mutated"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:default_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:coolish_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:default_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/old_clearer_water/biomes/extreme_hills_plus_trees.client_biome.json
+++ b/resource_packs/extras/terrain/old_clearer_water/biomes/extreme_hills_plus_trees.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "extreme_hills_plus_trees"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:default_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:coolish_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:default_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/old_clearer_water/biomes/extreme_hills_plus_trees_mutated.client_biome.json
+++ b/resource_packs/extras/terrain/old_clearer_water/biomes/extreme_hills_plus_trees_mutated.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "extreme_hills_plus_trees_mutated"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:default_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:coolish_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:default_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/old_clearer_water/biomes/flower_forest.client_biome.json
+++ b/resource_packs/extras/terrain/old_clearer_water/biomes/flower_forest.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "flower_forest"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:default_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:default_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:default_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/old_clearer_water/biomes/forest.client_biome.json
+++ b/resource_packs/extras/terrain/old_clearer_water/biomes/forest.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "forest"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:default_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:default_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:default_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/old_clearer_water/biomes/forest_hills.client_biome.json
+++ b/resource_packs/extras/terrain/old_clearer_water/biomes/forest_hills.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "forest_hills"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:default_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:default_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:default_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/old_clearer_water/biomes/frozen_ocean.client_biome.json
+++ b/resource_packs/extras/terrain/old_clearer_water/biomes/frozen_ocean.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "frozen_ocean"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:default_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:cold_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:default_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/old_clearer_water/biomes/frozen_peaks.client_biome.json
+++ b/resource_packs/extras/terrain/old_clearer_water/biomes/frozen_peaks.client_biome.json
@@ -1,15 +1,27 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "frozen_peaks"
 		},
 		"components": {
 			"minecraft:fog_appearance": {
-				"fog_identifier": "bt:fog_default"
+				"fog_identifier": "bt:fog_dry"
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:default_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:cold_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:default_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/old_clearer_water/biomes/frozen_river.client_biome.json
+++ b/resource_packs/extras/terrain/old_clearer_water/biomes/frozen_river.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "frozen_river"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:default_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:cold_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:default_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/old_clearer_water/biomes/grove.client_biome.json
+++ b/resource_packs/extras/terrain/old_clearer_water/biomes/grove.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "grove"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:default_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:coolish_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:default_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/old_clearer_water/biomes/hell.client_biome.json
+++ b/resource_packs/extras/terrain/old_clearer_water/biomes/hell.client_biome.json
@@ -1,20 +1,32 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "hell"
 		},
 		"components": {
-			"minecraft:ambient_sounds": {
-				"mood": "ambient.nether_wastes.mood",
-				"addition": "ambient.nether_wastes.additions",
-				"loop": "ambient.nether_wastes.loop"
-			},
 			"minecraft:fog_appearance": {
 				"fog_identifier": "bt:fog_hell"
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:ambient_sounds": {
+				"addition": "ambient.nether_wastes.additions",
+				"loop": "ambient.nether_wastes.loop",
+				"mood": "ambient.nether_wastes.mood"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:hell_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:default_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:nether_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/old_clearer_water/biomes/ice_mountains.client_biome.json
+++ b/resource_packs/extras/terrain/old_clearer_water/biomes/ice_mountains.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "ice_mountains"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:default_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:cold_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:default_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/old_clearer_water/biomes/ice_plains.client_biome.json
+++ b/resource_packs/extras/terrain/old_clearer_water/biomes/ice_plains.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "ice_plains"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:default_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:cold_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:default_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/old_clearer_water/biomes/ice_plains_spikes.client_biome.json
+++ b/resource_packs/extras/terrain/old_clearer_water/biomes/ice_plains_spikes.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "ice_plains_spikes"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:ice_plains_spikes_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:ice_plains_spikes_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:ice_plains_spikes_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/old_clearer_water/biomes/jagged_peaks.client_biome.json
+++ b/resource_packs/extras/terrain/old_clearer_water/biomes/jagged_peaks.client_biome.json
@@ -1,15 +1,27 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "jagged_peaks"
 		},
 		"components": {
 			"minecraft:fog_appearance": {
-				"fog_identifier": "bt:fog_default"
+				"fog_identifier": "bt:fog_dry"
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:default_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:coolish_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:default_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/old_clearer_water/biomes/jungle.client_biome.json
+++ b/resource_packs/extras/terrain/old_clearer_water/biomes/jungle.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "jungle"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:warmish_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:warmish_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:warmish_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/old_clearer_water/biomes/jungle_edge.client_biome.json
+++ b/resource_packs/extras/terrain/old_clearer_water/biomes/jungle_edge.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "jungle_edge"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:warmish_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:warmish_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:warmish_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/old_clearer_water/biomes/jungle_edge_mutated.client_biome.json
+++ b/resource_packs/extras/terrain/old_clearer_water/biomes/jungle_edge_mutated.client_biome.json
@@ -1,15 +1,27 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "jungle_edge_mutated"
 		},
 		"components": {
 			"minecraft:fog_appearance": {
-				"fog_identifier": "bt:fog_default"
+				"fog_identifier": "bt:fog_humid"
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:warmish_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:warmish_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:warmish_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/old_clearer_water/biomes/jungle_hills.client_biome.json
+++ b/resource_packs/extras/terrain/old_clearer_water/biomes/jungle_hills.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "jungle_hills"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:warmish_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:warmish_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:warmish_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/old_clearer_water/biomes/jungle_mutated.client_biome.json
+++ b/resource_packs/extras/terrain/old_clearer_water/biomes/jungle_mutated.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "jungle_mutated"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:warmish_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:warmish_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:warmish_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/old_clearer_water/biomes/legacy_frozen_ocean.client_biome.json
+++ b/resource_packs/extras/terrain/old_clearer_water/biomes/legacy_frozen_ocean.client_biome.json
@@ -1,15 +1,27 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "legacy_frozen_ocean"
 		},
 		"components": {
 			"minecraft:fog_appearance": {
-				"fog_identifier": "bt:fog_default"
+				"fog_identifier": "bt:fog_dry"
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:default_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:cold_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:default_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/old_clearer_water/biomes/lukewarm_ocean.client_biome.json
+++ b/resource_packs/extras/terrain/old_clearer_water/biomes/lukewarm_ocean.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "lukewarm_ocean"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:warmish_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:warmish_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:warmish_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/old_clearer_water/biomes/lush_caves.client_biome.json
+++ b/resource_packs/extras/terrain/old_clearer_water/biomes/lush_caves.client_biome.json
@@ -1,15 +1,27 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "lush_caves"
 		},
 		"components": {
 			"minecraft:fog_appearance": {
-				"fog_identifier": "bt:fog_default"
+				"fog_identifier": "bt:fog_lush_caves"
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:default_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:lush_caves_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:default_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/old_clearer_water/biomes/mangrove_swamp.client_biome.json
+++ b/resource_packs/extras/terrain/old_clearer_water/biomes/mangrove_swamp.client_biome.json
@@ -1,10 +1,16 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "mangrove_swamp"
 		},
 		"components": {
+			"minecraft:fog_appearance": {
+				"fog_identifier": "bt:fog_mangrove_swamp"
+			},
+			"minecraft:water_appearance": {
+				"surface_color": "#0056FF"
+			},
 			"minecraft:foliage_appearance": {
 				"color": {
 					"color_map": "mangrove_swamp_foliage"
@@ -15,11 +21,20 @@
 					"color_map": "swamp_grass"
 				}
 			},
-			"minecraft:fog_appearance": {
-				"fog_identifier": "bt:fog_mangrove_swamp"
+			"minecraft:dry_foliage_color": {
+				"color": "#7B5334"
 			},
-			"minecraft:water_appearance": {
-				"surface_color": "#0056FF"
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:mangrove_swamp_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:mangrove_swamp_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:mangrove_swamp_lighting"
+			},
+			"minecraft:biome_music": {
+				"music_definition": "mangrove_swamp"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/old_clearer_water/biomes/meadow.client_biome.json
+++ b/resource_packs/extras/terrain/old_clearer_water/biomes/meadow.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "meadow"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:default_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:default_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:default_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/old_clearer_water/biomes/mega_taiga.client_biome.json
+++ b/resource_packs/extras/terrain/old_clearer_water/biomes/mega_taiga.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "mega_taiga"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:default_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:coolish_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:default_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/old_clearer_water/biomes/mega_taiga_hills.client_biome.json
+++ b/resource_packs/extras/terrain/old_clearer_water/biomes/mega_taiga_hills.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "mega_taiga_hills"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:default_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:coolish_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:default_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/old_clearer_water/biomes/mesa.client_biome.json
+++ b/resource_packs/extras/terrain/old_clearer_water/biomes/mesa.client_biome.json
@@ -1,21 +1,33 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "mesa"
 		},
 		"components": {
+			"minecraft:fog_appearance": {
+				"fog_identifier": "bt:fog_mesa"
+			},
+			"minecraft:water_appearance": {
+				"surface_color": "#0056FF"
+			},
 			"minecraft:foliage_appearance": {
 				"color": "#aea42a"
 			},
 			"minecraft:grass_appearance": {
 				"color": "#90814d"
 			},
-			"minecraft:fog_appearance": {
-				"fog_identifier": "bt:fog_mesa"
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:mesa_atmospherics"
 			},
-			"minecraft:water_appearance": {
-				"surface_color": "#0056FF"
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:mesa_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:mesa_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/old_clearer_water/biomes/mesa_bryce.client_biome.json
+++ b/resource_packs/extras/terrain/old_clearer_water/biomes/mesa_bryce.client_biome.json
@@ -1,21 +1,33 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "mesa_bryce"
 		},
 		"components": {
+			"minecraft:fog_appearance": {
+				"fog_identifier": "bt:fog_mesa_bryce"
+			},
+			"minecraft:water_appearance": {
+				"surface_color": "#0056FF"
+			},
 			"minecraft:foliage_appearance": {
 				"color": "#aea42a"
 			},
 			"minecraft:grass_appearance": {
 				"color": "#90814d"
 			},
-			"minecraft:fog_appearance": {
-				"fog_identifier": "bt:fog_mesa_bryce"
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:mesa_atmospherics"
 			},
-			"minecraft:water_appearance": {
-				"surface_color": "#0056FF"
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:mesa_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:mesa_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/old_clearer_water/biomes/mesa_plateau.client_biome.json
+++ b/resource_packs/extras/terrain/old_clearer_water/biomes/mesa_plateau.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "mesa_plateau"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:mesa_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:mesa_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:mesa_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/old_clearer_water/biomes/mesa_plateau_mutated.client_biome.json
+++ b/resource_packs/extras/terrain/old_clearer_water/biomes/mesa_plateau_mutated.client_biome.json
@@ -1,21 +1,33 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "mesa_plateau_mutated"
 		},
 		"components": {
+			"minecraft:fog_appearance": {
+				"fog_identifier": "bt:fog_dry"
+			},
+			"minecraft:water_appearance": {
+				"surface_color": "#0056FF"
+			},
 			"minecraft:foliage_appearance": {
 				"color": "#aea42a"
 			},
 			"minecraft:grass_appearance": {
 				"color": "#90814d"
 			},
-			"minecraft:fog_appearance": {
-				"fog_identifier": "bt:fog_default"
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:mesa_atmospherics"
 			},
-			"minecraft:water_appearance": {
-				"surface_color": "#0056FF"
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:mesa_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:mesa_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/old_clearer_water/biomes/mesa_plateau_stone.client_biome.json
+++ b/resource_packs/extras/terrain/old_clearer_water/biomes/mesa_plateau_stone.client_biome.json
@@ -1,21 +1,33 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "mesa_plateau_stone"
 		},
 		"components": {
+			"minecraft:fog_appearance": {
+				"fog_identifier": "bt:fog_mesa_plateau_stone"
+			},
+			"minecraft:water_appearance": {
+				"surface_color": "#0056FF"
+			},
 			"minecraft:foliage_appearance": {
 				"color": "#aea42a"
 			},
 			"minecraft:grass_appearance": {
 				"color": "#90814d"
 			},
-			"minecraft:fog_appearance": {
-				"fog_identifier": "bt:fog_mesa_plateau_stone"
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:mesa_atmospherics"
 			},
-			"minecraft:water_appearance": {
-				"surface_color": "#0056FF"
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:mesa_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:mesa_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/old_clearer_water/biomes/mesa_plateau_stone_mutated.client_biome.json
+++ b/resource_packs/extras/terrain/old_clearer_water/biomes/mesa_plateau_stone_mutated.client_biome.json
@@ -1,21 +1,33 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "mesa_plateau_stone_mutated"
 		},
 		"components": {
+			"minecraft:fog_appearance": {
+				"fog_identifier": "bt:fog_dry"
+			},
+			"minecraft:water_appearance": {
+				"surface_color": "#0056FF"
+			},
 			"minecraft:foliage_appearance": {
 				"color": "#aea42a"
 			},
 			"minecraft:grass_appearance": {
 				"color": "#90814d"
 			},
-			"minecraft:fog_appearance": {
-				"fog_identifier": "bt:fog_default"
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:mesa_atmospherics"
 			},
-			"minecraft:water_appearance": {
-				"surface_color": "#0056FF"
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:mesa_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:mesa_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/old_clearer_water/biomes/mushroom_island.client_biome.json
+++ b/resource_packs/extras/terrain/old_clearer_water/biomes/mushroom_island.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "mushroom_island"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:mushroom_island_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:mushroom_island_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:mushroom_island_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/old_clearer_water/biomes/mushroom_island_shore.client_biome.json
+++ b/resource_packs/extras/terrain/old_clearer_water/biomes/mushroom_island_shore.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "mushroom_island_shore"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:mushroom_island_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:mushroom_island_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:mushroom_island_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/old_clearer_water/biomes/ocean.client_biome.json
+++ b/resource_packs/extras/terrain/old_clearer_water/biomes/ocean.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "ocean"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:default_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:default_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:default_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/old_clearer_water/biomes/pale_garden.client_biome.json
+++ b/resource_packs/extras/terrain/old_clearer_water/biomes/pale_garden.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "pale_garden"
@@ -22,6 +22,18 @@
 			},
 			"minecraft:grass_appearance": {
 				"color": "#778272"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:pale_garden_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:coolish_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:pale_garden_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/old_clearer_water/biomes/plains.client_biome.json
+++ b/resource_packs/extras/terrain/old_clearer_water/biomes/plains.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "plains"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:default_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:default_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:default_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/old_clearer_water/biomes/redwood_taiga_hills_mutated.client_biome.json
+++ b/resource_packs/extras/terrain/old_clearer_water/biomes/redwood_taiga_hills_mutated.client_biome.json
@@ -1,15 +1,27 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "redwood_taiga_hills_mutated"
 		},
 		"components": {
 			"minecraft:fog_appearance": {
-				"fog_identifier": "bt:fog_default"
+				"fog_identifier": "bt:fog_semi_humid"
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:default_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:coolish_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:default_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/old_clearer_water/biomes/redwood_taiga_mutated.client_biome.json
+++ b/resource_packs/extras/terrain/old_clearer_water/biomes/redwood_taiga_mutated.client_biome.json
@@ -1,15 +1,27 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "redwood_taiga_mutated"
 		},
 		"components": {
 			"minecraft:fog_appearance": {
-				"fog_identifier": "bt:fog_default"
+				"fog_identifier": "bt:fog_semi_humid"
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:default_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:coolish_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:default_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/old_clearer_water/biomes/river.client_biome.json
+++ b/resource_packs/extras/terrain/old_clearer_water/biomes/river.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "river"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:default_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:default_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:default_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/old_clearer_water/biomes/roofed_forest.client_biome.json
+++ b/resource_packs/extras/terrain/old_clearer_water/biomes/roofed_forest.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "roofed_forest"
@@ -10,6 +10,21 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:dry_foliage_color": {
+				"color": "#7B5334"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:default_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:default_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:default_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/old_clearer_water/biomes/roofed_forest_mutated.client_biome.json
+++ b/resource_packs/extras/terrain/old_clearer_water/biomes/roofed_forest_mutated.client_biome.json
@@ -1,15 +1,30 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "roofed_forest_mutated"
 		},
 		"components": {
 			"minecraft:fog_appearance": {
-				"fog_identifier": "bt:fog_default"
+				"fog_identifier": "bt:fog_semi_humid"
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:dry_foliage_color": {
+				"color": "#7B5334"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:default_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:default_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:default_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/old_clearer_water/biomes/savanna.client_biome.json
+++ b/resource_packs/extras/terrain/old_clearer_water/biomes/savanna.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "savanna"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:warmish_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:warmish_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:warmish_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/old_clearer_water/biomes/savanna_mutated.client_biome.json
+++ b/resource_packs/extras/terrain/old_clearer_water/biomes/savanna_mutated.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "savanna_mutated"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:warmish_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:warmish_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:warmish_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/old_clearer_water/biomes/savanna_plateau.client_biome.json
+++ b/resource_packs/extras/terrain/old_clearer_water/biomes/savanna_plateau.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "savanna_plateau"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:warmish_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:warmish_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:warmish_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/old_clearer_water/biomes/savanna_plateau_mutated.client_biome.json
+++ b/resource_packs/extras/terrain/old_clearer_water/biomes/savanna_plateau_mutated.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "savanna_plateau_mutated"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:warmish_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:warmish_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:warmish_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/old_clearer_water/biomes/snowy_slopes.client_biome.json
+++ b/resource_packs/extras/terrain/old_clearer_water/biomes/snowy_slopes.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "snowy_slopes"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:default_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:coolish_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:default_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/old_clearer_water/biomes/soulsand_valley.client_biome.json
+++ b/resource_packs/extras/terrain/old_clearer_water/biomes/soulsand_valley.client_biome.json
@@ -1,20 +1,32 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "soulsand_valley"
 		},
 		"components": {
-			"minecraft:ambient_sounds": {
-				"mood": "ambient.soulsand_valley.mood",
-				"addition": "ambient.soulsand_valley.additions",
-				"loop": "ambient.soulsand_valley.loop"
-			},
 			"minecraft:fog_appearance": {
 				"fog_identifier": "bt:fog_soulsand_valley"
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:ambient_sounds": {
+				"addition": "ambient.soulsand_valley.additions",
+				"loop": "ambient.soulsand_valley.loop",
+				"mood": "ambient.soulsand_valley.mood"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:soulsand_valley_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:default_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:nether_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/old_clearer_water/biomes/stone_beach.client_biome.json
+++ b/resource_packs/extras/terrain/old_clearer_water/biomes/stone_beach.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "stone_beach"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:default_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:default_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:default_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/old_clearer_water/biomes/stony_peaks.client_biome.json
+++ b/resource_packs/extras/terrain/old_clearer_water/biomes/stony_peaks.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "stony_peaks"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:warmish_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:warmish_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:warmish_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/old_clearer_water/biomes/sunflower_plains.client_biome.json
+++ b/resource_packs/extras/terrain/old_clearer_water/biomes/sunflower_plains.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "sunflower_plains"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:default_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:default_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:default_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/old_clearer_water/biomes/swampland.client_biome.json
+++ b/resource_packs/extras/terrain/old_clearer_water/biomes/swampland.client_biome.json
@@ -1,10 +1,17 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "swampland"
 		},
 		"components": {
+			"minecraft:fog_appearance": {
+				"fog_identifier": "bt:fog_swampland"
+			},
+			"minecraft:water_appearance": {
+				"surface_color": "#0056FF",
+				"surface_opacity": 1.0
+			},
 			"minecraft:foliage_appearance": {
 				"color": {
 					"color_map": "swamp_foliage"
@@ -15,12 +22,20 @@
 					"color_map": "swamp_grass"
 				}
 			},
-			"minecraft:fog_appearance": {
-				"fog_identifier": "bt:fog_swampland"
+			"minecraft:dry_foliage_color": {
+				"color": "#7B5334"
 			},
-			"minecraft:water_appearance": {
-				"surface_color": "#0056FF",
-				"surface_opacity": 1.0
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:swampland_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:swampland_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:swampland_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/old_clearer_water/biomes/swampland_mutated.client_biome.json
+++ b/resource_packs/extras/terrain/old_clearer_water/biomes/swampland_mutated.client_biome.json
@@ -1,10 +1,17 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "swampland_mutated"
 		},
 		"components": {
+			"minecraft:fog_appearance": {
+				"fog_identifier": "bt:fog_swampland_mutated"
+			},
+			"minecraft:water_appearance": {
+				"surface_color": "#0056FF",
+				"surface_opacity": 1.0
+			},
 			"minecraft:foliage_appearance": {
 				"color": {
 					"color_map": "swamp_foliage"
@@ -15,12 +22,20 @@
 					"color_map": "swamp_grass"
 				}
 			},
-			"minecraft:fog_appearance": {
-				"fog_identifier": "bt:fog_swampland_mutated"
+			"minecraft:dry_foliage_color": {
+				"color": "#7B5334"
 			},
-			"minecraft:water_appearance": {
-				"surface_color": "#0056FF",
-				"surface_opacity": 1.0
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:swampland_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:swampland_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:swampland_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/old_clearer_water/biomes/taiga.client_biome.json
+++ b/resource_packs/extras/terrain/old_clearer_water/biomes/taiga.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "taiga"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:default_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:coolish_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:default_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/old_clearer_water/biomes/taiga_hills.client_biome.json
+++ b/resource_packs/extras/terrain/old_clearer_water/biomes/taiga_hills.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "taiga_hills"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:default_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:coolish_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:default_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/old_clearer_water/biomes/taiga_mutated.client_biome.json
+++ b/resource_packs/extras/terrain/old_clearer_water/biomes/taiga_mutated.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "taiga_mutated"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:default_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:coolish_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:default_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/old_clearer_water/biomes/the_end.client_biome.json
+++ b/resource_packs/extras/terrain/old_clearer_water/biomes/the_end.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "the_end"
@@ -13,6 +13,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:end_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:default_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:end_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/old_clearer_water/biomes/warm_ocean.client_biome.json
+++ b/resource_packs/extras/terrain/old_clearer_water/biomes/warm_ocean.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "warm_ocean"
@@ -11,6 +11,18 @@
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF",
 				"surface_opacity": 0.55
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:warmish_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:warmish_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:warmish_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/old_clearer_water/biomes/warped_forest.client_biome.json
+++ b/resource_packs/extras/terrain/old_clearer_water/biomes/warped_forest.client_biome.json
@@ -1,20 +1,32 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "warped_forest"
 		},
 		"components": {
-			"minecraft:ambient_sounds": {
-				"mood": "ambient.warped_forest.mood",
-				"addition": "ambient.warped_forest.additions",
-				"loop": "ambient.warped_forest.loop"
-			},
 			"minecraft:fog_appearance": {
 				"fog_identifier": "bt:fog_warped_forest"
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:ambient_sounds": {
+				"addition": "ambient.warped_forest.additions",
+				"loop": "ambient.warped_forest.loop",
+				"mood": "ambient.warped_forest.mood"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:warped_forest_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:default_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:nether_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/files/retro/old_water/biomes/bamboo_jungle.client_biome.json
+++ b/resource_packs/files/retro/old_water/biomes/bamboo_jungle.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "bamboo_jungle"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:warmish_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:warmish_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:warmish_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/files/retro/old_water/biomes/bamboo_jungle_hills.client_biome.json
+++ b/resource_packs/files/retro/old_water/biomes/bamboo_jungle_hills.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "bamboo_jungle_hills"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:warmish_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:warmish_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:warmish_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/files/retro/old_water/biomes/basalt_deltas.client_biome.json
+++ b/resource_packs/files/retro/old_water/biomes/basalt_deltas.client_biome.json
@@ -1,20 +1,32 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "basalt_deltas"
 		},
 		"components": {
-			"minecraft:ambient_sounds": {
-				"mood": "ambient.basalt_deltas.mood",
-				"addition": "ambient.basalt_deltas.additions",
-				"loop": "ambient.basalt_deltas.loop"
-			},
 			"minecraft:fog_appearance": {
 				"fog_identifier": "minecraft:fog_basalt_deltas"
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:ambient_sounds": {
+				"addition": "ambient.basalt_deltas.additions",
+				"loop": "ambient.basalt_deltas.loop",
+				"mood": "ambient.basalt_deltas.mood"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:basalt_deltas_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:default_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:nether_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/files/retro/old_water/biomes/beach.client_biome.json
+++ b/resource_packs/files/retro/old_water/biomes/beach.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "beach"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:default_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:default_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:default_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/files/retro/old_water/biomes/birch_forest.client_biome.json
+++ b/resource_packs/files/retro/old_water/biomes/birch_forest.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "birch_forest"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:default_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:default_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:default_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/files/retro/old_water/biomes/birch_forest_hills.client_biome.json
+++ b/resource_packs/files/retro/old_water/biomes/birch_forest_hills.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "birch_forest_hills"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:default_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:default_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:default_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/files/retro/old_water/biomes/birch_forest_hills_mutated.client_biome.json
+++ b/resource_packs/files/retro/old_water/biomes/birch_forest_hills_mutated.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "birch_forest_hills_mutated"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:default_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:default_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:default_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/files/retro/old_water/biomes/birch_forest_mutated.client_biome.json
+++ b/resource_packs/files/retro/old_water/biomes/birch_forest_mutated.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "birch_forest_mutated"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:default_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:default_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:default_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/files/retro/old_water/biomes/cherry_grove.client_biome.json
+++ b/resource_packs/files/retro/old_water/biomes/cherry_grove.client_biome.json
@@ -1,21 +1,33 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "cherry_grove"
 		},
 		"components": {
+			"minecraft:fog_appearance": {
+				"fog_identifier": "minecraft:fog_cherry_grove"
+			},
+			"minecraft:water_appearance": {
+				"surface_color": "#0056FF"
+			},
 			"minecraft:foliage_appearance": {
 				"color": "#b6db61"
 			},
 			"minecraft:grass_appearance": {
 				"color": "#b6db61"
 			},
-			"minecraft:fog_appearance": {
-				"fog_identifier": "minecraft:fog_cherry_grove"
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:default_atmospherics"
 			},
-			"minecraft:water_appearance": {
-				"surface_color": "#0056FF"
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:default_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:default_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/files/retro/old_water/biomes/cold_beach.client_biome.json
+++ b/resource_packs/files/retro/old_water/biomes/cold_beach.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "cold_beach"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:default_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:cold_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:default_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/files/retro/old_water/biomes/cold_ocean.client_biome.json
+++ b/resource_packs/files/retro/old_water/biomes/cold_ocean.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "cold_ocean"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:default_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:coolish_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:default_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/files/retro/old_water/biomes/cold_taiga.client_biome.json
+++ b/resource_packs/files/retro/old_water/biomes/cold_taiga.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "cold_taiga"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:default_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:cold_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:default_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/files/retro/old_water/biomes/cold_taiga_hills.client_biome.json
+++ b/resource_packs/files/retro/old_water/biomes/cold_taiga_hills.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "cold_taiga_hills"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:default_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:cold_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:default_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/files/retro/old_water/biomes/cold_taiga_mutated.client_biome.json
+++ b/resource_packs/files/retro/old_water/biomes/cold_taiga_mutated.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "cold_taiga_mutated"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:default_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:cold_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:default_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/files/retro/old_water/biomes/crimson_forest.client_biome.json
+++ b/resource_packs/files/retro/old_water/biomes/crimson_forest.client_biome.json
@@ -1,20 +1,32 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "crimson_forest"
 		},
 		"components": {
-			"minecraft:ambient_sounds": {
-				"mood": "ambient.crimson_forest.mood",
-				"addition": "ambient.crimson_forest.additions",
-				"loop": "ambient.crimson_forest.loop"
-			},
 			"minecraft:fog_appearance": {
 				"fog_identifier": "minecraft:fog_crimson_forest"
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:ambient_sounds": {
+				"addition": "ambient.crimson_forest.additions",
+				"loop": "ambient.crimson_forest.loop",
+				"mood": "ambient.crimson_forest.mood"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:crimson_forest_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:default_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:nether_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/files/retro/old_water/biomes/deep_cold_ocean.client_biome.json
+++ b/resource_packs/files/retro/old_water/biomes/deep_cold_ocean.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "deep_cold_ocean"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:default_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:coolish_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:default_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/files/retro/old_water/biomes/deep_dark.client_biome.json
+++ b/resource_packs/files/retro/old_water/biomes/deep_dark.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "deep_dark"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:default_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:default_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:default_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/files/retro/old_water/biomes/deep_frozen_ocean.client_biome.json
+++ b/resource_packs/files/retro/old_water/biomes/deep_frozen_ocean.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "deep_frozen_ocean"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:default_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:cold_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:default_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/files/retro/old_water/biomes/deep_lukewarm_ocean.client_biome.json
+++ b/resource_packs/files/retro/old_water/biomes/deep_lukewarm_ocean.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "deep_lukewarm_ocean"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:warmish_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:warmish_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:warmish_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/files/retro/old_water/biomes/deep_ocean.client_biome.json
+++ b/resource_packs/files/retro/old_water/biomes/deep_ocean.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "deep_ocean"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:default_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:default_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:default_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/files/retro/old_water/biomes/deep_warm_ocean.client_biome.json
+++ b/resource_packs/files/retro/old_water/biomes/deep_warm_ocean.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "deep_warm_ocean"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:warmish_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:warmish_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:warmish_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/files/retro/old_water/biomes/desert.client_biome.json
+++ b/resource_packs/files/retro/old_water/biomes/desert.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "desert"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:desert_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:desert_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:desert_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/files/retro/old_water/biomes/desert_hills.client_biome.json
+++ b/resource_packs/files/retro/old_water/biomes/desert_hills.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "desert_hills"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:desert_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:desert_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:desert_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/files/retro/old_water/biomes/desert_mutated.client_biome.json
+++ b/resource_packs/files/retro/old_water/biomes/desert_mutated.client_biome.json
@@ -1,15 +1,27 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "desert_mutated"
 		},
 		"components": {
 			"minecraft:fog_appearance": {
-				"fog_identifier": "minecraft:fog_default"
+				"fog_identifier": "minecraft:fog_dry"
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:desert_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:desert_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:desert_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/files/retro/old_water/biomes/dripstone_caves.client_biome.json
+++ b/resource_packs/files/retro/old_water/biomes/dripstone_caves.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "dripstone_caves"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:default_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:default_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:default_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/files/retro/old_water/biomes/extreme_hills.client_biome.json
+++ b/resource_packs/files/retro/old_water/biomes/extreme_hills.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "extreme_hills"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:default_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:coolish_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:default_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/files/retro/old_water/biomes/extreme_hills_edge.client_biome.json
+++ b/resource_packs/files/retro/old_water/biomes/extreme_hills_edge.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "extreme_hills_edge"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:default_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:coolish_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:default_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/files/retro/old_water/biomes/extreme_hills_mutated.client_biome.json
+++ b/resource_packs/files/retro/old_water/biomes/extreme_hills_mutated.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "extreme_hills_mutated"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:default_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:coolish_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:default_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/files/retro/old_water/biomes/extreme_hills_plus_trees.client_biome.json
+++ b/resource_packs/files/retro/old_water/biomes/extreme_hills_plus_trees.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "extreme_hills_plus_trees"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:default_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:coolish_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:default_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/files/retro/old_water/biomes/extreme_hills_plus_trees_mutated.client_biome.json
+++ b/resource_packs/files/retro/old_water/biomes/extreme_hills_plus_trees_mutated.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "extreme_hills_plus_trees_mutated"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:default_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:coolish_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:default_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/files/retro/old_water/biomes/flower_forest.client_biome.json
+++ b/resource_packs/files/retro/old_water/biomes/flower_forest.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "flower_forest"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:default_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:default_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:default_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/files/retro/old_water/biomes/forest.client_biome.json
+++ b/resource_packs/files/retro/old_water/biomes/forest.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "forest"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:default_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:default_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:default_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/files/retro/old_water/biomes/forest_hills.client_biome.json
+++ b/resource_packs/files/retro/old_water/biomes/forest_hills.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "forest_hills"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:default_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:default_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:default_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/files/retro/old_water/biomes/frozen_ocean.client_biome.json
+++ b/resource_packs/files/retro/old_water/biomes/frozen_ocean.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "frozen_ocean"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:default_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:cold_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:default_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/files/retro/old_water/biomes/frozen_peaks.client_biome.json
+++ b/resource_packs/files/retro/old_water/biomes/frozen_peaks.client_biome.json
@@ -1,15 +1,27 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "frozen_peaks"
 		},
 		"components": {
 			"minecraft:fog_appearance": {
-				"fog_identifier": "minecraft:fog_default"
+				"fog_identifier": "minecraft:fog_dry"
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:default_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:cold_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:default_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/files/retro/old_water/biomes/frozen_river.client_biome.json
+++ b/resource_packs/files/retro/old_water/biomes/frozen_river.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "frozen_river"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:default_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:cold_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:default_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/files/retro/old_water/biomes/grove.client_biome.json
+++ b/resource_packs/files/retro/old_water/biomes/grove.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "grove"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:default_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:coolish_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:default_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/files/retro/old_water/biomes/hell.client_biome.json
+++ b/resource_packs/files/retro/old_water/biomes/hell.client_biome.json
@@ -1,20 +1,32 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "hell"
 		},
 		"components": {
-			"minecraft:ambient_sounds": {
-				"mood": "ambient.nether_wastes.mood",
-				"addition": "ambient.nether_wastes.additions",
-				"loop": "ambient.nether_wastes.loop"
-			},
 			"minecraft:fog_appearance": {
 				"fog_identifier": "minecraft:fog_hell"
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:ambient_sounds": {
+				"addition": "ambient.nether_wastes.additions",
+				"loop": "ambient.nether_wastes.loop",
+				"mood": "ambient.nether_wastes.mood"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:hell_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:default_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:nether_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/files/retro/old_water/biomes/ice_mountains.client_biome.json
+++ b/resource_packs/files/retro/old_water/biomes/ice_mountains.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "ice_mountains"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:default_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:cold_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:default_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/files/retro/old_water/biomes/ice_plains.client_biome.json
+++ b/resource_packs/files/retro/old_water/biomes/ice_plains.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "ice_plains"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:default_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:cold_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:default_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/files/retro/old_water/biomes/ice_plains_spikes.client_biome.json
+++ b/resource_packs/files/retro/old_water/biomes/ice_plains_spikes.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "ice_plains_spikes"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:ice_plains_spikes_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:ice_plains_spikes_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:ice_plains_spikes_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/files/retro/old_water/biomes/jagged_peaks.client_biome.json
+++ b/resource_packs/files/retro/old_water/biomes/jagged_peaks.client_biome.json
@@ -1,15 +1,27 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "jagged_peaks"
 		},
 		"components": {
 			"minecraft:fog_appearance": {
-				"fog_identifier": "minecraft:fog_default"
+				"fog_identifier": "minecraft:fog_dry"
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:default_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:coolish_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:default_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/files/retro/old_water/biomes/jungle.client_biome.json
+++ b/resource_packs/files/retro/old_water/biomes/jungle.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "jungle"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:warmish_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:warmish_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:warmish_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/files/retro/old_water/biomes/jungle_edge.client_biome.json
+++ b/resource_packs/files/retro/old_water/biomes/jungle_edge.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "jungle_edge"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:warmish_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:warmish_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:warmish_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/files/retro/old_water/biomes/jungle_edge_mutated.client_biome.json
+++ b/resource_packs/files/retro/old_water/biomes/jungle_edge_mutated.client_biome.json
@@ -1,15 +1,27 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "jungle_edge_mutated"
 		},
 		"components": {
 			"minecraft:fog_appearance": {
-				"fog_identifier": "minecraft:fog_default"
+				"fog_identifier": "minecraft:fog_humid"
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:warmish_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:warmish_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:warmish_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/files/retro/old_water/biomes/jungle_hills.client_biome.json
+++ b/resource_packs/files/retro/old_water/biomes/jungle_hills.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "jungle_hills"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:warmish_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:warmish_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:warmish_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/files/retro/old_water/biomes/jungle_mutated.client_biome.json
+++ b/resource_packs/files/retro/old_water/biomes/jungle_mutated.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "jungle_mutated"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:warmish_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:warmish_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:warmish_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/files/retro/old_water/biomes/legacy_frozen_ocean.client_biome.json
+++ b/resource_packs/files/retro/old_water/biomes/legacy_frozen_ocean.client_biome.json
@@ -1,15 +1,27 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "legacy_frozen_ocean"
 		},
 		"components": {
 			"minecraft:fog_appearance": {
-				"fog_identifier": "minecraft:fog_default"
+				"fog_identifier": "minecraft:fog_dry"
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:default_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:cold_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:default_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/files/retro/old_water/biomes/lukewarm_ocean.client_biome.json
+++ b/resource_packs/files/retro/old_water/biomes/lukewarm_ocean.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "lukewarm_ocean"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:warmish_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:warmish_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:warmish_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/files/retro/old_water/biomes/lush_caves.client_biome.json
+++ b/resource_packs/files/retro/old_water/biomes/lush_caves.client_biome.json
@@ -1,15 +1,27 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "lush_caves"
 		},
 		"components": {
 			"minecraft:fog_appearance": {
-				"fog_identifier": "minecraft:fog_default"
+				"fog_identifier": "minecraft:fog_lush_caves"
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:default_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:lush_caves_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:default_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/files/retro/old_water/biomes/mangrove_swamp.client_biome.json
+++ b/resource_packs/files/retro/old_water/biomes/mangrove_swamp.client_biome.json
@@ -1,10 +1,16 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "mangrove_swamp"
 		},
 		"components": {
+			"minecraft:fog_appearance": {
+				"fog_identifier": "minecraft:fog_mangrove_swamp"
+			},
+			"minecraft:water_appearance": {
+				"surface_color": "#0056FF"
+			},
 			"minecraft:foliage_appearance": {
 				"color": {
 					"color_map": "mangrove_swamp_foliage"
@@ -15,11 +21,20 @@
 					"color_map": "swamp_grass"
 				}
 			},
-			"minecraft:fog_appearance": {
-				"fog_identifier": "minecraft:fog_mangrove_swamp"
+			"minecraft:dry_foliage_color": {
+				"color": "#7B5334"
 			},
-			"minecraft:water_appearance": {
-				"surface_color": "#0056FF"
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:mangrove_swamp_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:mangrove_swamp_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:mangrove_swamp_lighting"
+			},
+			"minecraft:biome_music": {
+				"music_definition": "mangrove_swamp"
 			}
 		}
 	}

--- a/resource_packs/files/retro/old_water/biomes/meadow.client_biome.json
+++ b/resource_packs/files/retro/old_water/biomes/meadow.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "meadow"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:default_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:default_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:default_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/files/retro/old_water/biomes/mega_taiga.client_biome.json
+++ b/resource_packs/files/retro/old_water/biomes/mega_taiga.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "mega_taiga"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:default_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:coolish_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:default_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/files/retro/old_water/biomes/mega_taiga_hills.client_biome.json
+++ b/resource_packs/files/retro/old_water/biomes/mega_taiga_hills.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "mega_taiga_hills"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:default_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:coolish_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:default_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/files/retro/old_water/biomes/mesa.client_biome.json
+++ b/resource_packs/files/retro/old_water/biomes/mesa.client_biome.json
@@ -1,21 +1,33 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "mesa"
 		},
 		"components": {
+			"minecraft:fog_appearance": {
+				"fog_identifier": "minecraft:fog_mesa"
+			},
+			"minecraft:water_appearance": {
+				"surface_color": "#0056FF"
+			},
 			"minecraft:foliage_appearance": {
 				"color": "#aea42a"
 			},
 			"minecraft:grass_appearance": {
 				"color": "#90814d"
 			},
-			"minecraft:fog_appearance": {
-				"fog_identifier": "minecraft:fog_mesa"
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:mesa_atmospherics"
 			},
-			"minecraft:water_appearance": {
-				"surface_color": "#0056FF"
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:mesa_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:mesa_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/files/retro/old_water/biomes/mesa_bryce.client_biome.json
+++ b/resource_packs/files/retro/old_water/biomes/mesa_bryce.client_biome.json
@@ -1,21 +1,33 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "mesa_bryce"
 		},
 		"components": {
+			"minecraft:fog_appearance": {
+				"fog_identifier": "minecraft:fog_mesa_bryce"
+			},
+			"minecraft:water_appearance": {
+				"surface_color": "#0056FF"
+			},
 			"minecraft:foliage_appearance": {
 				"color": "#aea42a"
 			},
 			"minecraft:grass_appearance": {
 				"color": "#90814d"
 			},
-			"minecraft:fog_appearance": {
-				"fog_identifier": "minecraft:fog_mesa_bryce"
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:mesa_atmospherics"
 			},
-			"minecraft:water_appearance": {
-				"surface_color": "#0056FF"
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:mesa_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:mesa_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/files/retro/old_water/biomes/mesa_plateau.client_biome.json
+++ b/resource_packs/files/retro/old_water/biomes/mesa_plateau.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "mesa_plateau"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:mesa_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:mesa_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:mesa_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/files/retro/old_water/biomes/mesa_plateau_mutated.client_biome.json
+++ b/resource_packs/files/retro/old_water/biomes/mesa_plateau_mutated.client_biome.json
@@ -1,21 +1,33 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "mesa_plateau_mutated"
 		},
 		"components": {
+			"minecraft:fog_appearance": {
+				"fog_identifier": "minecraft:fog_dry"
+			},
+			"minecraft:water_appearance": {
+				"surface_color": "#0056FF"
+			},
 			"minecraft:foliage_appearance": {
 				"color": "#aea42a"
 			},
 			"minecraft:grass_appearance": {
 				"color": "#90814d"
 			},
-			"minecraft:fog_appearance": {
-				"fog_identifier": "minecraft:fog_default"
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:mesa_atmospherics"
 			},
-			"minecraft:water_appearance": {
-				"surface_color": "#0056FF"
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:mesa_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:mesa_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/files/retro/old_water/biomes/mesa_plateau_stone.client_biome.json
+++ b/resource_packs/files/retro/old_water/biomes/mesa_plateau_stone.client_biome.json
@@ -1,21 +1,33 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "mesa_plateau_stone"
 		},
 		"components": {
+			"minecraft:fog_appearance": {
+				"fog_identifier": "minecraft:fog_mesa_plateau_stone"
+			},
+			"minecraft:water_appearance": {
+				"surface_color": "#0056FF"
+			},
 			"minecraft:foliage_appearance": {
 				"color": "#aea42a"
 			},
 			"minecraft:grass_appearance": {
 				"color": "#90814d"
 			},
-			"minecraft:fog_appearance": {
-				"fog_identifier": "minecraft:fog_mesa_plateau_stone"
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:mesa_atmospherics"
 			},
-			"minecraft:water_appearance": {
-				"surface_color": "#0056FF"
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:mesa_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:mesa_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/files/retro/old_water/biomes/mesa_plateau_stone_mutated.client_biome.json
+++ b/resource_packs/files/retro/old_water/biomes/mesa_plateau_stone_mutated.client_biome.json
@@ -1,21 +1,33 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "mesa_plateau_stone_mutated"
 		},
 		"components": {
+			"minecraft:fog_appearance": {
+				"fog_identifier": "minecraft:fog_dry"
+			},
+			"minecraft:water_appearance": {
+				"surface_color": "#0056FF"
+			},
 			"minecraft:foliage_appearance": {
 				"color": "#aea42a"
 			},
 			"minecraft:grass_appearance": {
 				"color": "#90814d"
 			},
-			"minecraft:fog_appearance": {
-				"fog_identifier": "minecraft:fog_default"
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:mesa_atmospherics"
 			},
-			"minecraft:water_appearance": {
-				"surface_color": "#0056FF"
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:mesa_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:mesa_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/files/retro/old_water/biomes/mushroom_island.client_biome.json
+++ b/resource_packs/files/retro/old_water/biomes/mushroom_island.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "mushroom_island"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:mushroom_island_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:mushroom_island_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:mushroom_island_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/files/retro/old_water/biomes/mushroom_island_shore.client_biome.json
+++ b/resource_packs/files/retro/old_water/biomes/mushroom_island_shore.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "mushroom_island_shore"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:mushroom_island_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:mushroom_island_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:mushroom_island_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/files/retro/old_water/biomes/ocean.client_biome.json
+++ b/resource_packs/files/retro/old_water/biomes/ocean.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "ocean"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:default_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:default_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:default_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/files/retro/old_water/biomes/pale_garden.client_biome.json
+++ b/resource_packs/files/retro/old_water/biomes/pale_garden.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "pale_garden"
@@ -22,6 +22,18 @@
 			},
 			"minecraft:grass_appearance": {
 				"color": "#778272"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:pale_garden_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:coolish_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:pale_garden_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/files/retro/old_water/biomes/plains.client_biome.json
+++ b/resource_packs/files/retro/old_water/biomes/plains.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "plains"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:default_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:default_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:default_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/files/retro/old_water/biomes/redwood_taiga_hills_mutated.client_biome.json
+++ b/resource_packs/files/retro/old_water/biomes/redwood_taiga_hills_mutated.client_biome.json
@@ -1,15 +1,27 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "redwood_taiga_hills_mutated"
 		},
 		"components": {
 			"minecraft:fog_appearance": {
-				"fog_identifier": "minecraft:fog_default"
+				"fog_identifier": "minecraft:fog_semi_humid"
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:default_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:coolish_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:default_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/files/retro/old_water/biomes/redwood_taiga_mutated.client_biome.json
+++ b/resource_packs/files/retro/old_water/biomes/redwood_taiga_mutated.client_biome.json
@@ -1,15 +1,27 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "redwood_taiga_mutated"
 		},
 		"components": {
 			"minecraft:fog_appearance": {
-				"fog_identifier": "minecraft:fog_default"
+				"fog_identifier": "minecraft:fog_semi_humid"
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:default_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:coolish_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:default_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/files/retro/old_water/biomes/river.client_biome.json
+++ b/resource_packs/files/retro/old_water/biomes/river.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "river"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:default_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:default_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:default_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/files/retro/old_water/biomes/roofed_forest.client_biome.json
+++ b/resource_packs/files/retro/old_water/biomes/roofed_forest.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "roofed_forest"
@@ -10,6 +10,21 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:dry_foliage_color": {
+				"color": "#7B5334"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:default_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:default_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:default_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/files/retro/old_water/biomes/roofed_forest_mutated.client_biome.json
+++ b/resource_packs/files/retro/old_water/biomes/roofed_forest_mutated.client_biome.json
@@ -1,15 +1,30 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "roofed_forest_mutated"
 		},
 		"components": {
 			"minecraft:fog_appearance": {
-				"fog_identifier": "minecraft:fog_default"
+				"fog_identifier": "minecraft:fog_semi_humid"
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:dry_foliage_color": {
+				"color": "#7B5334"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:default_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:default_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:default_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/files/retro/old_water/biomes/savanna.client_biome.json
+++ b/resource_packs/files/retro/old_water/biomes/savanna.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "savanna"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:warmish_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:warmish_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:warmish_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/files/retro/old_water/biomes/savanna_mutated.client_biome.json
+++ b/resource_packs/files/retro/old_water/biomes/savanna_mutated.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "savanna_mutated"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:warmish_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:warmish_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:warmish_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/files/retro/old_water/biomes/savanna_plateau.client_biome.json
+++ b/resource_packs/files/retro/old_water/biomes/savanna_plateau.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "savanna_plateau"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:warmish_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:warmish_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:warmish_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/files/retro/old_water/biomes/savanna_plateau_mutated.client_biome.json
+++ b/resource_packs/files/retro/old_water/biomes/savanna_plateau_mutated.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "savanna_plateau_mutated"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:warmish_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:warmish_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:warmish_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/files/retro/old_water/biomes/snowy_slopes.client_biome.json
+++ b/resource_packs/files/retro/old_water/biomes/snowy_slopes.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "snowy_slopes"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:default_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:coolish_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:default_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/files/retro/old_water/biomes/soulsand_valley.client_biome.json
+++ b/resource_packs/files/retro/old_water/biomes/soulsand_valley.client_biome.json
@@ -1,20 +1,32 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "soulsand_valley"
 		},
 		"components": {
-			"minecraft:ambient_sounds": {
-				"mood": "ambient.soulsand_valley.mood",
-				"addition": "ambient.soulsand_valley.additions",
-				"loop": "ambient.soulsand_valley.loop"
-			},
 			"minecraft:fog_appearance": {
 				"fog_identifier": "minecraft:fog_soulsand_valley"
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:ambient_sounds": {
+				"addition": "ambient.soulsand_valley.additions",
+				"loop": "ambient.soulsand_valley.loop",
+				"mood": "ambient.soulsand_valley.mood"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:soulsand_valley_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:default_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:nether_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/files/retro/old_water/biomes/stone_beach.client_biome.json
+++ b/resource_packs/files/retro/old_water/biomes/stone_beach.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "stone_beach"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:default_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:default_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:default_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/files/retro/old_water/biomes/stony_peaks.client_biome.json
+++ b/resource_packs/files/retro/old_water/biomes/stony_peaks.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "stony_peaks"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:warmish_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:warmish_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:warmish_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/files/retro/old_water/biomes/sunflower_plains.client_biome.json
+++ b/resource_packs/files/retro/old_water/biomes/sunflower_plains.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "sunflower_plains"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:default_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:default_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:default_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/files/retro/old_water/biomes/swampland.client_biome.json
+++ b/resource_packs/files/retro/old_water/biomes/swampland.client_biome.json
@@ -1,10 +1,17 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "swampland"
 		},
 		"components": {
+			"minecraft:fog_appearance": {
+				"fog_identifier": "minecraft:fog_swampland"
+			},
+			"minecraft:water_appearance": {
+				"surface_color": "#0056FF",
+				"surface_opacity": 1.0
+			},
 			"minecraft:foliage_appearance": {
 				"color": {
 					"color_map": "swamp_foliage"
@@ -15,12 +22,20 @@
 					"color_map": "swamp_grass"
 				}
 			},
-			"minecraft:fog_appearance": {
-				"fog_identifier": "minecraft:fog_swampland"
+			"minecraft:dry_foliage_color": {
+				"color": "#7B5334"
 			},
-			"minecraft:water_appearance": {
-				"surface_color": "#0056FF",
-				"surface_opacity": 1.0
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:swampland_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:swampland_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:swampland_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/files/retro/old_water/biomes/swampland_mutated.client_biome.json
+++ b/resource_packs/files/retro/old_water/biomes/swampland_mutated.client_biome.json
@@ -1,10 +1,17 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "swampland_mutated"
 		},
 		"components": {
+			"minecraft:fog_appearance": {
+				"fog_identifier": "minecraft:fog_swampland_mutated"
+			},
+			"minecraft:water_appearance": {
+				"surface_color": "#0056FF",
+				"surface_opacity": 1.0
+			},
 			"minecraft:foliage_appearance": {
 				"color": {
 					"color_map": "swamp_foliage"
@@ -15,12 +22,20 @@
 					"color_map": "swamp_grass"
 				}
 			},
-			"minecraft:fog_appearance": {
-				"fog_identifier": "minecraft:fog_swampland_mutated"
+			"minecraft:dry_foliage_color": {
+				"color": "#7B5334"
 			},
-			"minecraft:water_appearance": {
-				"surface_color": "#0056FF",
-				"surface_opacity": 1.0
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:swampland_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:swampland_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:swampland_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/files/retro/old_water/biomes/taiga.client_biome.json
+++ b/resource_packs/files/retro/old_water/biomes/taiga.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "taiga"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:default_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:coolish_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:default_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/files/retro/old_water/biomes/taiga_hills.client_biome.json
+++ b/resource_packs/files/retro/old_water/biomes/taiga_hills.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "taiga_hills"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:default_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:coolish_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:default_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/files/retro/old_water/biomes/taiga_mutated.client_biome.json
+++ b/resource_packs/files/retro/old_water/biomes/taiga_mutated.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "taiga_mutated"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:default_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:coolish_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:default_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/files/retro/old_water/biomes/the_end.client_biome.json
+++ b/resource_packs/files/retro/old_water/biomes/the_end.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "the_end"
@@ -13,6 +13,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:end_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:default_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:end_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/files/retro/old_water/biomes/warm_ocean.client_biome.json
+++ b/resource_packs/files/retro/old_water/biomes/warm_ocean.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "warm_ocean"
@@ -11,6 +11,18 @@
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF",
 				"surface_opacity": 0.55
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:warmish_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:warmish_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:warmish_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/files/retro/old_water/biomes/warped_forest.client_biome.json
+++ b/resource_packs/files/retro/old_water/biomes/warped_forest.client_biome.json
@@ -1,20 +1,32 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "warped_forest"
 		},
 		"components": {
-			"minecraft:ambient_sounds": {
-				"mood": "ambient.warped_forest.mood",
-				"addition": "ambient.warped_forest.additions",
-				"loop": "ambient.warped_forest.loop"
-			},
 			"minecraft:fog_appearance": {
 				"fog_identifier": "minecraft:fog_warped_forest"
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
+			},
+			"minecraft:ambient_sounds": {
+				"addition": "ambient.warped_forest.additions",
+				"loop": "ambient.warped_forest.loop",
+				"mood": "ambient.warped_forest.mood"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:warped_forest_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:default_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:nether_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/files/terrain/clearer_water/biomes/bamboo_jungle.client_biome.json
+++ b/resource_packs/files/terrain/clearer_water/biomes/bamboo_jungle.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "bamboo_jungle"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#14A2C5"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:warmish_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:warmish_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:warmish_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/files/terrain/clearer_water/biomes/bamboo_jungle_hills.client_biome.json
+++ b/resource_packs/files/terrain/clearer_water/biomes/bamboo_jungle_hills.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "bamboo_jungle_hills"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#1B9ED8"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:warmish_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:warmish_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:warmish_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/files/terrain/clearer_water/biomes/basalt_deltas.client_biome.json
+++ b/resource_packs/files/terrain/clearer_water/biomes/basalt_deltas.client_biome.json
@@ -1,20 +1,32 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "basalt_deltas"
 		},
 		"components": {
-			"minecraft:ambient_sounds": {
-				"mood": "ambient.basalt_deltas.mood",
-				"addition": "ambient.basalt_deltas.additions",
-				"loop": "ambient.basalt_deltas.loop"
-			},
 			"minecraft:fog_appearance": {
 				"fog_identifier": "bt:fog_basalt_deltas"
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#3f76e4"
+			},
+			"minecraft:ambient_sounds": {
+				"addition": "ambient.basalt_deltas.additions",
+				"loop": "ambient.basalt_deltas.loop",
+				"mood": "ambient.basalt_deltas.mood"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:basalt_deltas_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:default_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:nether_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/files/terrain/clearer_water/biomes/beach.client_biome.json
+++ b/resource_packs/files/terrain/clearer_water/biomes/beach.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "beach"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#157cab"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:default_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:default_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:default_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/files/terrain/clearer_water/biomes/birch_forest.client_biome.json
+++ b/resource_packs/files/terrain/clearer_water/biomes/birch_forest.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "birch_forest"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0677ce"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:default_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:default_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:default_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/files/terrain/clearer_water/biomes/birch_forest_hills.client_biome.json
+++ b/resource_packs/files/terrain/clearer_water/biomes/birch_forest_hills.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "birch_forest_hills"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0a74c4"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:default_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:default_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:default_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/files/terrain/clearer_water/biomes/birch_forest_hills_mutated.client_biome.json
+++ b/resource_packs/files/terrain/clearer_water/biomes/birch_forest_hills_mutated.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "birch_forest_hills_mutated"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#44AFF5"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:default_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:default_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:default_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/files/terrain/clearer_water/biomes/birch_forest_mutated.client_biome.json
+++ b/resource_packs/files/terrain/clearer_water/biomes/birch_forest_mutated.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "birch_forest_mutated"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#44AFF5"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:default_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:default_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:default_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/files/terrain/clearer_water/biomes/cherry_grove.client_biome.json
+++ b/resource_packs/files/terrain/clearer_water/biomes/cherry_grove.client_biome.json
@@ -1,21 +1,33 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "cherry_grove"
 		},
 		"components": {
+			"minecraft:fog_appearance": {
+				"fog_identifier": "bt:fog_cherry_grove"
+			},
+			"minecraft:water_appearance": {
+				"surface_color": "#5db7ef"
+			},
 			"minecraft:foliage_appearance": {
 				"color": "#b6db61"
 			},
 			"minecraft:grass_appearance": {
 				"color": "#b6db61"
 			},
-			"minecraft:fog_appearance": {
-				"fog_identifier": "bt:fog_cherry_grove"
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:default_atmospherics"
 			},
-			"minecraft:water_appearance": {
-				"surface_color": "#5db7ef"
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:default_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:default_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/files/terrain/clearer_water/biomes/cold_beach.client_biome.json
+++ b/resource_packs/files/terrain/clearer_water/biomes/cold_beach.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "cold_beach"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#1463a5"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:default_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:cold_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:default_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/files/terrain/clearer_water/biomes/cold_ocean.client_biome.json
+++ b/resource_packs/files/terrain/clearer_water/biomes/cold_ocean.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "cold_ocean"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#2080C9"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:default_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:coolish_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:default_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/files/terrain/clearer_water/biomes/cold_taiga.client_biome.json
+++ b/resource_packs/files/terrain/clearer_water/biomes/cold_taiga.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "cold_taiga"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#205e83"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:default_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:cold_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:default_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/files/terrain/clearer_water/biomes/cold_taiga_hills.client_biome.json
+++ b/resource_packs/files/terrain/clearer_water/biomes/cold_taiga_hills.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "cold_taiga_hills"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#245b78"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:default_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:cold_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:default_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/files/terrain/clearer_water/biomes/cold_taiga_mutated.client_biome.json
+++ b/resource_packs/files/terrain/clearer_water/biomes/cold_taiga_mutated.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "cold_taiga_mutated"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#205e83"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:default_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:cold_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:default_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/files/terrain/clearer_water/biomes/crimson_forest.client_biome.json
+++ b/resource_packs/files/terrain/clearer_water/biomes/crimson_forest.client_biome.json
@@ -1,20 +1,32 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "crimson_forest"
 		},
 		"components": {
-			"minecraft:ambient_sounds": {
-				"mood": "ambient.crimson_forest.mood",
-				"addition": "ambient.crimson_forest.additions",
-				"loop": "ambient.crimson_forest.loop"
-			},
 			"minecraft:fog_appearance": {
 				"fog_identifier": "bt:fog_crimson_forest"
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#905957"
+			},
+			"minecraft:ambient_sounds": {
+				"addition": "ambient.crimson_forest.additions",
+				"loop": "ambient.crimson_forest.loop",
+				"mood": "ambient.crimson_forest.mood"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:crimson_forest_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:default_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:nether_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/files/terrain/clearer_water/biomes/deep_cold_ocean.client_biome.json
+++ b/resource_packs/files/terrain/clearer_water/biomes/deep_cold_ocean.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "deep_cold_ocean"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#2080C9"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:default_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:coolish_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:default_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/files/terrain/clearer_water/biomes/deep_dark.client_biome.json
+++ b/resource_packs/files/terrain/clearer_water/biomes/deep_dark.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "deep_dark"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#44AFF5"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:default_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:default_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:default_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/files/terrain/clearer_water/biomes/deep_frozen_ocean.client_biome.json
+++ b/resource_packs/files/terrain/clearer_water/biomes/deep_frozen_ocean.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "deep_frozen_ocean"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#2570B5"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:default_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:cold_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:default_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/files/terrain/clearer_water/biomes/deep_lukewarm_ocean.client_biome.json
+++ b/resource_packs/files/terrain/clearer_water/biomes/deep_lukewarm_ocean.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "deep_lukewarm_ocean"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0D96DB"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:warmish_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:warmish_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:warmish_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/files/terrain/clearer_water/biomes/deep_ocean.client_biome.json
+++ b/resource_packs/files/terrain/clearer_water/biomes/deep_ocean.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "deep_ocean"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#1787D4"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:default_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:default_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:default_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/files/terrain/clearer_water/biomes/deep_warm_ocean.client_biome.json
+++ b/resource_packs/files/terrain/clearer_water/biomes/deep_warm_ocean.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "deep_warm_ocean"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#02B0E5"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:warmish_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:warmish_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:warmish_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/files/terrain/clearer_water/biomes/desert.client_biome.json
+++ b/resource_packs/files/terrain/clearer_water/biomes/desert.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "desert"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#32A598"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:desert_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:desert_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:desert_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/files/terrain/clearer_water/biomes/desert_hills.client_biome.json
+++ b/resource_packs/files/terrain/clearer_water/biomes/desert_hills.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "desert_hills"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#1a7aa1"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:desert_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:desert_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:desert_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/files/terrain/clearer_water/biomes/desert_mutated.client_biome.json
+++ b/resource_packs/files/terrain/clearer_water/biomes/desert_mutated.client_biome.json
@@ -1,15 +1,27 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "desert_mutated"
 		},
 		"components": {
 			"minecraft:fog_appearance": {
-				"fog_identifier": "bt:fog_default"
+				"fog_identifier": "bt:fog_dry"
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#44AFF5"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:desert_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:desert_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:desert_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/files/terrain/clearer_water/biomes/dripstone_caves.client_biome.json
+++ b/resource_packs/files/terrain/clearer_water/biomes/dripstone_caves.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "dripstone_caves"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#44AFF5"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:default_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:default_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:default_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/files/terrain/clearer_water/biomes/extreme_hills.client_biome.json
+++ b/resource_packs/files/terrain/clearer_water/biomes/extreme_hills.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "extreme_hills"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#007BF7"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:default_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:coolish_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:default_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/files/terrain/clearer_water/biomes/extreme_hills_edge.client_biome.json
+++ b/resource_packs/files/terrain/clearer_water/biomes/extreme_hills_edge.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "extreme_hills_edge"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#045cd5"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:default_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:coolish_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:default_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/files/terrain/clearer_water/biomes/extreme_hills_mutated.client_biome.json
+++ b/resource_packs/files/terrain/clearer_water/biomes/extreme_hills_mutated.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "extreme_hills_mutated"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0E63AB"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:default_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:coolish_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:default_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/files/terrain/clearer_water/biomes/extreme_hills_plus_trees.client_biome.json
+++ b/resource_packs/files/terrain/clearer_water/biomes/extreme_hills_plus_trees.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "extreme_hills_plus_trees"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0E63AB"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:default_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:coolish_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:default_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/files/terrain/clearer_water/biomes/extreme_hills_plus_trees_mutated.client_biome.json
+++ b/resource_packs/files/terrain/clearer_water/biomes/extreme_hills_plus_trees_mutated.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "extreme_hills_plus_trees_mutated"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0E63AB"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:default_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:coolish_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:default_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/files/terrain/clearer_water/biomes/flower_forest.client_biome.json
+++ b/resource_packs/files/terrain/clearer_water/biomes/flower_forest.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "flower_forest"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#20A3CC"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:default_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:default_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:default_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/files/terrain/clearer_water/biomes/forest.client_biome.json
+++ b/resource_packs/files/terrain/clearer_water/biomes/forest.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "forest"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#1E97F2"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:default_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:default_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:default_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/files/terrain/clearer_water/biomes/forest_hills.client_biome.json
+++ b/resource_packs/files/terrain/clearer_water/biomes/forest_hills.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "forest_hills"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#056bd1"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:default_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:default_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:default_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/files/terrain/clearer_water/biomes/frozen_ocean.client_biome.json
+++ b/resource_packs/files/terrain/clearer_water/biomes/frozen_ocean.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "frozen_ocean"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#2570B5"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:default_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:cold_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:default_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/files/terrain/clearer_water/biomes/frozen_peaks.client_biome.json
+++ b/resource_packs/files/terrain/clearer_water/biomes/frozen_peaks.client_biome.json
@@ -1,15 +1,27 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "frozen_peaks"
 		},
 		"components": {
 			"minecraft:fog_appearance": {
-				"fog_identifier": "bt:fog_default"
+				"fog_identifier": "bt:fog_dry"
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#44AFF5"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:default_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:cold_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:default_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/files/terrain/clearer_water/biomes/frozen_river.client_biome.json
+++ b/resource_packs/files/terrain/clearer_water/biomes/frozen_river.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "frozen_river"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#185390"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:default_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:cold_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:default_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/files/terrain/clearer_water/biomes/grove.client_biome.json
+++ b/resource_packs/files/terrain/clearer_water/biomes/grove.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "grove"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#44AFF5"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:default_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:coolish_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:default_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/files/terrain/clearer_water/biomes/hell.client_biome.json
+++ b/resource_packs/files/terrain/clearer_water/biomes/hell.client_biome.json
@@ -1,20 +1,32 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "hell"
 		},
 		"components": {
-			"minecraft:ambient_sounds": {
-				"mood": "ambient.nether_wastes.mood",
-				"addition": "ambient.nether_wastes.additions",
-				"loop": "ambient.nether_wastes.loop"
-			},
 			"minecraft:fog_appearance": {
 				"fog_identifier": "bt:fog_hell"
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#905957"
+			},
+			"minecraft:ambient_sounds": {
+				"addition": "ambient.nether_wastes.additions",
+				"loop": "ambient.nether_wastes.loop",
+				"mood": "ambient.nether_wastes.mood"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:hell_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:default_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:nether_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/files/terrain/clearer_water/biomes/ice_mountains.client_biome.json
+++ b/resource_packs/files/terrain/clearer_water/biomes/ice_mountains.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "ice_mountains"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#1156a7"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:default_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:cold_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:default_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/files/terrain/clearer_water/biomes/ice_plains.client_biome.json
+++ b/resource_packs/files/terrain/clearer_water/biomes/ice_plains.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "ice_plains"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#14559b"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:default_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:cold_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:default_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/files/terrain/clearer_water/biomes/ice_plains_spikes.client_biome.json
+++ b/resource_packs/files/terrain/clearer_water/biomes/ice_plains_spikes.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "ice_plains_spikes"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#14559b"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:ice_plains_spikes_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:ice_plains_spikes_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:ice_plains_spikes_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/files/terrain/clearer_water/biomes/jagged_peaks.client_biome.json
+++ b/resource_packs/files/terrain/clearer_water/biomes/jagged_peaks.client_biome.json
@@ -1,15 +1,27 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "jagged_peaks"
 		},
 		"components": {
 			"minecraft:fog_appearance": {
-				"fog_identifier": "bt:fog_default"
+				"fog_identifier": "bt:fog_dry"
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#44AFF5"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:default_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:coolish_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:default_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/files/terrain/clearer_water/biomes/jungle.client_biome.json
+++ b/resource_packs/files/terrain/clearer_water/biomes/jungle.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "jungle"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#14A2C5"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:warmish_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:warmish_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:warmish_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/files/terrain/clearer_water/biomes/jungle_edge.client_biome.json
+++ b/resource_packs/files/terrain/clearer_water/biomes/jungle_edge.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "jungle_edge"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0D8AE3"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:warmish_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:warmish_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:warmish_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/files/terrain/clearer_water/biomes/jungle_edge_mutated.client_biome.json
+++ b/resource_packs/files/terrain/clearer_water/biomes/jungle_edge_mutated.client_biome.json
@@ -1,15 +1,27 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "jungle_edge_mutated"
 		},
 		"components": {
 			"minecraft:fog_appearance": {
-				"fog_identifier": "bt:fog_default"
+				"fog_identifier": "bt:fog_humid"
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#44AFF5"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:warmish_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:warmish_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:warmish_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/files/terrain/clearer_water/biomes/jungle_hills.client_biome.json
+++ b/resource_packs/files/terrain/clearer_water/biomes/jungle_hills.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "jungle_hills"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#1B9ED8"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:warmish_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:warmish_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:warmish_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/files/terrain/clearer_water/biomes/jungle_mutated.client_biome.json
+++ b/resource_packs/files/terrain/clearer_water/biomes/jungle_mutated.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "jungle_mutated"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#1B9ED8"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:warmish_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:warmish_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:warmish_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/files/terrain/clearer_water/biomes/legacy_frozen_ocean.client_biome.json
+++ b/resource_packs/files/terrain/clearer_water/biomes/legacy_frozen_ocean.client_biome.json
@@ -1,15 +1,27 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "legacy_frozen_ocean"
 		},
 		"components": {
 			"minecraft:fog_appearance": {
-				"fog_identifier": "bt:fog_default"
+				"fog_identifier": "bt:fog_dry"
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#44AFF5"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:default_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:cold_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:default_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/files/terrain/clearer_water/biomes/lukewarm_ocean.client_biome.json
+++ b/resource_packs/files/terrain/clearer_water/biomes/lukewarm_ocean.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "lukewarm_ocean"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0D96DB"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:warmish_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:warmish_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:warmish_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/files/terrain/clearer_water/biomes/lush_caves.client_biome.json
+++ b/resource_packs/files/terrain/clearer_water/biomes/lush_caves.client_biome.json
@@ -1,15 +1,27 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "lush_caves"
 		},
 		"components": {
 			"minecraft:fog_appearance": {
-				"fog_identifier": "bt:fog_default"
+				"fog_identifier": "bt:fog_lush_caves"
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#44AFF5"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:default_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:lush_caves_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:default_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/files/terrain/clearer_water/biomes/mangrove_swamp.client_biome.json
+++ b/resource_packs/files/terrain/clearer_water/biomes/mangrove_swamp.client_biome.json
@@ -1,10 +1,16 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "mangrove_swamp"
 		},
 		"components": {
+			"minecraft:fog_appearance": {
+				"fog_identifier": "bt:fog_mangrove_swamp"
+			},
+			"minecraft:water_appearance": {
+				"surface_color": "#3a7a6a"
+			},
 			"minecraft:foliage_appearance": {
 				"color": {
 					"color_map": "mangrove_swamp_foliage"
@@ -15,11 +21,20 @@
 					"color_map": "swamp_grass"
 				}
 			},
-			"minecraft:fog_appearance": {
-				"fog_identifier": "bt:fog_mangrove_swamp"
+			"minecraft:dry_foliage_color": {
+				"color": "#7B5334"
 			},
-			"minecraft:water_appearance": {
-				"surface_color": "#3a7a6a"
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:mangrove_swamp_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:mangrove_swamp_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:mangrove_swamp_lighting"
+			},
+			"minecraft:biome_music": {
+				"music_definition": "mangrove_swamp"
 			}
 		}
 	}

--- a/resource_packs/files/terrain/clearer_water/biomes/meadow.client_biome.json
+++ b/resource_packs/files/terrain/clearer_water/biomes/meadow.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "meadow"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#44AFF5"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:default_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:default_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:default_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/files/terrain/clearer_water/biomes/mega_taiga.client_biome.json
+++ b/resource_packs/files/terrain/clearer_water/biomes/mega_taiga.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "mega_taiga"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#2d6d77"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:default_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:coolish_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:default_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/files/terrain/clearer_water/biomes/mega_taiga_hills.client_biome.json
+++ b/resource_packs/files/terrain/clearer_water/biomes/mega_taiga_hills.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "mega_taiga_hills"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#286378"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:default_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:coolish_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:default_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/files/terrain/clearer_water/biomes/mesa.client_biome.json
+++ b/resource_packs/files/terrain/clearer_water/biomes/mesa.client_biome.json
@@ -1,21 +1,33 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "mesa"
 		},
 		"components": {
+			"minecraft:fog_appearance": {
+				"fog_identifier": "bt:fog_mesa"
+			},
+			"minecraft:water_appearance": {
+				"surface_color": "#4E7F81"
+			},
 			"minecraft:foliage_appearance": {
 				"color": "#aea42a"
 			},
 			"minecraft:grass_appearance": {
 				"color": "#90814d"
 			},
-			"minecraft:fog_appearance": {
-				"fog_identifier": "bt:fog_mesa"
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:mesa_atmospherics"
 			},
-			"minecraft:water_appearance": {
-				"surface_color": "#4E7F81"
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:mesa_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:mesa_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/files/terrain/clearer_water/biomes/mesa_bryce.client_biome.json
+++ b/resource_packs/files/terrain/clearer_water/biomes/mesa_bryce.client_biome.json
@@ -1,21 +1,33 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "mesa_bryce"
 		},
 		"components": {
+			"minecraft:fog_appearance": {
+				"fog_identifier": "bt:fog_mesa_bryce"
+			},
+			"minecraft:water_appearance": {
+				"surface_color": "#497F99"
+			},
 			"minecraft:foliage_appearance": {
 				"color": "#aea42a"
 			},
 			"minecraft:grass_appearance": {
 				"color": "#90814d"
 			},
-			"minecraft:fog_appearance": {
-				"fog_identifier": "bt:fog_mesa_bryce"
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:mesa_atmospherics"
 			},
-			"minecraft:water_appearance": {
-				"surface_color": "#497F99"
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:mesa_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:mesa_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/files/terrain/clearer_water/biomes/mesa_plateau.client_biome.json
+++ b/resource_packs/files/terrain/clearer_water/biomes/mesa_plateau.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "mesa_plateau"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#55809E"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:mesa_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:mesa_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:mesa_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/files/terrain/clearer_water/biomes/mesa_plateau_mutated.client_biome.json
+++ b/resource_packs/files/terrain/clearer_water/biomes/mesa_plateau_mutated.client_biome.json
@@ -1,21 +1,33 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "mesa_plateau_mutated"
 		},
 		"components": {
+			"minecraft:fog_appearance": {
+				"fog_identifier": "bt:fog_dry"
+			},
+			"minecraft:water_appearance": {
+				"surface_color": "#44AFF5"
+			},
 			"minecraft:foliage_appearance": {
 				"color": "#aea42a"
 			},
 			"minecraft:grass_appearance": {
 				"color": "#90814d"
 			},
-			"minecraft:fog_appearance": {
-				"fog_identifier": "bt:fog_default"
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:mesa_atmospherics"
 			},
-			"minecraft:water_appearance": {
-				"surface_color": "#44AFF5"
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:mesa_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:mesa_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/files/terrain/clearer_water/biomes/mesa_plateau_stone.client_biome.json
+++ b/resource_packs/files/terrain/clearer_water/biomes/mesa_plateau_stone.client_biome.json
@@ -1,21 +1,33 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "mesa_plateau_stone"
 		},
 		"components": {
+			"minecraft:fog_appearance": {
+				"fog_identifier": "bt:fog_mesa_plateau_stone"
+			},
+			"minecraft:water_appearance": {
+				"surface_color": "#55809E"
+			},
 			"minecraft:foliage_appearance": {
 				"color": "#aea42a"
 			},
 			"minecraft:grass_appearance": {
 				"color": "#90814d"
 			},
-			"minecraft:fog_appearance": {
-				"fog_identifier": "bt:fog_mesa_plateau_stone"
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:mesa_atmospherics"
 			},
-			"minecraft:water_appearance": {
-				"surface_color": "#55809E"
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:mesa_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:mesa_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/files/terrain/clearer_water/biomes/mesa_plateau_stone_mutated.client_biome.json
+++ b/resource_packs/files/terrain/clearer_water/biomes/mesa_plateau_stone_mutated.client_biome.json
@@ -1,21 +1,33 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "mesa_plateau_stone_mutated"
 		},
 		"components": {
+			"minecraft:fog_appearance": {
+				"fog_identifier": "bt:fog_dry"
+			},
+			"minecraft:water_appearance": {
+				"surface_color": "#44AFF5"
+			},
 			"minecraft:foliage_appearance": {
 				"color": "#aea42a"
 			},
 			"minecraft:grass_appearance": {
 				"color": "#90814d"
 			},
-			"minecraft:fog_appearance": {
-				"fog_identifier": "bt:fog_default"
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:mesa_atmospherics"
 			},
-			"minecraft:water_appearance": {
-				"surface_color": "#44AFF5"
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:mesa_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:mesa_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/files/terrain/clearer_water/biomes/mushroom_island.client_biome.json
+++ b/resource_packs/files/terrain/clearer_water/biomes/mushroom_island.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "mushroom_island"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#8a8997"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:mushroom_island_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:mushroom_island_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:mushroom_island_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/files/terrain/clearer_water/biomes/mushroom_island_shore.client_biome.json
+++ b/resource_packs/files/terrain/clearer_water/biomes/mushroom_island_shore.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "mushroom_island_shore"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#818193"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:mushroom_island_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:mushroom_island_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:mushroom_island_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/files/terrain/clearer_water/biomes/ocean.client_biome.json
+++ b/resource_packs/files/terrain/clearer_water/biomes/ocean.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "ocean"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#1787D4"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:default_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:default_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:default_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/files/terrain/clearer_water/biomes/pale_garden.client_biome.json
+++ b/resource_packs/files/terrain/clearer_water/biomes/pale_garden.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "pale_garden"
@@ -22,6 +22,18 @@
 			},
 			"minecraft:grass_appearance": {
 				"color": "#778272"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:pale_garden_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:coolish_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:pale_garden_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/files/terrain/clearer_water/biomes/plains.client_biome.json
+++ b/resource_packs/files/terrain/clearer_water/biomes/plains.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "plains"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#44AFF5"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:default_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:default_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:default_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/files/terrain/clearer_water/biomes/redwood_taiga_hills_mutated.client_biome.json
+++ b/resource_packs/files/terrain/clearer_water/biomes/redwood_taiga_hills_mutated.client_biome.json
@@ -1,15 +1,27 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "redwood_taiga_hills_mutated"
 		},
 		"components": {
 			"minecraft:fog_appearance": {
-				"fog_identifier": "bt:fog_default"
+				"fog_identifier": "bt:fog_semi_humid"
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#44AFF5"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:default_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:coolish_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:default_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/files/terrain/clearer_water/biomes/redwood_taiga_mutated.client_biome.json
+++ b/resource_packs/files/terrain/clearer_water/biomes/redwood_taiga_mutated.client_biome.json
@@ -1,15 +1,27 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "redwood_taiga_mutated"
 		},
 		"components": {
 			"minecraft:fog_appearance": {
-				"fog_identifier": "bt:fog_default"
+				"fog_identifier": "bt:fog_semi_humid"
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#44AFF5"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:default_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:coolish_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:default_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/files/terrain/clearer_water/biomes/river.client_biome.json
+++ b/resource_packs/files/terrain/clearer_water/biomes/river.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "river"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0084FF"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:default_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:default_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:default_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/files/terrain/clearer_water/biomes/roofed_forest.client_biome.json
+++ b/resource_packs/files/terrain/clearer_water/biomes/roofed_forest.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "roofed_forest"
@@ -10,6 +10,21 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#3B6CD1"
+			},
+			"minecraft:dry_foliage_color": {
+				"color": "#7B5334"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:default_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:default_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:default_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/files/terrain/clearer_water/biomes/roofed_forest_mutated.client_biome.json
+++ b/resource_packs/files/terrain/clearer_water/biomes/roofed_forest_mutated.client_biome.json
@@ -1,15 +1,30 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "roofed_forest_mutated"
 		},
 		"components": {
 			"minecraft:fog_appearance": {
-				"fog_identifier": "bt:fog_default"
+				"fog_identifier": "bt:fog_semi_humid"
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#44AFF5"
+			},
+			"minecraft:dry_foliage_color": {
+				"color": "#7B5334"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:default_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:default_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:default_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/files/terrain/clearer_water/biomes/savanna.client_biome.json
+++ b/resource_packs/files/terrain/clearer_water/biomes/savanna.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "savanna"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#2C8B9C"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:warmish_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:warmish_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:warmish_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/files/terrain/clearer_water/biomes/savanna_mutated.client_biome.json
+++ b/resource_packs/files/terrain/clearer_water/biomes/savanna_mutated.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "savanna_mutated"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#2590A8"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:warmish_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:warmish_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:warmish_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/files/terrain/clearer_water/biomes/savanna_plateau.client_biome.json
+++ b/resource_packs/files/terrain/clearer_water/biomes/savanna_plateau.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "savanna_plateau"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#2590A8"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:warmish_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:warmish_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:warmish_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/files/terrain/clearer_water/biomes/savanna_plateau_mutated.client_biome.json
+++ b/resource_packs/files/terrain/clearer_water/biomes/savanna_plateau_mutated.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "savanna_plateau_mutated"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#44AFF5"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:warmish_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:warmish_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:warmish_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/files/terrain/clearer_water/biomes/snowy_slopes.client_biome.json
+++ b/resource_packs/files/terrain/clearer_water/biomes/snowy_slopes.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "snowy_slopes"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#44AFF5"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:default_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:coolish_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:default_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/files/terrain/clearer_water/biomes/soulsand_valley.client_biome.json
+++ b/resource_packs/files/terrain/clearer_water/biomes/soulsand_valley.client_biome.json
@@ -1,20 +1,32 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "soulsand_valley"
 		},
 		"components": {
-			"minecraft:ambient_sounds": {
-				"mood": "ambient.soulsand_valley.mood",
-				"addition": "ambient.soulsand_valley.additions",
-				"loop": "ambient.soulsand_valley.loop"
-			},
 			"minecraft:fog_appearance": {
 				"fog_identifier": "bt:fog_soulsand_valley"
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#905957"
+			},
+			"minecraft:ambient_sounds": {
+				"addition": "ambient.soulsand_valley.additions",
+				"loop": "ambient.soulsand_valley.loop",
+				"mood": "ambient.soulsand_valley.mood"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:soulsand_valley_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:default_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:nether_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/files/terrain/clearer_water/biomes/stone_beach.client_biome.json
+++ b/resource_packs/files/terrain/clearer_water/biomes/stone_beach.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "stone_beach"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#0d67bb"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:default_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:default_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:default_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/files/terrain/clearer_water/biomes/stony_peaks.client_biome.json
+++ b/resource_packs/files/terrain/clearer_water/biomes/stony_peaks.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "stony_peaks"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#44AFF5"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:warmish_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:warmish_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:warmish_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/files/terrain/clearer_water/biomes/sunflower_plains.client_biome.json
+++ b/resource_packs/files/terrain/clearer_water/biomes/sunflower_plains.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "sunflower_plains"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#44AFF5"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:default_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:default_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:default_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/files/terrain/clearer_water/biomes/swampland.client_biome.json
+++ b/resource_packs/files/terrain/clearer_water/biomes/swampland.client_biome.json
@@ -1,10 +1,17 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "swampland"
 		},
 		"components": {
+			"minecraft:fog_appearance": {
+				"fog_identifier": "bt:fog_swampland"
+			},
+			"minecraft:water_appearance": {
+				"surface_color": "#4c6559",
+				"surface_opacity": 1.0
+			},
 			"minecraft:foliage_appearance": {
 				"color": {
 					"color_map": "swamp_foliage"
@@ -15,12 +22,20 @@
 					"color_map": "swamp_grass"
 				}
 			},
-			"minecraft:fog_appearance": {
-				"fog_identifier": "bt:fog_swampland"
+			"minecraft:dry_foliage_color": {
+				"color": "#7B5334"
 			},
-			"minecraft:water_appearance": {
-				"surface_color": "#4c6559",
-				"surface_opacity": 1.0
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:swampland_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:swampland_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:swampland_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/files/terrain/clearer_water/biomes/swampland_mutated.client_biome.json
+++ b/resource_packs/files/terrain/clearer_water/biomes/swampland_mutated.client_biome.json
@@ -1,10 +1,17 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "swampland_mutated"
 		},
 		"components": {
+			"minecraft:fog_appearance": {
+				"fog_identifier": "bt:fog_swampland_mutated"
+			},
+			"minecraft:water_appearance": {
+				"surface_color": "#4c6156",
+				"surface_opacity": 1.0
+			},
 			"minecraft:foliage_appearance": {
 				"color": {
 					"color_map": "swamp_foliage"
@@ -15,12 +22,20 @@
 					"color_map": "swamp_grass"
 				}
 			},
-			"minecraft:fog_appearance": {
-				"fog_identifier": "bt:fog_swampland_mutated"
+			"minecraft:dry_foliage_color": {
+				"color": "#7B5334"
 			},
-			"minecraft:water_appearance": {
-				"surface_color": "#4c6156",
-				"surface_opacity": 1.0
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:swampland_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:swampland_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:swampland_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/files/terrain/clearer_water/biomes/taiga.client_biome.json
+++ b/resource_packs/files/terrain/clearer_water/biomes/taiga.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "taiga"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#287082"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:default_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:coolish_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:default_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/files/terrain/clearer_water/biomes/taiga_hills.client_biome.json
+++ b/resource_packs/files/terrain/clearer_water/biomes/taiga_hills.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "taiga_hills"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#236583"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:default_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:coolish_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:default_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/files/terrain/clearer_water/biomes/taiga_mutated.client_biome.json
+++ b/resource_packs/files/terrain/clearer_water/biomes/taiga_mutated.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "taiga_mutated"
@@ -10,6 +10,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#1E6B82"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:default_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:coolish_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:default_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/files/terrain/clearer_water/biomes/the_end.client_biome.json
+++ b/resource_packs/files/terrain/clearer_water/biomes/the_end.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "the_end"
@@ -13,6 +13,18 @@
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#62529e"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:end_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:default_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:end_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/files/terrain/clearer_water/biomes/warm_ocean.client_biome.json
+++ b/resource_packs/files/terrain/clearer_water/biomes/warm_ocean.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "warm_ocean"
@@ -11,6 +11,18 @@
 			"minecraft:water_appearance": {
 				"surface_color": "#02B0E5",
 				"surface_opacity": 0.55
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:warmish_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:warmish_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:warmish_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/files/terrain/clearer_water/biomes/warped_forest.client_biome.json
+++ b/resource_packs/files/terrain/clearer_water/biomes/warped_forest.client_biome.json
@@ -1,20 +1,32 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "warped_forest"
 		},
 		"components": {
-			"minecraft:ambient_sounds": {
-				"mood": "ambient.warped_forest.mood",
-				"addition": "ambient.warped_forest.additions",
-				"loop": "ambient.warped_forest.loop"
-			},
 			"minecraft:fog_appearance": {
 				"fog_identifier": "bt:fog_warped_forest"
 			},
 			"minecraft:water_appearance": {
 				"surface_color": "#905957"
+			},
+			"minecraft:ambient_sounds": {
+				"addition": "ambient.warped_forest.additions",
+				"loop": "ambient.warped_forest.loop",
+				"mood": "ambient.warped_forest.mood"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:warped_forest_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:default_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:nether_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/files/terrain/clearer_water/fogs/bamboo_jungle_fog_setting.json
+++ b/resource_packs/files/terrain/clearer_water/fogs/bamboo_jungle_fog_setting.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.16.100",
+	"format_version": "1.21.90",
 	"minecraft:fog_settings": {
 		"description": {
 			"identifier": "bt:fog_bamboo_jungle"
@@ -10,6 +10,34 @@
 				"fog_end": 64.0,
 				"fog_color": "#14A2C5",
 				"render_distance_type": "fixed"
+			}
+		},
+		"volumetric": {
+			"density": {
+				"air": {
+					"max_density": 0.05,
+					"zero_density_height": 320.0,
+					"max_density_height": 320.0
+				}
+			},
+			"media_coefficients": {
+				"air": {
+					"scattering": [
+						0.06,
+						0.06,
+						0.06
+					],
+					"absorption": [
+						0.0,
+						0.0,
+						0.0
+					]
+				}
+			},
+			"henyey_greenstein_g": {
+				"air": {
+					"henyey_greenstein_g": 0.4
+				}
 			}
 		}
 	}

--- a/resource_packs/files/terrain/clearer_water/fogs/bamboo_jungle_hills_fog_setting.json
+++ b/resource_packs/files/terrain/clearer_water/fogs/bamboo_jungle_hills_fog_setting.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.16.100",
+	"format_version": "1.21.90",
 	"minecraft:fog_settings": {
 		"description": {
 			"identifier": "bt:fog_bamboo_jungle_hills"
@@ -10,6 +10,34 @@
 				"fog_end": 64.0,
 				"fog_color": "#1B9ED8",
 				"render_distance_type": "fixed"
+			}
+		},
+		"volumetric": {
+			"density": {
+				"air": {
+					"max_density": 0.05,
+					"zero_density_height": 320.0,
+					"max_density_height": 320.0
+				}
+			},
+			"media_coefficients": {
+				"air": {
+					"scattering": [
+						0.06,
+						0.06,
+						0.06
+					],
+					"absorption": [
+						0.0,
+						0.0,
+						0.0
+					]
+				}
+			},
+			"henyey_greenstein_g": {
+				"air": {
+					"henyey_greenstein_g": 0.4
+				}
 			}
 		}
 	}

--- a/resource_packs/files/terrain/clearer_water/fogs/beach_fog_setting.json
+++ b/resource_packs/files/terrain/clearer_water/fogs/beach_fog_setting.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.16.100",
+	"format_version": "1.21.90",
 	"minecraft:fog_settings": {
 		"description": {
 			"identifier": "bt:fog_beach"
@@ -10,6 +10,34 @@
 				"fog_end": 64.0,
 				"fog_color": "#157cab",
 				"render_distance_type": "fixed"
+			}
+		},
+		"volumetric": {
+			"density": {
+				"air": {
+					"max_density": 0.05,
+					"zero_density_height": 320.0,
+					"max_density_height": 320.0
+				}
+			},
+			"media_coefficients": {
+				"air": {
+					"scattering": [
+						0.04,
+						0.04,
+						0.04
+					],
+					"absorption": [
+						0.0,
+						0.0,
+						0.0
+					]
+				}
+			},
+			"henyey_greenstein_g": {
+				"air": {
+					"henyey_greenstein_g": 0.6
+				}
 			}
 		}
 	}

--- a/resource_packs/files/terrain/clearer_water/fogs/cold_taiga_fog_setting.json
+++ b/resource_packs/files/terrain/clearer_water/fogs/cold_taiga_fog_setting.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.16.100",
+	"format_version": "1.21.90",
 	"minecraft:fog_settings": {
 		"description": {
 			"identifier": "bt:fog_cold_taiga"
@@ -10,6 +10,34 @@
 				"fog_end": 64.0,
 				"fog_color": "#205e83",
 				"render_distance_type": "fixed"
+			}
+		},
+		"volumetric": {
+			"density": {
+				"air": {
+					"max_density": 0.05,
+					"zero_density_height": 320.0,
+					"max_density_height": 320.0
+				}
+			},
+			"media_coefficients": {
+				"air": {
+					"scattering": [
+						0.04,
+						0.04,
+						0.04
+					],
+					"absorption": [
+						0.0,
+						0.0,
+						0.0
+					]
+				}
+			},
+			"henyey_greenstein_g": {
+				"air": {
+					"henyey_greenstein_g": 0.6
+				}
 			}
 		}
 	}

--- a/resource_packs/files/terrain/clearer_water/fogs/cold_taiga_hills_fog_setting.json
+++ b/resource_packs/files/terrain/clearer_water/fogs/cold_taiga_hills_fog_setting.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.16.100",
+	"format_version": "1.21.90",
 	"minecraft:fog_settings": {
 		"description": {
 			"identifier": "bt:fog_cold_taiga_hills"
@@ -10,6 +10,34 @@
 				"fog_end": 64.0,
 				"fog_color": "#245b78",
 				"render_distance_type": "fixed"
+			}
+		},
+		"volumetric": {
+			"density": {
+				"air": {
+					"max_density": 0.05,
+					"zero_density_height": 320.0,
+					"max_density_height": 320.0
+				}
+			},
+			"media_coefficients": {
+				"air": {
+					"scattering": [
+						0.04,
+						0.04,
+						0.04
+					],
+					"absorption": [
+						0.0,
+						0.0,
+						0.0
+					]
+				}
+			},
+			"henyey_greenstein_g": {
+				"air": {
+					"henyey_greenstein_g": 0.6
+				}
 			}
 		}
 	}

--- a/resource_packs/files/terrain/clearer_water/fogs/cold_taiga_mutated_fog_setting.json
+++ b/resource_packs/files/terrain/clearer_water/fogs/cold_taiga_mutated_fog_setting.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.16.100",
+	"format_version": "1.21.90",
 	"minecraft:fog_settings": {
 		"description": {
 			"identifier": "bt:fog_cold_taiga_mutated"
@@ -10,6 +10,34 @@
 				"fog_end": 64.0,
 				"fog_color": "#205e83",
 				"render_distance_type": "fixed"
+			}
+		},
+		"volumetric": {
+			"density": {
+				"air": {
+					"max_density": 0.05,
+					"zero_density_height": 320.0,
+					"max_density_height": 320.0
+				}
+			},
+			"media_coefficients": {
+				"air": {
+					"scattering": [
+						0.04,
+						0.04,
+						0.04
+					],
+					"absorption": [
+						0.0,
+						0.0,
+						0.0
+					]
+				}
+			},
+			"henyey_greenstein_g": {
+				"air": {
+					"henyey_greenstein_g": 0.6
+				}
 			}
 		}
 	}

--- a/resource_packs/files/terrain/clearer_water/fogs/deep_frozen_ocean_fog_setting.json
+++ b/resource_packs/files/terrain/clearer_water/fogs/deep_frozen_ocean_fog_setting.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.16.100",
+	"format_version": "1.21.90",
 	"minecraft:fog_settings": {
 		"description": {
 			"identifier": "bt:fog_deep_frozen_ocean"
@@ -10,6 +10,34 @@
 				"fog_end": 64.0,
 				"fog_color": "#1a4879",
 				"render_distance_type": "fixed"
+			}
+		},
+		"volumetric": {
+			"density": {
+				"air": {
+					"max_density": 0.0,
+					"zero_density_height": 320.0,
+					"max_density_height": 320.0
+				}
+			},
+			"media_coefficients": {
+				"air": {
+					"scattering": [
+						0.0,
+						0.0,
+						0.0
+					],
+					"absorption": [
+						0.0,
+						0.0,
+						0.0
+					]
+				}
+			},
+			"henyey_greenstein_g": {
+				"air": {
+					"henyey_greenstein_g": 0.75
+				}
 			}
 		}
 	}

--- a/resource_packs/files/terrain/clearer_water/fogs/deep_lukewarm_ocean_fog_setting.json
+++ b/resource_packs/files/terrain/clearer_water/fogs/deep_lukewarm_ocean_fog_setting.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.16.100",
+	"format_version": "1.21.90",
 	"minecraft:fog_settings": {
 		"description": {
 			"identifier": "bt:fog_deep_lukewarm_ocean"
@@ -10,6 +10,34 @@
 				"fog_end": 64.0,
 				"fog_color": "#0e72b9",
 				"render_distance_type": "fixed"
+			}
+		},
+		"volumetric": {
+			"density": {
+				"air": {
+					"max_density": 0.05,
+					"zero_density_height": 320.0,
+					"max_density_height": 320.0
+				}
+			},
+			"media_coefficients": {
+				"air": {
+					"scattering": [
+						0.04,
+						0.04,
+						0.04
+					],
+					"absorption": [
+						0.0,
+						0.0,
+						0.0
+					]
+				}
+			},
+			"henyey_greenstein_g": {
+				"air": {
+					"henyey_greenstein_g": 0.6
+				}
 			}
 		}
 	}

--- a/resource_packs/files/terrain/clearer_water/fogs/deep_warm_ocean_fog_setting.json
+++ b/resource_packs/files/terrain/clearer_water/fogs/deep_warm_ocean_fog_setting.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.16.100",
+	"format_version": "1.21.90",
 	"minecraft:fog_settings": {
 		"description": {
 			"identifier": "bt:fog_deep_warm_ocean"
@@ -10,6 +10,34 @@
 				"fog_end": 64.0,
 				"fog_color": "#0686ca",
 				"render_distance_type": "fixed"
+			}
+		},
+		"volumetric": {
+			"density": {
+				"air": {
+					"max_density": 0.05,
+					"zero_density_height": 320.0,
+					"max_density_height": 320.0
+				}
+			},
+			"media_coefficients": {
+				"air": {
+					"scattering": [
+						0.04,
+						0.04,
+						0.04
+					],
+					"absorption": [
+						0.0,
+						0.0,
+						0.0
+					]
+				}
+			},
+			"henyey_greenstein_g": {
+				"air": {
+					"henyey_greenstein_g": 0.6
+				}
 			}
 		}
 	}

--- a/resource_packs/files/terrain/clearer_water/fogs/desert_fog_setting.json
+++ b/resource_packs/files/terrain/clearer_water/fogs/desert_fog_setting.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.16.100",
+	"format_version": "1.21.90",
 	"minecraft:fog_settings": {
 		"description": {
 			"identifier": "bt:fog_desert"
@@ -10,6 +10,34 @@
 				"fog_end": 64.0,
 				"fog_color": "#32A598",
 				"render_distance_type": "fixed"
+			}
+		},
+		"volumetric": {
+			"density": {
+				"air": {
+					"max_density": 0.0,
+					"zero_density_height": 320.0,
+					"max_density_height": 320.0
+				}
+			},
+			"media_coefficients": {
+				"air": {
+					"scattering": [
+						0.0,
+						0.0,
+						0.0
+					],
+					"absorption": [
+						0.0,
+						0.0,
+						0.0
+					]
+				}
+			},
+			"henyey_greenstein_g": {
+				"air": {
+					"henyey_greenstein_g": 0.75
+				}
 			}
 		}
 	}

--- a/resource_packs/files/terrain/clearer_water/fogs/desert_hills_fog_setting.json
+++ b/resource_packs/files/terrain/clearer_water/fogs/desert_hills_fog_setting.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.16.100",
+	"format_version": "1.21.90",
 	"minecraft:fog_settings": {
 		"description": {
 			"identifier": "bt:fog_desert_hills"
@@ -10,6 +10,34 @@
 				"fog_end": 64.0,
 				"fog_color": "#1a7aa1",
 				"render_distance_type": "fixed"
+			}
+		},
+		"volumetric": {
+			"density": {
+				"air": {
+					"max_density": 0.0,
+					"zero_density_height": 320.0,
+					"max_density_height": 320.0
+				}
+			},
+			"media_coefficients": {
+				"air": {
+					"scattering": [
+						0.0,
+						0.0,
+						0.0
+					],
+					"absorption": [
+						0.0,
+						0.0,
+						0.0
+					]
+				}
+			},
+			"henyey_greenstein_g": {
+				"air": {
+					"henyey_greenstein_g": 0.75
+				}
 			}
 		}
 	}

--- a/resource_packs/files/terrain/clearer_water/fogs/dry_fog_setting.json
+++ b/resource_packs/files/terrain/clearer_water/fogs/dry_fog_setting.json
@@ -1,0 +1,68 @@
+{
+	"format_version": "1.21.90",
+	"minecraft:fog_settings": {
+		"description": {
+			"identifier": "bt:fog_dry"
+		},
+		"distance": {
+			"air": {
+				"fog_start": 0.92,
+				"fog_end": 1.0,
+				"fog_color": "#ABD2FF",
+				"render_distance_type": "render"
+			},
+			"water": {
+				"fog_start": 32.0,
+				"fog_end": 64.0,
+				"fog_color": "#44AFF5",
+				"render_distance_type": "fixed"
+			},
+			"weather": {
+				"fog_start": 0.23,
+				"fog_end": 0.7,
+				"fog_color": "#666666",
+				"render_distance_type": "render"
+			},
+			"lava": {
+				"fog_start": 0.0,
+				"fog_end": 0.64,
+				"fog_color": "#991A00",
+				"render_distance_type": "fixed"
+			},
+			"lava_resistance": {
+				"fog_start": 2.0,
+				"fog_end": 4.0,
+				"fog_color": "#991A00",
+				"render_distance_type": "fixed"
+			}
+		},
+		"volumetric": {
+			"density": {
+				"air": {
+					"max_density": 0.0,
+					"zero_density_height": 320.0,
+					"max_density_height": 320.0
+				}
+			},
+			"media_coefficients": {
+				"air": {
+					"scattering": [
+						0.0,
+						0.0,
+						0.0
+					],
+					"absorption": [
+						0.0,
+						0.0,
+						0.0
+					]
+				}
+			},
+			"henyey_greenstein_g": {
+				"air": {
+					"henyey_greenstein_g": 0.75
+				}
+			}
+		}
+	}
+}

--- a/resource_packs/files/terrain/clearer_water/fogs/extreme_hills_plus_trees_fog_setting.json
+++ b/resource_packs/files/terrain/clearer_water/fogs/extreme_hills_plus_trees_fog_setting.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.16.100",
+	"format_version": "1.21.90",
 	"minecraft:fog_settings": {
 		"description": {
 			"identifier": "bt:fog_extreme_hills_plus_trees"
@@ -10,6 +10,34 @@
 				"fog_end": 64.0,
 				"fog_color": "#0E63AB",
 				"render_distance_type": "fixed"
+			}
+		},
+		"volumetric": {
+			"density": {
+				"air": {
+					"max_density": 0.05,
+					"zero_density_height": 320.0,
+					"max_density_height": 320.0
+				}
+			},
+			"media_coefficients": {
+				"air": {
+					"scattering": [
+						0.04,
+						0.04,
+						0.04
+					],
+					"absorption": [
+						0.0,
+						0.0,
+						0.0
+					]
+				}
+			},
+			"henyey_greenstein_g": {
+				"air": {
+					"henyey_greenstein_g": 0.6
+				}
 			}
 		}
 	}

--- a/resource_packs/files/terrain/clearer_water/fogs/extreme_hills_plus_trees_mutated_fog_setting.json
+++ b/resource_packs/files/terrain/clearer_water/fogs/extreme_hills_plus_trees_mutated_fog_setting.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.16.100",
+	"format_version": "1.21.90",
 	"minecraft:fog_settings": {
 		"description": {
 			"identifier": "bt:fog_extreme_hills_plus_trees_mutated"
@@ -10,6 +10,34 @@
 				"fog_end": 64.0,
 				"fog_color": "#0E63AB",
 				"render_distance_type": "fixed"
+			}
+		},
+		"volumetric": {
+			"density": {
+				"air": {
+					"max_density": 0.05,
+					"zero_density_height": 320.0,
+					"max_density_height": 320.0
+				}
+			},
+			"media_coefficients": {
+				"air": {
+					"scattering": [
+						0.04,
+						0.04,
+						0.04
+					],
+					"absorption": [
+						0.0,
+						0.0,
+						0.0
+					]
+				}
+			},
+			"henyey_greenstein_g": {
+				"air": {
+					"henyey_greenstein_g": 0.6
+				}
 			}
 		}
 	}

--- a/resource_packs/files/terrain/clearer_water/fogs/flower_forest_fog_setting.json
+++ b/resource_packs/files/terrain/clearer_water/fogs/flower_forest_fog_setting.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.16.100",
+	"format_version": "1.21.90",
 	"minecraft:fog_settings": {
 		"description": {
 			"identifier": "bt:fog_flower_forest"
@@ -10,6 +10,34 @@
 				"fog_end": 64.0,
 				"fog_color": "#20A3CC",
 				"render_distance_type": "fixed"
+			}
+		},
+		"volumetric": {
+			"density": {
+				"air": {
+					"max_density": 0.0,
+					"zero_density_height": 320.0,
+					"max_density_height": 320.0
+				}
+			},
+			"media_coefficients": {
+				"air": {
+					"scattering": [
+						0.0,
+						0.0,
+						0.0
+					],
+					"absorption": [
+						0.0,
+						0.0,
+						0.0
+					]
+				}
+			},
+			"henyey_greenstein_g": {
+				"air": {
+					"henyey_greenstein_g": 0.75
+				}
 			}
 		}
 	}

--- a/resource_packs/files/terrain/clearer_water/fogs/frozen_ocean_fog_setting.json
+++ b/resource_packs/files/terrain/clearer_water/fogs/frozen_ocean_fog_setting.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.16.100",
+	"format_version": "1.21.90",
 	"minecraft:fog_settings": {
 		"description": {
 			"identifier": "bt:fog_frozen_ocean"
@@ -10,6 +10,34 @@
 				"fog_end": 64.0,
 				"fog_color": "#174985",
 				"render_distance_type": "fixed"
+			}
+		},
+		"volumetric": {
+			"density": {
+				"air": {
+					"max_density": 0.0,
+					"zero_density_height": 320.0,
+					"max_density_height": 320.0
+				}
+			},
+			"media_coefficients": {
+				"air": {
+					"scattering": [
+						0.0,
+						0.0,
+						0.0
+					],
+					"absorption": [
+						0.0,
+						0.0,
+						0.0
+					]
+				}
+			},
+			"henyey_greenstein_g": {
+				"air": {
+					"henyey_greenstein_g": 0.75
+				}
 			}
 		}
 	}

--- a/resource_packs/files/terrain/clearer_water/fogs/frozen_river_fog_setting.json
+++ b/resource_packs/files/terrain/clearer_water/fogs/frozen_river_fog_setting.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.16.100",
+	"format_version": "1.21.90",
 	"minecraft:fog_settings": {
 		"description": {
 			"identifier": "bt:fog_frozen_river"
@@ -10,6 +10,34 @@
 				"fog_end": 64.0,
 				"fog_color": "#185390",
 				"render_distance_type": "fixed"
+			}
+		},
+		"volumetric": {
+			"density": {
+				"air": {
+					"max_density": 0.0,
+					"zero_density_height": 320.0,
+					"max_density_height": 320.0
+				}
+			},
+			"media_coefficients": {
+				"air": {
+					"scattering": [
+						0.0,
+						0.0,
+						0.0
+					],
+					"absorption": [
+						0.0,
+						0.0,
+						0.0
+					]
+				}
+			},
+			"henyey_greenstein_g": {
+				"air": {
+					"henyey_greenstein_g": 0.75
+				}
 			}
 		}
 	}

--- a/resource_packs/files/terrain/clearer_water/fogs/humid_fog_setting.json
+++ b/resource_packs/files/terrain/clearer_water/fogs/humid_fog_setting.json
@@ -1,0 +1,68 @@
+{
+	"format_version": "1.21.90",
+	"minecraft:fog_settings": {
+		"description": {
+			"identifier": "bt:fog_humid"
+		},
+		"distance": {
+			"air": {
+				"fog_start": 0.92,
+				"fog_end": 1.0,
+				"fog_color": "#ABD2FF",
+				"render_distance_type": "render"
+			},
+			"water": {
+				"fog_start": 32.0,
+				"fog_end": 64.0,
+				"fog_color": "#44AFF5",
+				"render_distance_type": "fixed"
+			},
+			"weather": {
+				"fog_start": 0.23,
+				"fog_end": 0.7,
+				"fog_color": "#666666",
+				"render_distance_type": "render"
+			},
+			"lava": {
+				"fog_start": 0.0,
+				"fog_end": 0.64,
+				"fog_color": "#991A00",
+				"render_distance_type": "fixed"
+			},
+			"lava_resistance": {
+				"fog_start": 2.0,
+				"fog_end": 4.0,
+				"fog_color": "#991A00",
+				"render_distance_type": "fixed"
+			}
+		},
+		"volumetric": {
+			"density": {
+				"air": {
+					"max_density": 0.05,
+					"zero_density_height": 320.0,
+					"max_density_height": 320.0
+				}
+			},
+			"media_coefficients": {
+				"air": {
+					"scattering": [
+						0.06,
+						0.06,
+						0.06
+					],
+					"absorption": [
+						0.0,
+						0.0,
+						0.0
+					]
+				}
+			},
+			"henyey_greenstein_g": {
+				"air": {
+					"henyey_greenstein_g": 0.4
+				}
+			}
+		}
+	}
+}

--- a/resource_packs/files/terrain/clearer_water/fogs/ice_mountains_fog_setting.json
+++ b/resource_packs/files/terrain/clearer_water/fogs/ice_mountains_fog_setting.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.16.100",
+	"format_version": "1.21.90",
 	"minecraft:fog_settings": {
 		"description": {
 			"identifier": "bt:fog_ice_mountains"
@@ -10,6 +10,34 @@
 				"fog_end": 64.0,
 				"fog_color": "#1156a7",
 				"render_distance_type": "fixed"
+			}
+		},
+		"volumetric": {
+			"density": {
+				"air": {
+					"max_density": 0.0,
+					"zero_density_height": 320.0,
+					"max_density_height": 320.0
+				}
+			},
+			"media_coefficients": {
+				"air": {
+					"scattering": [
+						0.0,
+						0.0,
+						0.0
+					],
+					"absorption": [
+						0.0,
+						0.0,
+						0.0
+					]
+				}
+			},
+			"henyey_greenstein_g": {
+				"air": {
+					"henyey_greenstein_g": 0.75
+				}
 			}
 		}
 	}

--- a/resource_packs/files/terrain/clearer_water/fogs/ice_plains_fog_setting.json
+++ b/resource_packs/files/terrain/clearer_water/fogs/ice_plains_fog_setting.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.16.100",
+	"format_version": "1.21.90",
 	"minecraft:fog_settings": {
 		"description": {
 			"identifier": "bt:fog_ice_plains"
@@ -10,6 +10,34 @@
 				"fog_end": 64.0,
 				"fog_color": "#14559b",
 				"render_distance_type": "fixed"
+			}
+		},
+		"volumetric": {
+			"density": {
+				"air": {
+					"max_density": 0.0,
+					"zero_density_height": 320.0,
+					"max_density_height": 320.0
+				}
+			},
+			"media_coefficients": {
+				"air": {
+					"scattering": [
+						0.0,
+						0.0,
+						0.0
+					],
+					"absorption": [
+						0.0,
+						0.0,
+						0.0
+					]
+				}
+			},
+			"henyey_greenstein_g": {
+				"air": {
+					"henyey_greenstein_g": 0.75
+				}
 			}
 		}
 	}

--- a/resource_packs/files/terrain/clearer_water/fogs/ice_plains_spikes_fog_setting.json
+++ b/resource_packs/files/terrain/clearer_water/fogs/ice_plains_spikes_fog_setting.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.16.100",
+	"format_version": "1.21.90",
 	"minecraft:fog_settings": {
 		"description": {
 			"identifier": "bt:fog_ice_plains_spikes"
@@ -10,6 +10,34 @@
 				"fog_end": 64.0,
 				"fog_color": "#14559b",
 				"render_distance_type": "fixed"
+			}
+		},
+		"volumetric": {
+			"density": {
+				"air": {
+					"max_density": 0.05,
+					"zero_density_height": 320.0,
+					"max_density_height": 320.0
+				}
+			},
+			"media_coefficients": {
+				"air": {
+					"scattering": [
+						0.02,
+						0.02,
+						0.02
+					],
+					"absorption": [
+						0.0,
+						0.0,
+						0.0
+					]
+				}
+			},
+			"henyey_greenstein_g": {
+				"air": {
+					"henyey_greenstein_g": 0.3
+				}
 			}
 		}
 	}

--- a/resource_packs/files/terrain/clearer_water/fogs/jungle_edge_fog_setting.json
+++ b/resource_packs/files/terrain/clearer_water/fogs/jungle_edge_fog_setting.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.16.100",
+	"format_version": "1.21.90",
 	"minecraft:fog_settings": {
 		"description": {
 			"identifier": "bt:fog_jungle_edge"
@@ -10,6 +10,34 @@
 				"fog_end": 64.0,
 				"fog_color": "#0D8AE3",
 				"render_distance_type": "fixed"
+			}
+		},
+		"volumetric": {
+			"density": {
+				"air": {
+					"max_density": 0.05,
+					"zero_density_height": 320.0,
+					"max_density_height": 320.0
+				}
+			},
+			"media_coefficients": {
+				"air": {
+					"scattering": [
+						0.04,
+						0.04,
+						0.04
+					],
+					"absorption": [
+						0.0,
+						0.0,
+						0.0
+					]
+				}
+			},
+			"henyey_greenstein_g": {
+				"air": {
+					"henyey_greenstein_g": 0.6
+				}
 			}
 		}
 	}

--- a/resource_packs/files/terrain/clearer_water/fogs/jungle_fog_setting.json
+++ b/resource_packs/files/terrain/clearer_water/fogs/jungle_fog_setting.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.16.100",
+	"format_version": "1.21.90",
 	"minecraft:fog_settings": {
 		"description": {
 			"identifier": "bt:fog_jungle"
@@ -10,6 +10,34 @@
 				"fog_end": 64.0,
 				"fog_color": "#14A2C5",
 				"render_distance_type": "fixed"
+			}
+		},
+		"volumetric": {
+			"density": {
+				"air": {
+					"max_density": 0.05,
+					"zero_density_height": 320.0,
+					"max_density_height": 320.0
+				}
+			},
+			"media_coefficients": {
+				"air": {
+					"scattering": [
+						0.06,
+						0.06,
+						0.06
+					],
+					"absorption": [
+						0.0,
+						0.0,
+						0.0
+					]
+				}
+			},
+			"henyey_greenstein_g": {
+				"air": {
+					"henyey_greenstein_g": 0.4
+				}
 			}
 		}
 	}

--- a/resource_packs/files/terrain/clearer_water/fogs/jungle_hills_fog_setting.json
+++ b/resource_packs/files/terrain/clearer_water/fogs/jungle_hills_fog_setting.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.16.100",
+	"format_version": "1.21.90",
 	"minecraft:fog_settings": {
 		"description": {
 			"identifier": "bt:fog_jungle_hills"
@@ -10,6 +10,34 @@
 				"fog_end": 64.0,
 				"fog_color": "#1B9ED8",
 				"render_distance_type": "fixed"
+			}
+		},
+		"volumetric": {
+			"density": {
+				"air": {
+					"max_density": 0.05,
+					"zero_density_height": 320.0,
+					"max_density_height": 320.0
+				}
+			},
+			"media_coefficients": {
+				"air": {
+					"scattering": [
+						0.06,
+						0.06,
+						0.06
+					],
+					"absorption": [
+						0.0,
+						0.0,
+						0.0
+					]
+				}
+			},
+			"henyey_greenstein_g": {
+				"air": {
+					"henyey_greenstein_g": 0.4
+				}
 			}
 		}
 	}

--- a/resource_packs/files/terrain/clearer_water/fogs/jungle_mutated_fog_setting.json
+++ b/resource_packs/files/terrain/clearer_water/fogs/jungle_mutated_fog_setting.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.16.100",
+	"format_version": "1.21.90",
 	"minecraft:fog_settings": {
 		"description": {
 			"identifier": "bt:fog_jungle_mutated"
@@ -10,6 +10,34 @@
 				"fog_end": 64.0,
 				"fog_color": "#1B9ED8",
 				"render_distance_type": "fixed"
+			}
+		},
+		"volumetric": {
+			"density": {
+				"air": {
+					"max_density": 0.05,
+					"zero_density_height": 320.0,
+					"max_density_height": 320.0
+				}
+			},
+			"media_coefficients": {
+				"air": {
+					"scattering": [
+						0.06,
+						0.06,
+						0.06
+					],
+					"absorption": [
+						0.0,
+						0.0,
+						0.0
+					]
+				}
+			},
+			"henyey_greenstein_g": {
+				"air": {
+					"henyey_greenstein_g": 0.4
+				}
 			}
 		}
 	}

--- a/resource_packs/files/terrain/clearer_water/fogs/lukewarm_ocean_fog_setting.json
+++ b/resource_packs/files/terrain/clearer_water/fogs/lukewarm_ocean_fog_setting.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.16.100",
+	"format_version": "1.21.90",
 	"minecraft:fog_settings": {
 		"description": {
 			"identifier": "bt:fog_lukewarm_ocean"
@@ -10,6 +10,34 @@
 				"fog_end": 64.0,
 				"fog_color": "#0a74c4",
 				"render_distance_type": "fixed"
+			}
+		},
+		"volumetric": {
+			"density": {
+				"air": {
+					"max_density": 0.05,
+					"zero_density_height": 320.0,
+					"max_density_height": 320.0
+				}
+			},
+			"media_coefficients": {
+				"air": {
+					"scattering": [
+						0.04,
+						0.04,
+						0.04
+					],
+					"absorption": [
+						0.0,
+						0.0,
+						0.0
+					]
+				}
+			},
+			"henyey_greenstein_g": {
+				"air": {
+					"henyey_greenstein_g": 0.6
+				}
 			}
 		}
 	}

--- a/resource_packs/files/terrain/clearer_water/fogs/lush_caves_fog_setting.json
+++ b/resource_packs/files/terrain/clearer_water/fogs/lush_caves_fog_setting.json
@@ -1,0 +1,68 @@
+{
+	"format_version": "1.21.90",
+	"minecraft:fog_settings": {
+		"description": {
+			"identifier": "bt:fog_lush_caves"
+		},
+		"distance": {
+			"air": {
+				"fog_start": 0.92,
+				"fog_end": 1.0,
+				"fog_color": "#ABD2FF",
+				"render_distance_type": "render"
+			},
+			"water": {
+				"fog_start": 32.0,
+				"fog_end": 64.0,
+				"fog_color": "#44AFF5",
+				"render_distance_type": "fixed"
+			},
+			"weather": {
+				"fog_start": 0.23,
+				"fog_end": 0.7,
+				"fog_color": "#666666",
+				"render_distance_type": "render"
+			},
+			"lava": {
+				"fog_start": 0.0,
+				"fog_end": 0.64,
+				"fog_color": "#991A00",
+				"render_distance_type": "fixed"
+			},
+			"lava_resistance": {
+				"fog_start": 2.0,
+				"fog_end": 4.0,
+				"fog_color": "#991A00",
+				"render_distance_type": "fixed"
+			}
+		},
+		"volumetric": {
+			"density": {
+				"air": {
+					"max_density": 0.05,
+					"zero_density_height": 320.0,
+					"max_density_height": 320.0
+				}
+			},
+			"media_coefficients": {
+				"air": {
+					"scattering": [
+						0.06,
+						0.06,
+						0.06
+					],
+					"absorption": [
+						0.0,
+						0.0,
+						0.0
+					]
+				}
+			},
+			"henyey_greenstein_g": {
+				"air": {
+					"henyey_greenstein_g": 0.4
+				}
+			}
+		}
+	}
+}

--- a/resource_packs/files/terrain/clearer_water/fogs/mangrove_swamp_fog_setting.json
+++ b/resource_packs/files/terrain/clearer_water/fogs/mangrove_swamp_fog_setting.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.16.100",
+	"format_version": "1.21.90",
 	"minecraft:fog_settings": {
 		"description": {
 			"identifier": "bt:fog_mangrove_swamp"
@@ -10,6 +10,34 @@
 				"fog_end": 64.0,
 				"fog_color": "#4d7a60",
 				"render_distance_type": "fixed"
+			}
+		},
+		"volumetric": {
+			"density": {
+				"air": {
+					"max_density": 0.05,
+					"zero_density_height": 320.0,
+					"max_density_height": 320.0
+				}
+			},
+			"media_coefficients": {
+				"air": {
+					"scattering": [
+						0.06,
+						0.06,
+						0.06
+					],
+					"absorption": [
+						0.0,
+						0.0,
+						0.0
+					]
+				}
+			},
+			"henyey_greenstein_g": {
+				"air": {
+					"henyey_greenstein_g": 0.4
+				}
 			}
 		}
 	}

--- a/resource_packs/files/terrain/clearer_water/fogs/mega_taiga_fog_setting.json
+++ b/resource_packs/files/terrain/clearer_water/fogs/mega_taiga_fog_setting.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.16.100",
+	"format_version": "1.21.90",
 	"minecraft:fog_settings": {
 		"description": {
 			"identifier": "bt:fog_mega_taiga"
@@ -10,6 +10,34 @@
 				"fog_end": 64.0,
 				"fog_color": "#2d6d77",
 				"render_distance_type": "fixed"
+			}
+		},
+		"volumetric": {
+			"density": {
+				"air": {
+					"max_density": 0.05,
+					"zero_density_height": 320.0,
+					"max_density_height": 320.0
+				}
+			},
+			"media_coefficients": {
+				"air": {
+					"scattering": [
+						0.04,
+						0.04,
+						0.04
+					],
+					"absorption": [
+						0.0,
+						0.0,
+						0.0
+					]
+				}
+			},
+			"henyey_greenstein_g": {
+				"air": {
+					"henyey_greenstein_g": 0.6
+				}
 			}
 		}
 	}

--- a/resource_packs/files/terrain/clearer_water/fogs/mega_taiga_hills_fog_setting.json
+++ b/resource_packs/files/terrain/clearer_water/fogs/mega_taiga_hills_fog_setting.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.16.100",
+	"format_version": "1.21.90",
 	"minecraft:fog_settings": {
 		"description": {
 			"identifier": "bt:fog_mega_taiga_hills"
@@ -10,6 +10,34 @@
 				"fog_end": 64.0,
 				"fog_color": "#286378",
 				"render_distance_type": "fixed"
+			}
+		},
+		"volumetric": {
+			"density": {
+				"air": {
+					"max_density": 0.05,
+					"zero_density_height": 320.0,
+					"max_density_height": 320.0
+				}
+			},
+			"media_coefficients": {
+				"air": {
+					"scattering": [
+						0.04,
+						0.04,
+						0.04
+					],
+					"absorption": [
+						0.0,
+						0.0,
+						0.0
+					]
+				}
+			},
+			"henyey_greenstein_g": {
+				"air": {
+					"henyey_greenstein_g": 0.6
+				}
 			}
 		}
 	}

--- a/resource_packs/files/terrain/clearer_water/fogs/mesa_bryce_fog_setting.json
+++ b/resource_packs/files/terrain/clearer_water/fogs/mesa_bryce_fog_setting.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.16.100",
+	"format_version": "1.21.90",
 	"minecraft:fog_settings": {
 		"description": {
 			"identifier": "bt:fog_mesa_bryce"
@@ -10,6 +10,34 @@
 				"fog_end": 64.0,
 				"fog_color": "#497F99",
 				"render_distance_type": "fixed"
+			}
+		},
+		"volumetric": {
+			"density": {
+				"air": {
+					"max_density": 0.0,
+					"zero_density_height": 320.0,
+					"max_density_height": 320.0
+				}
+			},
+			"media_coefficients": {
+				"air": {
+					"scattering": [
+						0.0,
+						0.0,
+						0.0
+					],
+					"absorption": [
+						0.0,
+						0.0,
+						0.0
+					]
+				}
+			},
+			"henyey_greenstein_g": {
+				"air": {
+					"henyey_greenstein_g": 0.75
+				}
 			}
 		}
 	}

--- a/resource_packs/files/terrain/clearer_water/fogs/mesa_fog_setting.json
+++ b/resource_packs/files/terrain/clearer_water/fogs/mesa_fog_setting.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.16.100",
+	"format_version": "1.21.90",
 	"minecraft:fog_settings": {
 		"description": {
 			"identifier": "bt:fog_mesa"
@@ -10,6 +10,34 @@
 				"fog_end": 64.0,
 				"fog_color": "#4E7F81",
 				"render_distance_type": "fixed"
+			}
+		},
+		"volumetric": {
+			"density": {
+				"air": {
+					"max_density": 0.0,
+					"zero_density_height": 320.0,
+					"max_density_height": 320.0
+				}
+			},
+			"media_coefficients": {
+				"air": {
+					"scattering": [
+						0.0,
+						0.0,
+						0.0
+					],
+					"absorption": [
+						0.0,
+						0.0,
+						0.0
+					]
+				}
+			},
+			"henyey_greenstein_g": {
+				"air": {
+					"henyey_greenstein_g": 0.75
+				}
 			}
 		}
 	}

--- a/resource_packs/files/terrain/clearer_water/fogs/mesa_plateau_fog_setting.json
+++ b/resource_packs/files/terrain/clearer_water/fogs/mesa_plateau_fog_setting.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.16.100",
+	"format_version": "1.21.90",
 	"minecraft:fog_settings": {
 		"description": {
 			"identifier": "bt:fog_mesa_plateau"
@@ -10,6 +10,34 @@
 				"fog_end": 64.0,
 				"fog_color": "#55809E",
 				"render_distance_type": "fixed"
+			}
+		},
+		"volumetric": {
+			"density": {
+				"air": {
+					"max_density": 0.0,
+					"zero_density_height": 320.0,
+					"max_density_height": 320.0
+				}
+			},
+			"media_coefficients": {
+				"air": {
+					"scattering": [
+						0.0,
+						0.0,
+						0.0
+					],
+					"absorption": [
+						0.0,
+						0.0,
+						0.0
+					]
+				}
+			},
+			"henyey_greenstein_g": {
+				"air": {
+					"henyey_greenstein_g": 0.75
+				}
 			}
 		}
 	}

--- a/resource_packs/files/terrain/clearer_water/fogs/mesa_plateau_stone_fog_setting.json
+++ b/resource_packs/files/terrain/clearer_water/fogs/mesa_plateau_stone_fog_setting.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.16.100",
+	"format_version": "1.21.90",
 	"minecraft:fog_settings": {
 		"description": {
 			"identifier": "bt:fog_mesa_plateau_stone"
@@ -10,6 +10,34 @@
 				"fog_end": 64.0,
 				"fog_color": "#55809E",
 				"render_distance_type": "fixed"
+			}
+		},
+		"volumetric": {
+			"density": {
+				"air": {
+					"max_density": 0.0,
+					"zero_density_height": 320.0,
+					"max_density_height": 320.0
+				}
+			},
+			"media_coefficients": {
+				"air": {
+					"scattering": [
+						0.0,
+						0.0,
+						0.0
+					],
+					"absorption": [
+						0.0,
+						0.0,
+						0.0
+					]
+				}
+			},
+			"henyey_greenstein_g": {
+				"air": {
+					"henyey_greenstein_g": 0.75
+				}
 			}
 		}
 	}

--- a/resource_packs/files/terrain/clearer_water/fogs/mushroom_island_fog_setting.json
+++ b/resource_packs/files/terrain/clearer_water/fogs/mushroom_island_fog_setting.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.16.100",
+	"format_version": "1.21.90",
 	"minecraft:fog_settings": {
 		"description": {
 			"identifier": "bt:fog_mushroom_island"
@@ -10,6 +10,34 @@
 				"fog_end": 64.0,
 				"fog_color": "#8a8997",
 				"render_distance_type": "fixed"
+			}
+		},
+		"volumetric": {
+			"density": {
+				"air": {
+					"max_density": 0.007,
+					"zero_density_height": 320.0,
+					"max_density_height": 320.0
+				}
+			},
+			"media_coefficients": {
+				"air": {
+					"scattering": [
+						0.059,
+						0.059,
+						0.059
+					],
+					"absorption": [
+						0.3,
+						1.0,
+						0.09
+					]
+				}
+			},
+			"henyey_greenstein_g": {
+				"air": {
+					"henyey_greenstein_g": 0.3
+				}
 			}
 		}
 	}

--- a/resource_packs/files/terrain/clearer_water/fogs/mushroom_island_shore_fog_setting.json
+++ b/resource_packs/files/terrain/clearer_water/fogs/mushroom_island_shore_fog_setting.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.16.100",
+	"format_version": "1.21.90",
 	"minecraft:fog_settings": {
 		"description": {
 			"identifier": "bt:fog_mushroom_island_shore"
@@ -10,6 +10,34 @@
 				"fog_end": 64.0,
 				"fog_color": "#818193",
 				"render_distance_type": "fixed"
+			}
+		},
+		"volumetric": {
+			"density": {
+				"air": {
+					"max_density": 0.007,
+					"zero_density_height": 320.0,
+					"max_density_height": 320.0
+				}
+			},
+			"media_coefficients": {
+				"air": {
+					"scattering": [
+						0.059,
+						0.059,
+						0.059
+					],
+					"absorption": [
+						0.3,
+						1.0,
+						0.09
+					]
+				}
+			},
+			"henyey_greenstein_g": {
+				"air": {
+					"henyey_greenstein_g": 0.3
+				}
 			}
 		}
 	}

--- a/resource_packs/files/terrain/clearer_water/fogs/pale_garden_fog_setting.json
+++ b/resource_packs/files/terrain/clearer_water/fogs/pale_garden_fog_setting.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.16.100",
+	"format_version": "1.21.90",
 	"minecraft:fog_settings": {
 		"description": {
 			"identifier": "bt:fog_pale_garden"
@@ -22,6 +22,34 @@
 				"fog_end": 64.0,
 				"fog_color": "#556980",
 				"render_distance_type": "fixed"
+			}
+		},
+		"volumetric": {
+			"density": {
+				"air": {
+					"max_density": 0.07,
+					"zero_density_height": 320.0,
+					"max_density_height": 320.0
+				}
+			},
+			"media_coefficients": {
+				"air": {
+					"scattering": [
+						0.5,
+						0.5,
+						0.5
+					],
+					"absorption": [
+						0.25,
+						0.125,
+						0.125
+					]
+				}
+			},
+			"henyey_greenstein_g": {
+				"air": {
+					"henyey_greenstein_g": 0.3
+				}
 			}
 		}
 	}

--- a/resource_packs/files/terrain/clearer_water/fogs/roofed_forest_fog_setting.json
+++ b/resource_packs/files/terrain/clearer_water/fogs/roofed_forest_fog_setting.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.16.100",
+	"format_version": "1.21.90",
 	"minecraft:fog_settings": {
 		"description": {
 			"identifier": "bt:fog_roofed_forest"
@@ -10,6 +10,34 @@
 				"fog_end": 64.0,
 				"fog_color": "#3B6CD1",
 				"render_distance_type": "fixed"
+			}
+		},
+		"volumetric": {
+			"density": {
+				"air": {
+					"max_density": 0.05,
+					"zero_density_height": 320.0,
+					"max_density_height": 320.0
+				}
+			},
+			"media_coefficients": {
+				"air": {
+					"scattering": [
+						0.04,
+						0.04,
+						0.04
+					],
+					"absorption": [
+						0.0,
+						0.0,
+						0.0
+					]
+				}
+			},
+			"henyey_greenstein_g": {
+				"air": {
+					"henyey_greenstein_g": 0.6
+				}
 			}
 		}
 	}

--- a/resource_packs/files/terrain/clearer_water/fogs/semi_humid_fog_setting.json
+++ b/resource_packs/files/terrain/clearer_water/fogs/semi_humid_fog_setting.json
@@ -1,0 +1,68 @@
+{
+	"format_version": "1.21.90",
+	"minecraft:fog_settings": {
+		"description": {
+			"identifier": "bt:fog_semi_humid"
+		},
+		"distance": {
+			"air": {
+				"fog_start": 0.92,
+				"fog_end": 1.0,
+				"fog_color": "#ABD2FF",
+				"render_distance_type": "render"
+			},
+			"water": {
+				"fog_start": 32.0,
+				"fog_end": 64.0,
+				"fog_color": "#44AFF5",
+				"render_distance_type": "fixed"
+			},
+			"weather": {
+				"fog_start": 0.23,
+				"fog_end": 0.7,
+				"fog_color": "#666666",
+				"render_distance_type": "render"
+			},
+			"lava": {
+				"fog_start": 0.0,
+				"fog_end": 0.64,
+				"fog_color": "#991A00",
+				"render_distance_type": "fixed"
+			},
+			"lava_resistance": {
+				"fog_start": 2.0,
+				"fog_end": 4.0,
+				"fog_color": "#991A00",
+				"render_distance_type": "fixed"
+			}
+		},
+		"volumetric": {
+			"density": {
+				"air": {
+					"max_density": 0.05,
+					"zero_density_height": 320.0,
+					"max_density_height": 320.0
+				}
+			},
+			"media_coefficients": {
+				"air": {
+					"scattering": [
+						0.04,
+						0.04,
+						0.04
+					],
+					"absorption": [
+						0.0,
+						0.0,
+						0.0
+					]
+				}
+			},
+			"henyey_greenstein_g": {
+				"air": {
+					"henyey_greenstein_g": 0.6
+				}
+			}
+		}
+	}
+}

--- a/resource_packs/files/terrain/clearer_water/fogs/sunflower_plains_fog_setting.json
+++ b/resource_packs/files/terrain/clearer_water/fogs/sunflower_plains_fog_setting.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.16.100",
+	"format_version": "1.21.90",
 	"minecraft:fog_settings": {
 		"description": {
 			"identifier": "bt:fog_sunflower_plains"
@@ -10,6 +10,34 @@
 				"fog_end": 64.0,
 				"fog_color": "#44AFF5",
 				"render_distance_type": "fixed"
+			}
+		},
+		"volumetric": {
+			"density": {
+				"air": {
+					"max_density": 0.0,
+					"zero_density_height": 320.0,
+					"max_density_height": 320.0
+				}
+			},
+			"media_coefficients": {
+				"air": {
+					"scattering": [
+						0.0,
+						0.0,
+						0.0
+					],
+					"absorption": [
+						0.0,
+						0.0,
+						0.0
+					]
+				}
+			},
+			"henyey_greenstein_g": {
+				"air": {
+					"henyey_greenstein_g": 0.75
+				}
 			}
 		}
 	}

--- a/resource_packs/files/terrain/clearer_water/fogs/swampland_fog_setting.json
+++ b/resource_packs/files/terrain/clearer_water/fogs/swampland_fog_setting.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.16.100",
+	"format_version": "1.21.90",
 	"minecraft:fog_settings": {
 		"description": {
 			"identifier": "bt:fog_swampland"
@@ -10,6 +10,34 @@
 				"fog_end": 64.0,
 				"fog_color": "#4c6559",
 				"render_distance_type": "fixed"
+			}
+		},
+		"volumetric": {
+			"density": {
+				"air": {
+					"max_density": 0.07,
+					"zero_density_height": 320.0,
+					"max_density_height": 320.0
+				}
+			},
+			"media_coefficients": {
+				"air": {
+					"scattering": [
+						0.059,
+						0.059,
+						0.059
+					],
+					"absorption": [
+						0.2549019753932953,
+						0.12995001673698425,
+						0.18875093758106232
+					]
+				}
+			},
+			"henyey_greenstein_g": {
+				"air": {
+					"henyey_greenstein_g": 0.4
+				}
 			}
 		}
 	}

--- a/resource_packs/files/terrain/clearer_water/fogs/swampland_mutated_fog_setting.json
+++ b/resource_packs/files/terrain/clearer_water/fogs/swampland_mutated_fog_setting.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.16.100",
+	"format_version": "1.21.90",
 	"minecraft:fog_settings": {
 		"description": {
 			"identifier": "bt:fog_swampland_mutated"
@@ -10,6 +10,34 @@
 				"fog_end": 64.0,
 				"fog_color": "#4c6156",
 				"render_distance_type": "fixed"
+			}
+		},
+		"volumetric": {
+			"density": {
+				"air": {
+					"max_density": 0.07,
+					"zero_density_height": 320.0,
+					"max_density_height": 320.0
+				}
+			},
+			"media_coefficients": {
+				"air": {
+					"scattering": [
+						0.059,
+						0.059,
+						0.059
+					],
+					"absorption": [
+						0.2549019753932953,
+						0.12995001673698425,
+						0.18875093758106232
+					]
+				}
+			},
+			"henyey_greenstein_g": {
+				"air": {
+					"henyey_greenstein_g": 0.4
+				}
 			}
 		}
 	}

--- a/resource_packs/files/terrain/clearer_water/fogs/taiga_fog_setting.json
+++ b/resource_packs/files/terrain/clearer_water/fogs/taiga_fog_setting.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.16.100",
+	"format_version": "1.21.90",
 	"minecraft:fog_settings": {
 		"description": {
 			"identifier": "bt:fog_taiga"
@@ -10,6 +10,34 @@
 				"fog_end": 64.0,
 				"fog_color": "#287082",
 				"render_distance_type": "fixed"
+			}
+		},
+		"volumetric": {
+			"density": {
+				"air": {
+					"max_density": 0.05,
+					"zero_density_height": 320.0,
+					"max_density_height": 320.0
+				}
+			},
+			"media_coefficients": {
+				"air": {
+					"scattering": [
+						0.04,
+						0.04,
+						0.04
+					],
+					"absorption": [
+						0.0,
+						0.0,
+						0.0
+					]
+				}
+			},
+			"henyey_greenstein_g": {
+				"air": {
+					"henyey_greenstein_g": 0.6
+				}
 			}
 		}
 	}

--- a/resource_packs/files/terrain/clearer_water/fogs/taiga_hills_fog_setting.json
+++ b/resource_packs/files/terrain/clearer_water/fogs/taiga_hills_fog_setting.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.16.100",
+	"format_version": "1.21.90",
 	"minecraft:fog_settings": {
 		"description": {
 			"identifier": "bt:fog_taiga_hills"
@@ -10,6 +10,34 @@
 				"fog_end": 64.0,
 				"fog_color": "#236583",
 				"render_distance_type": "fixed"
+			}
+		},
+		"volumetric": {
+			"density": {
+				"air": {
+					"max_density": 0.05,
+					"zero_density_height": 320.0,
+					"max_density_height": 320.0
+				}
+			},
+			"media_coefficients": {
+				"air": {
+					"scattering": [
+						0.04,
+						0.04,
+						0.04
+					],
+					"absorption": [
+						0.0,
+						0.0,
+						0.0
+					]
+				}
+			},
+			"henyey_greenstein_g": {
+				"air": {
+					"henyey_greenstein_g": 0.6
+				}
 			}
 		}
 	}

--- a/resource_packs/files/terrain/clearer_water/fogs/taiga_mutated_fog_setting.json
+++ b/resource_packs/files/terrain/clearer_water/fogs/taiga_mutated_fog_setting.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.16.100",
+	"format_version": "1.21.90",
 	"minecraft:fog_settings": {
 		"description": {
 			"identifier": "bt:fog_taiga_mutated"
@@ -10,6 +10,34 @@
 				"fog_end": 64.0,
 				"fog_color": "#1E6B82",
 				"render_distance_type": "fixed"
+			}
+		},
+		"volumetric": {
+			"density": {
+				"air": {
+					"max_density": 0.05,
+					"zero_density_height": 320.0,
+					"max_density_height": 320.0
+				}
+			},
+			"media_coefficients": {
+				"air": {
+					"scattering": [
+						0.04,
+						0.04,
+						0.04
+					],
+					"absorption": [
+						0.0,
+						0.0,
+						0.0
+					]
+				}
+			},
+			"henyey_greenstein_g": {
+				"air": {
+					"henyey_greenstein_g": 0.6
+				}
 			}
 		}
 	}

--- a/resource_packs/files/terrain/clearer_water/fogs/the_end_fog_setting.json
+++ b/resource_packs/files/terrain/clearer_water/fogs/the_end_fog_setting.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.16.100",
+	"format_version": "1.21.90",
 	"minecraft:fog_settings": {
 		"description": {
 			"identifier": "bt:fog_the_end"
@@ -16,6 +16,34 @@
 				"fog_end": 64.0,
 				"fog_color": "#62529e",
 				"render_distance_type": "fixed"
+			}
+		},
+		"volumetric": {
+			"density": {
+				"air": {
+					"max_density": 0.25,
+					"zero_density_height": 320.0,
+					"max_density_height": 320.0
+				}
+			},
+			"media_coefficients": {
+				"air": {
+					"scattering": [
+						0.02,
+						0.02,
+						0.02
+					],
+					"absorption": [
+						0.0,
+						0.0,
+						0.0
+					]
+				}
+			},
+			"henyey_greenstein_g": {
+				"air": {
+					"henyey_greenstein_g": 0.8
+				}
 			}
 		}
 	}

--- a/resource_packs/files/terrain/clearer_water/fogs/warm_ocean_fog_setting.json
+++ b/resource_packs/files/terrain/clearer_water/fogs/warm_ocean_fog_setting.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.16.100",
+	"format_version": "1.21.90",
 	"minecraft:fog_settings": {
 		"description": {
 			"identifier": "bt:fog_warm_ocean"
@@ -10,6 +10,34 @@
 				"fog_end": 64.0,
 				"fog_color": "#0289d5",
 				"render_distance_type": "fixed"
+			}
+		},
+		"volumetric": {
+			"density": {
+				"air": {
+					"max_density": 0.05,
+					"zero_density_height": 320.0,
+					"max_density_height": 320.0
+				}
+			},
+			"media_coefficients": {
+				"air": {
+					"scattering": [
+						0.04,
+						0.04,
+						0.04
+					],
+					"absorption": [
+						0.0,
+						0.0,
+						0.0
+					]
+				}
+			},
+			"henyey_greenstein_g": {
+				"air": {
+					"henyey_greenstein_g": 0.6
+				}
 			}
 		}
 	}

--- a/resource_packs/files/terrain/lush_grass_all_round/biomes/cherry_grove.client_biome.json
+++ b/resource_packs/files/terrain/lush_grass_all_round/biomes/cherry_grove.client_biome.json
@@ -1,21 +1,33 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "cherry_grove"
 		},
 		"components": {
+			"minecraft:fog_appearance": {
+				"fog_identifier": "minecraft:fog_cherry_grove"
+			},
+			"minecraft:water_appearance": {
+				"surface_color": "#5db7ef"
+			},
 			"minecraft:foliage_appearance": {
 				"color": "#2abb0e"
 			},
 			"minecraft:grass_appearance": {
 				"color": "#2abb0e"
 			},
-			"minecraft:fog_appearance": {
-				"fog_identifier": "minecraft:fog_cherry_grove"
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:default_atmospherics"
 			},
-			"minecraft:water_appearance": {
-				"surface_color": "#5db7ef"
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:default_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:default_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/files/terrain/lush_grass_all_round/biomes/mesa.client_biome.json
+++ b/resource_packs/files/terrain/lush_grass_all_round/biomes/mesa.client_biome.json
@@ -1,21 +1,33 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "mesa"
 		},
 		"components": {
+			"minecraft:fog_appearance": {
+				"fog_identifier": "minecraft:fog_mesa"
+			},
+			"minecraft:water_appearance": {
+				"surface_color": "#4E7F81"
+			},
 			"minecraft:foliage_appearance": {
 				"color": "#2abb0e"
 			},
 			"minecraft:grass_appearance": {
 				"color": "#2abb0e"
 			},
-			"minecraft:fog_appearance": {
-				"fog_identifier": "minecraft:fog_mesa"
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:mesa_atmospherics"
 			},
-			"minecraft:water_appearance": {
-				"surface_color": "#4E7F81"
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:mesa_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:mesa_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/files/terrain/lush_grass_all_round/biomes/mesa_bryce.client_biome.json
+++ b/resource_packs/files/terrain/lush_grass_all_round/biomes/mesa_bryce.client_biome.json
@@ -1,21 +1,33 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "mesa_bryce"
 		},
 		"components": {
+			"minecraft:fog_appearance": {
+				"fog_identifier": "minecraft:fog_mesa_bryce"
+			},
+			"minecraft:water_appearance": {
+				"surface_color": "#497F99"
+			},
 			"minecraft:foliage_appearance": {
 				"color": "#2abb0e"
 			},
 			"minecraft:grass_appearance": {
 				"color": "#2abb0e"
 			},
-			"minecraft:fog_appearance": {
-				"fog_identifier": "minecraft:fog_mesa_bryce"
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:mesa_atmospherics"
 			},
-			"minecraft:water_appearance": {
-				"surface_color": "#497F99"
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:mesa_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:mesa_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/files/terrain/lush_grass_all_round/biomes/mesa_plateau_mutated.client_biome.json
+++ b/resource_packs/files/terrain/lush_grass_all_round/biomes/mesa_plateau_mutated.client_biome.json
@@ -1,21 +1,33 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "mesa_plateau_mutated"
 		},
 		"components": {
+			"minecraft:fog_appearance": {
+				"fog_identifier": "minecraft:fog_dry"
+			},
+			"minecraft:water_appearance": {
+				"surface_color": "#44AFF5"
+			},
 			"minecraft:foliage_appearance": {
 				"color": "#2abb0e"
 			},
 			"minecraft:grass_appearance": {
 				"color": "#2abb0e"
 			},
-			"minecraft:fog_appearance": {
-				"fog_identifier": "minecraft:fog_default"
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:mesa_atmospherics"
 			},
-			"minecraft:water_appearance": {
-				"surface_color": "#44AFF5"
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:mesa_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:mesa_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/files/terrain/lush_grass_all_round/biomes/mesa_plateau_stone.client_biome.json
+++ b/resource_packs/files/terrain/lush_grass_all_round/biomes/mesa_plateau_stone.client_biome.json
@@ -1,21 +1,33 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "mesa_plateau_stone"
 		},
 		"components": {
+			"minecraft:fog_appearance": {
+				"fog_identifier": "minecraft:fog_mesa_plateau_stone"
+			},
+			"minecraft:water_appearance": {
+				"surface_color": "#55809E"
+			},
 			"minecraft:foliage_appearance": {
 				"color": "#2abb0e"
 			},
 			"minecraft:grass_appearance": {
 				"color": "#2abb0e"
 			},
-			"minecraft:fog_appearance": {
-				"fog_identifier": "minecraft:fog_mesa_plateau_stone"
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:mesa_atmospherics"
 			},
-			"minecraft:water_appearance": {
-				"surface_color": "#55809E"
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:mesa_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:mesa_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/files/terrain/lush_grass_all_round/biomes/mesa_plateau_stone_mutated.client_biome.json
+++ b/resource_packs/files/terrain/lush_grass_all_round/biomes/mesa_plateau_stone_mutated.client_biome.json
@@ -1,21 +1,33 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "mesa_plateau_stone_mutated"
 		},
 		"components": {
+			"minecraft:fog_appearance": {
+				"fog_identifier": "minecraft:fog_dry"
+			},
+			"minecraft:water_appearance": {
+				"surface_color": "#44AFF5"
+			},
 			"minecraft:foliage_appearance": {
 				"color": "#2abb0e"
 			},
 			"minecraft:grass_appearance": {
 				"color": "#2abb0e"
 			},
-			"minecraft:fog_appearance": {
-				"fog_identifier": "minecraft:fog_default"
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:mesa_atmospherics"
 			},
-			"minecraft:water_appearance": {
-				"surface_color": "#44AFF5"
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:mesa_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:mesa_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}

--- a/resource_packs/files/terrain/lush_grass_all_round/biomes/pale_garden.client_biome.json
+++ b/resource_packs/files/terrain/lush_grass_all_round/biomes/pale_garden.client_biome.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.40",
+	"format_version": "1.21.70",
 	"minecraft:client_biome": {
 		"description": {
 			"identifier": "pale_garden"
@@ -22,6 +22,18 @@
 			},
 			"minecraft:grass_appearance": {
 				"color": "#2abb0e"
+			},
+			"minecraft:atmosphere_identifier": {
+				"atmosphere_identifier": "minecraft:pale_garden_atmospherics"
+			},
+			"minecraft:color_grading_identifier": {
+				"color_grading_identifier": "minecraft:coolish_color_grading"
+			},
+			"minecraft:lighting_identifier": {
+				"lighting_identifier": "minecraft:pale_garden_lighting"
+			},
+			"minecraft:water_identifier": {
+				"water_identifier": "minecraft:default_water"
 			}
 		}
 	}


### PR DESCRIPTION
1. Update Clearer Water to 1.21.90 and support Vibrant Visuals by updating all the client biome and fog files to the latest format version from bedrock samples
2. Update Old Water to 1.21.90 and support Vibrant Visuals by updating all the client biome files to the latest format version from bedrock samples
3. Update Lush Grass All 'Round! to 1.21.90 and support Vibrant Visuals by updating all the client biome files to the latest format version from bedrock samples
4. Update `lush_grass_clearer_water`, `lush_grass_old_clearer_water`, `lush_grass_old_water` and `old_clearer_water` combinations to 1.21.90 and support Vibrant Visuals by updating all the client biome and fog files to the latest format version from bedrock samples

By checking the following boxes with an X, you ensure that:

- [X] The pack was tested ingame in at least one device.
- [X] The pack is an existing BT pack, is a missing pack from VT or is an accepted pack/change in a discussion.
- [X] The pack code follows the style guide.
- [X] The commits follow the contribution guidelines.
- [X] The PR follows the contribution guidelines.

- [X] (Optional) Tested in Windows
- [ ] (Optional) Tested in Android
- [ ] (Optional) Tested in iOS
- [ ] (Optional) Tested in any console
- [ ] (Optional) Tested in BDS
