### PR TITLE
fix(files): Fix the size of the spyglass to not be huge and improved the position of the spyglass when scoping in 3rd person mode to be consistent when moving the player and rotating the head in 2D Spyglass

### DIFF
--- a/resource_packs/files/aesthetic/2d_spyglass/animations/spyglass.animation.json
+++ b/resource_packs/files/aesthetic/2d_spyglass/animations/spyglass.animation.json
@@ -4,34 +4,36 @@
 		"animation.rp.bt.spyglass_holding": {
 			"loop": true,
 			"bones": {
-				"rightitem": {
+				"spyglass": {
 					"position": [
-						"c.is_first_person ? -5.5 : -1.5",
-						"c.is_first_person ? -3.0 : 1.5",
-						"c.is_first_person ? -3.0 : -8.0"
+						"c.is_first_person ? -8.5 : -1.0",
+						"c.is_first_person ? 23.0 : 25.0",
+						"c.is_first_person ? -5.0 : -5.5"
 					],
 					"rotation": [
 						"c.is_first_person ? 38.0 : 180.0",
 						"c.is_first_person ? -120.0 : 0.0",
 						"c.is_first_person ? -63.0 : 0.0"
-					]
+					],
+					"scale": "c.is_first_person ? 0.68 : 0.65"
 				}
 			}
 		},
 		"animation.rp.bt.spyglass_scoping": {
 			"loop": true,
 			"bones": {
-				"rightitem": {
+				"spyglass": {
 					"position": [
-						-1.5,
-						-8.5,
-						0.0
+						-3.0,
+						30.0,
+						-11.0
 					],
 					"rotation": [
-						-45.0,
+						-190.0,
 						0.0,
 						0.0
-					]
+					],
+					"scale": 0.65
 				}
 			}
 		}

--- a/resource_packs/files/aesthetic/2d_spyglass/attachables/spyglass.attachable.json
+++ b/resource_packs/files/aesthetic/2d_spyglass/attachables/spyglass.attachable.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.10.0",
+	"format_version": "1.21.0",
 	"minecraft:attachable": {
 		"description": {
 			"identifier": "minecraft:spyglass",
@@ -12,7 +12,7 @@
 				"enchanted": "textures/misc/enchanted_item_glint"
 			},
 			"geometry": {
-				"default": "geometry.bow_standby"
+				"default": "geometry.bt_spyglass"
 			},
 			"animations": {
 				"holding": "animation.rp.bt.spyglass_holding",
@@ -29,7 +29,7 @@
 				]
 			},
 			"render_controllers": [
-				"controller.render.default"
+				"controller.render.bt.spyglass"
 			]
 		}
 	}

--- a/resource_packs/files/aesthetic/2d_spyglass/models/entity/spyglass.geo.json
+++ b/resource_packs/files/aesthetic/2d_spyglass/models/entity/spyglass.geo.json
@@ -1,0 +1,50 @@
+{
+	"format_version": "1.21.0",
+	"minecraft:geometry": [
+		{
+			"description": {
+				"identifier": "geometry.bt_spyglass",
+				"texture_width": 16,
+				"texture_height": 16,
+				"visible_bounds_width": 1,
+				"visible_bounds_height": 1,
+				"visible_bounds_offset": [
+					0,
+					0,
+					0
+				]
+			},
+			"bones": [
+				{
+					"name": "spyglass",
+					"pivot": [
+						0,
+						0,
+						0
+					],
+					"binding": "q.item_slot_to_bone_name(q.main_hand_item_use_duration > 0.0f && !c.is_first_person ? 'head' : 'main_hand')",
+					"texture_meshes": [
+						{
+							"texture": "default",
+							"position": [
+								2,
+								1,
+								-2
+							],
+							"rotation": [
+								0,
+								-135,
+								90
+							],
+							"local_pivot": [
+								6,
+								0,
+								6
+							]
+						}
+					]
+				}
+			]
+		}
+	]
+}

--- a/resource_packs/files/aesthetic/2d_spyglass/render_controllers/spyglass.rc.json
+++ b/resource_packs/files/aesthetic/2d_spyglass/render_controllers/spyglass.rc.json
@@ -1,0 +1,17 @@
+{
+	"format_version": "1.10.0",
+	"render_controllers": {
+		"controller.render.bt.spyglass": {
+			"geometry": "Geometry.default",
+			"materials": [
+				{
+					"*": "variable.is_enchanted ? Material.enchanted : Material.default"
+				}
+			],
+			"textures": [
+				"Texture.default",
+				"Texture.enchanted"
+			]
+		}
+	}
+}


### PR DESCRIPTION
1. The size of the spyglass has been adjusted to not be huge
2. Improved the position of the spyglass when scoping in 3rd person mode to be consistent when moving the player and rotating the head by fully rewriting the geometry and animation files

Resolves #673

By checking the following boxes with an X, you ensure that:

- [X] The pack was tested ingame in at least one device.
- [X] The pack is an existing BT pack, is a missing pack from VT or is an accepted pack/change in a discussion.
- [X] The pack code follows the style guide.
- [X] The commits follow the contribution guidelines.
- [X] The PR follows the contribution guidelines.

- [X] (Optional) Tested in Windows
- [ ] (Optional) Tested in Android
- [ ] (Optional) Tested in iOS
- [ ] (Optional) Tested in any console
- [ ] (Optional) Tested in BDS
