### PR TITLE
feat(files): Add a combination between Alternate Dyes and Paletteless Dyes

### DIFF
--- a/resource_packs/extras/dyes/paletteless_alternate_dyes/textures/items/dye_powder_black_new.png
+++ b/resource_packs/extras/dyes/paletteless_alternate_dyes/textures/items/dye_powder_black_new.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:89aa958d22cc69700283d66b6be4846759bac0af101b0f790e9eaf57354cdbdb
+size 465

--- a/resource_packs/extras/dyes/paletteless_alternate_dyes/textures/items/dye_powder_blue_new.png
+++ b/resource_packs/extras/dyes/paletteless_alternate_dyes/textures/items/dye_powder_blue_new.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:20bdf445b5ade8a339b42816e7a0c736ac80966ae8dbcff8d1d07707f2779eaa
+size 469

--- a/resource_packs/extras/dyes/paletteless_alternate_dyes/textures/items/dye_powder_brown_new.png
+++ b/resource_packs/extras/dyes/paletteless_alternate_dyes/textures/items/dye_powder_brown_new.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7b6c9899efd06d3a1592e7b3c1a5c97eae20419f433b52d4ecbbed58d7433a7d
+size 461

--- a/resource_packs/extras/dyes/paletteless_alternate_dyes/textures/items/dye_powder_gray.png
+++ b/resource_packs/extras/dyes/paletteless_alternate_dyes/textures/items/dye_powder_gray.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:55ee883402fc6fc837ca21bb629c29819073dee23afa02dd1dd0aeb7cc298d20
+size 472

--- a/resource_packs/extras/dyes/paletteless_alternate_dyes/textures/items/dye_powder_green.png
+++ b/resource_packs/extras/dyes/paletteless_alternate_dyes/textures/items/dye_powder_green.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ab4885850e6094106c47cbc551e91c8c05bd22760d4ab077761b6dadc911b2a5
+size 477

--- a/resource_packs/extras/dyes/paletteless_alternate_dyes/textures/items/dye_powder_light_blue.png
+++ b/resource_packs/extras/dyes/paletteless_alternate_dyes/textures/items/dye_powder_light_blue.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d2ea84a5f86c0920eaefd41562ec764944e0fcad78ffe165bcdfadf8075c7f62
+size 475

--- a/resource_packs/extras/dyes/paletteless_alternate_dyes/textures/items/dye_powder_lime.png
+++ b/resource_packs/extras/dyes/paletteless_alternate_dyes/textures/items/dye_powder_lime.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:775b89cea8d61f26f5b176dd742ef89cc4091bc4a5fb59dcc46b6b479f71cacf
+size 472

--- a/resource_packs/extras/dyes/paletteless_alternate_dyes/textures/items/dye_powder_magenta.png
+++ b/resource_packs/extras/dyes/paletteless_alternate_dyes/textures/items/dye_powder_magenta.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5a5765c2d787d7265950692e8bb69941f5d32b8fc1d66685ddc22e26633a43a9
+size 488

--- a/resource_packs/extras/dyes/paletteless_alternate_dyes/textures/items/dye_powder_pink.png
+++ b/resource_packs/extras/dyes/paletteless_alternate_dyes/textures/items/dye_powder_pink.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f7b899a6b11768fd22ff2554414a162cbf4c3bce9c62b0a0e37fb86d1be73a20
+size 483

--- a/resource_packs/extras/dyes/paletteless_alternate_dyes/textures/items/dye_powder_purple.png
+++ b/resource_packs/extras/dyes/paletteless_alternate_dyes/textures/items/dye_powder_purple.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cac2bec6b3a02be3c2a76c46b90e598927d69a15ab6edfe1f46423acdbebe0e7
+size 471

--- a/resource_packs/extras/dyes/paletteless_alternate_dyes/textures/items/dye_powder_white_new.png
+++ b/resource_packs/extras/dyes/paletteless_alternate_dyes/textures/items/dye_powder_white_new.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4cd33bd570b4cb6df3c9d1140cc3ae541901da4e1136e733b1c25cb8868a4511
+size 484

--- a/resource_packs/extras/dyes/paletteless_alternate_dyes/textures/items/dye_powder_yellow.png
+++ b/resource_packs/extras/dyes/paletteless_alternate_dyes/textures/items/dye_powder_yellow.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:089ac09ac51446502fa223d630bf462dda2055b28319698f5a89ef4c846d3a00
+size 470

--- a/resource_packs/packs.json
+++ b/resource_packs/packs.json
@@ -2299,9 +2299,14 @@
 			"name": "World of Color",
 			"packs": [
 				{
-					"id": "unique_dyes",
-					"name": "Unique Dyes",
-					"description": "Adds variation to the dyes by making each one different"
+					"id": "alternate_dyes",
+					"name": "Alternate Dyes",
+					"description": "Retextures dyes to make them even more unique to each other"
+				},
+				{
+					"id": "paletteless_dyes",
+					"name": "Paletteless Dyes",
+					"description": "Removes the palettes from under all dyes"
 				}
 			]
 		},
@@ -3658,6 +3663,13 @@
 			"combines": [
 				"parity/earth_wooly_cow",
 				"retro/snoutless_cows"
+			]
+		},
+		{
+			"id": "extras/dyes/paletteless_alternate_dyes",
+			"combines": [
+				"world_of_color/paletteless_dyes",
+				"world_of_color/alternate_dyes"
 			]
 		}
 	],


### PR DESCRIPTION
1. Added `paletteless_alternate_dyes` combination for combining Alternate Dyes and Paletteless Dyes
2. Added the entries for Alternate Dyes and Paletteless Dyes to `packs.json` so that it won't create a merge conflict when merging the PRs where the packs are added

Resolves #720

By checking the following boxes with an X, you ensure that:

- [X] The pack was tested ingame in at least one device.
- [X] The pack is an existing BT pack, is a missing pack from VT or is an accepted pack/change in a discussion.
- [X] The pack code follows the style guide.
- [X] The commits follow the contribution guidelines.
- [X] The PR follows the contribution guidelines.

- [X] (Optional) Tested in Windows
- [ ] (Optional) Tested in Android
- [ ] (Optional) Tested in iOS
- [ ] (Optional) Tested in any console
- [ ] (Optional) Tested in BDS
