### PR TITLE
update(files): Update Quieter Ghasts to mirror changes made in 1.21.100

### DIFF
--- a/resource_packs/files/peace_and_quiet/mobs/quieter_ghasts/sounds.json
+++ b/resource_packs/files/peace_and_quiet/mobs/quieter_ghasts/sounds.json
@@ -14,7 +14,7 @@
 					"key": "query.is_baby ? 'ghastling' : 'adult'",
 					"map": {
 						"adult": {
-							"volume": 0.05
+							"volume": 0.2
 						},
 						"ghastling": {
 							"volume": 0.05


### PR DESCRIPTION
1. In 1.21.100, Happy Ghast adult volume was adjusted from 1.0 to 4.0 to account for the changes made in vanilla `sound_definitions.json` so I just mirrored those changes and decreased it by 95%

By checking the following boxes with an X, you ensure that:

- [X] The pack was tested ingame in at least one device.
- [X] The pack is an existing BT pack, is a missing pack from VT or is an accepted pack/change in a discussion.
- [X] The pack code follows the style guide.
- [X] The commits follow the contribution guidelines.
- [X] The PR follows the contribution guidelines.

- [X] (Optional) Tested in Windows
- [ ] (Optional) Tested in Android
- [ ] (Optional) Tested in iOS
- [ ] (Optional) Tested in any console
- [ ] (Optional) Tested in BDS
