### PR TITLE
fix(files): Add the missing crafter textures to Old Planks

### DIFF
--- a/resource_packs/files/retro/old_planks/textures/blocks/crafter_east.png
+++ b/resource_packs/files/retro/old_planks/textures/blocks/crafter_east.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c93ff5ef415621bbee22cb77ad9dd440aec8f1b4ee2a08affd8cab19e635a719
+size 546

--- a/resource_packs/files/retro/old_planks/textures/blocks/crafter_east_crafting.png
+++ b/resource_packs/files/retro/old_planks/textures/blocks/crafter_east_crafting.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:531bb34e88aefbb73577fa80b3b4aa90d1ce7baf4b31fd77b5589cb1e5c8826d
+size 547

--- a/resource_packs/files/retro/old_planks/textures/blocks/crafter_east_triggered.png
+++ b/resource_packs/files/retro/old_planks/textures/blocks/crafter_east_triggered.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d2fe959255a9faa32f014279e76086051e212b9e9fa3bfaba067dbafdae67ad8
+size 546

--- a/resource_packs/files/retro/old_planks/textures/blocks/crafter_north.png
+++ b/resource_packs/files/retro/old_planks/textures/blocks/crafter_north.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:298c3880a219cab7200cf6214f0a472c1e60d9c1b08f4f9b458c3f3ba6b87c78
+size 531

--- a/resource_packs/files/retro/old_planks/textures/blocks/crafter_north_crafting.png
+++ b/resource_packs/files/retro/old_planks/textures/blocks/crafter_north_crafting.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3826a0b7cf5840bc1e86d94ed4609624282e4002263ddce9adcf1a510679b767
+size 530

--- a/resource_packs/files/retro/old_planks/textures/blocks/crafter_south.png
+++ b/resource_packs/files/retro/old_planks/textures/blocks/crafter_south.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:71f1d880dc111d5d60f5979cc5b1299a6db81db077690fb7032fa6e288e0e142
+size 541

--- a/resource_packs/files/retro/old_planks/textures/blocks/crafter_south_triggered.png
+++ b/resource_packs/files/retro/old_planks/textures/blocks/crafter_south_triggered.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d45afa5a29c279d5bae5817277360f9d188498b69a9104522f4d2996ad06ab55
+size 545

--- a/resource_packs/files/retro/old_planks/textures/blocks/crafter_west.png
+++ b/resource_packs/files/retro/old_planks/textures/blocks/crafter_west.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d447255b5126a72416b679f34403aa523215779484e3389cefb54d6120a6663c
+size 542

--- a/resource_packs/files/retro/old_planks/textures/blocks/crafter_west_crafting.png
+++ b/resource_packs/files/retro/old_planks/textures/blocks/crafter_west_crafting.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a99bab3b36a62c4e7ea5626096a56b1093faeba77958cafec837761ecfee1e76
+size 543

--- a/resource_packs/files/retro/old_planks/textures/blocks/crafter_west_triggered.png
+++ b/resource_packs/files/retro/old_planks/textures/blocks/crafter_west_triggered.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:03e31a160920c08eb915a403aa7bbaf2d550e97a04d1a97964fd0f644d519069
+size 542


### PR DESCRIPTION
1. Add the missing crafter textures to Old Planks

Resolves #697

By checking the following boxes with an X, you ensure that:

- [X] The pack was tested ingame in at least one device.
- [X] The pack is an existing BT pack, is a missing pack from VT or is an accepted pack/change in a discussion.
- [X] The pack code follows the style guide.
- [X] The commits follow the contribution guidelines.
- [X] The PR follows the contribution guidelines.

- [X] (Optional) Tested in Windows
- [ ] (Optional) Tested in Android
- [ ] (Optional) Tested in iOS
- [ ] (Optional) Tested in any console
- [ ] (Optional) Tested in BDS
