### PR TITLE
update(files): Update Visual Waxed Copper Items to include the new copper blocks and items

### DIFF
--- a/resource_packs/files/utility/visual_waxed_copper_items/blocks.json
+++ b/resource_packs/files/utility/visual_waxed_copper_items/blocks.json
@@ -223,5 +223,165 @@
 		"sound": "copper",
 		"textures": "weathered_copper_trapdoor",
 		"carried_textures": "waxed_weathered_copper_trapdoor"
+	},
+	"waxed_copper_bars": {
+		"sound": "copper",
+		"textures": "copper_bars",
+		"carried_textures": "waxed_copper_bars"
+	},
+	"waxed_copper_chain": {
+		"sound": "chain",
+		"textures": {
+			"down": "copper_chain1",
+			"side": "copper_chain2",
+			"up": "copper_chain1"
+		},
+		"carried_textures": "waxed_copper_chain"
+	},
+	"waxed_copper_chest": {
+		"isotropic": false,
+		"sound": "copper_chest",
+		"textures": {
+			"down": "waxed_copper_chest_inventory_top",
+			"east": "waxed_copper_chest_inventory_side",
+			"north": "waxed_copper_chest_inventory_side",
+			"south": "waxed_copper_chest_inventory_front",
+			"up": "waxed_copper_chest_inventory_top",
+			"west": "waxed_copper_chest_inventory_side"
+		}
+	},
+	"waxed_copper_lantern": {
+		"sound": "lantern",
+		"textures": "copper_lantern",
+		"carried_textures": "waxed_copper_lantern"
+	},
+	"waxed_exposed_copper_bars": {
+		"sound": "copper",
+		"textures": "exposed_copper_bars",
+		"carried_textures": "waxed_exposed_copper_bars"
+	},
+	"waxed_exposed_copper_chain": {
+		"sound": "chain",
+		"textures": {
+			"down": "exposed_copper_chain1",
+			"side": "exposed_copper_chain2",
+			"up": "exposed_copper_chain1"
+		},
+		"carried_textures": "waxed_exposed_copper_chain"
+	},
+	"waxed_exposed_copper_chest": {
+		"isotropic": false,
+		"sound": "copper_chest",
+		"textures": {
+			"down": "waxed_exposed_copper_chest_inventory_top",
+			"east": "waxed_exposed_copper_chest_inventory_side",
+			"north": "waxed_exposed_copper_chest_inventory_side",
+			"south": "waxed_exposed_copper_chest_inventory_front",
+			"up": "waxed_exposed_copper_chest_inventory_top",
+			"west": "waxed_exposed_copper_chest_inventory_side"
+		}
+	},
+	"waxed_exposed_copper_lantern": {
+		"sound": "lantern",
+		"textures": "exposed_copper_lantern",
+		"carried_textures": "waxed_exposed_copper_lantern"
+	},
+	"waxed_oxidized_copper_bars": {
+		"sound": "copper",
+		"textures": "oxidized_copper_bars",
+		"carried_textures": "waxed_oxidized_copper_bars"
+	},
+	"waxed_oxidized_copper_chain": {
+		"sound": "chain",
+		"textures": {
+			"down": "oxidized_copper_chain1",
+			"side": "oxidized_copper_chain2",
+			"up": "oxidized_copper_chain1"
+		},
+		"carried_textures": "waxed_oxidized_copper_chain"
+	},
+	"waxed_oxidized_copper_chest": {
+		"isotropic": false,
+		"sound": "copper_chest_oxidized",
+		"textures": {
+			"down": "waxed_oxidized_copper_chest_inventory_top",
+			"east": "waxed_oxidized_copper_chest_inventory_side",
+			"north": "waxed_oxidized_copper_chest_inventory_side",
+			"south": "waxed_oxidized_copper_chest_inventory_front",
+			"up": "waxed_oxidized_copper_chest_inventory_top",
+			"west": "waxed_oxidized_copper_chest_inventory_side"
+		}
+	},
+	"waxed_oxidized_copper_lantern": {
+		"sound": "lantern",
+		"textures": "oxidized_copper_lantern",
+		"carried_textures": "waxed_oxidized_copper_lantern"
+	},
+	"waxed_weathered_copper_bars": {
+		"sound": "copper",
+		"textures": "weathered_copper_bars",
+		"carried_textures": "waxed_weathered_copper_bars"
+	},
+	"waxed_weathered_copper_chain": {
+		"sound": "chain",
+		"textures": {
+			"down": "weathered_copper_chain1",
+			"side": "weathered_copper_chain2",
+			"up": "weathered_copper_chain1"
+		},
+		"carried_textures": "waxed_weathered_copper_chain"
+	},
+	"waxed_weathered_copper_chest": {
+		"isotropic": false,
+		"sound": "copper_chest_weathered",
+		"textures": {
+			"down": "waxed_weathered_copper_chest_inventory_top",
+			"east": "waxed_weathered_copper_chest_inventory_side",
+			"north": "waxed_weathered_copper_chest_inventory_side",
+			"south": "waxed_weathered_copper_chest_inventory_front",
+			"up": "waxed_weathered_copper_chest_inventory_top",
+			"west": "waxed_weathered_copper_chest_inventory_side"
+		}
+	},
+	"waxed_weathered_copper_lantern": {
+		"sound": "lantern",
+		"textures": "weathered_copper_lantern",
+		"carried_textures": "waxed_weathered_copper_lantern"
+	},
+	"waxed_exposed_lightning_rod": {
+		"isotropic": false,
+		"sound": "copper",
+		"textures": {
+			"up": "waxed_exposed_lightning_rod",
+			"side": "exposed_lightning_rod",
+			"down": "exposed_lightning_rod"
+		}
+	},
+	"waxed_lightning_rod": {
+		"isotropic": false,
+		"sound": "copper",
+		"textures": {
+			"up": "waxed_lightning_rod",
+			"side": "lightning_rod",
+			"down": "lightning_rod"
+		}
+	},
+	"waxed_oxidized_lightning_rod": {
+		"isotropic": false,
+		"sound": "copper",
+		"textures": {
+			"up": "waxed_oxidized_lightning_rod",
+			"side": "oxidized_lightning_rod",
+			"down": "oxidized_lightning_rod"
+		}
+	},
+	"waxed_weathered_lightning_rod": {
+		"isotropic": false,
+		"sound": "copper",
+		"textures": {
+			"up": "waxed_weathered_lightning_rod",
+			"side": "weathered_lightning_rod",
+			"down": "weathered_lightning_rod"
+		}
 	}
 }

--- a/resource_packs/files/utility/visual_waxed_copper_items/textures/blocks/waxed_copper_bars.png
+++ b/resource_packs/files/utility/visual_waxed_copper_items/textures/blocks/waxed_copper_bars.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7d7a73d9b9b54e057fe173579c0aed4fa1b1fc3229a4975a9e65f9cd60208318
+size 548

--- a/resource_packs/files/utility/visual_waxed_copper_items/textures/blocks/waxed_copper_chain.png
+++ b/resource_packs/files/utility/visual_waxed_copper_items/textures/blocks/waxed_copper_chain.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d2e8236b7e4d766b8ecb469ff0297af3fa173d745450ffad1bb2f0adf1399f0c
+size 489

--- a/resource_packs/files/utility/visual_waxed_copper_items/textures/blocks/waxed_copper_chest_inventory_front.png
+++ b/resource_packs/files/utility/visual_waxed_copper_items/textures/blocks/waxed_copper_chest_inventory_front.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1ed4b73050d36d38b2ebf69099adc55bb072180f8861bd73bd6113cdd9c9e43f
+size 570

--- a/resource_packs/files/utility/visual_waxed_copper_items/textures/blocks/waxed_copper_chest_inventory_side.png
+++ b/resource_packs/files/utility/visual_waxed_copper_items/textures/blocks/waxed_copper_chest_inventory_side.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e2aede910a17e1ab9fce43360f2b2374152b8089dbf843d2fc834033be969651
+size 552

--- a/resource_packs/files/utility/visual_waxed_copper_items/textures/blocks/waxed_copper_chest_inventory_top.png
+++ b/resource_packs/files/utility/visual_waxed_copper_items/textures/blocks/waxed_copper_chest_inventory_top.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:71f1f3b91cf673e6a5565d43e785818e3ec727c48b7ac5ed09ddd3908effe2bb
+size 546

--- a/resource_packs/files/utility/visual_waxed_copper_items/textures/blocks/waxed_copper_lantern.png
+++ b/resource_packs/files/utility/visual_waxed_copper_items/textures/blocks/waxed_copper_lantern.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a7c31569b36a442cb69eb08b4e6df8e4b4c64420f97bcfd4b11a80ac6dfe2448
+size 529

--- a/resource_packs/files/utility/visual_waxed_copper_items/textures/blocks/waxed_exposed_copper_bars.png
+++ b/resource_packs/files/utility/visual_waxed_copper_items/textures/blocks/waxed_exposed_copper_bars.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7658ca7f7968d12a30b3218c6bba0b4acb6830f817376239b1d6f219b7ea02eb
+size 555

--- a/resource_packs/files/utility/visual_waxed_copper_items/textures/blocks/waxed_exposed_copper_chain.png
+++ b/resource_packs/files/utility/visual_waxed_copper_items/textures/blocks/waxed_exposed_copper_chain.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:96ee200aa8ccca70eaba80d6e3e2bc18dde4ab3f344be3b7c151fc24648a89e5
+size 493

--- a/resource_packs/files/utility/visual_waxed_copper_items/textures/blocks/waxed_exposed_copper_chest_inventory_front.png
+++ b/resource_packs/files/utility/visual_waxed_copper_items/textures/blocks/waxed_exposed_copper_chest_inventory_front.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d7d091e3c9532c83e9cf382e4d119d21cf6d958200c23b0c2a4b0c7325395479
+size 553

--- a/resource_packs/files/utility/visual_waxed_copper_items/textures/blocks/waxed_exposed_copper_chest_inventory_side.png
+++ b/resource_packs/files/utility/visual_waxed_copper_items/textures/blocks/waxed_exposed_copper_chest_inventory_side.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2fb2cd97eb16db6b40853ada2bea59265902a8aeb4d1b79c6509492667722b3d
+size 549

--- a/resource_packs/files/utility/visual_waxed_copper_items/textures/blocks/waxed_exposed_copper_chest_inventory_top.png
+++ b/resource_packs/files/utility/visual_waxed_copper_items/textures/blocks/waxed_exposed_copper_chest_inventory_top.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:09e09a00242f83a91566d9a8db59b7dee456a9e0001c0d3bc3995a0ca2cb004c
+size 547

--- a/resource_packs/files/utility/visual_waxed_copper_items/textures/blocks/waxed_exposed_copper_lantern.png
+++ b/resource_packs/files/utility/visual_waxed_copper_items/textures/blocks/waxed_exposed_copper_lantern.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8ceb9f5d0bb030b889711e8d77db496857995442e78561d0b666a311348b30a9
+size 534

--- a/resource_packs/files/utility/visual_waxed_copper_items/textures/blocks/waxed_exposed_lightning_rod.png
+++ b/resource_packs/files/utility/visual_waxed_copper_items/textures/blocks/waxed_exposed_lightning_rod.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:61093fa86e8089d0c6200cd8ed19fa85dc2f343b68f8d0c4b4c03daf14cab0ce
+size 497

--- a/resource_packs/files/utility/visual_waxed_copper_items/textures/blocks/waxed_lightning_rod.png
+++ b/resource_packs/files/utility/visual_waxed_copper_items/textures/blocks/waxed_lightning_rod.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0a392ad85a49e71ff719929a2cafc8bee88ac00f7da27c10446384fb0e31a125
+size 492

--- a/resource_packs/files/utility/visual_waxed_copper_items/textures/blocks/waxed_oxidized_copper_bars.png
+++ b/resource_packs/files/utility/visual_waxed_copper_items/textures/blocks/waxed_oxidized_copper_bars.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c86e809573bb6e3a6a13f1928666fcae47d8ce07495661d55c1694c58c8199ea
+size 548

--- a/resource_packs/files/utility/visual_waxed_copper_items/textures/blocks/waxed_oxidized_copper_chain.png
+++ b/resource_packs/files/utility/visual_waxed_copper_items/textures/blocks/waxed_oxidized_copper_chain.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3148c938b44068cf98aed93b0703542237aebfe7ebd370eab97aa946d4c5cbc4
+size 488

--- a/resource_packs/files/utility/visual_waxed_copper_items/textures/blocks/waxed_oxidized_copper_chest_inventory_front.png
+++ b/resource_packs/files/utility/visual_waxed_copper_items/textures/blocks/waxed_oxidized_copper_chest_inventory_front.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:625903a79618c60ffcaf8ce499c17171b1a489fafd5b6819d03b67f43a6d9410
+size 560

--- a/resource_packs/files/utility/visual_waxed_copper_items/textures/blocks/waxed_oxidized_copper_chest_inventory_side.png
+++ b/resource_packs/files/utility/visual_waxed_copper_items/textures/blocks/waxed_oxidized_copper_chest_inventory_side.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e29795dfdc3d2565a01fff796bb30ec8a6e1ed20404d25e1f59cb884faeb64b1
+size 544

--- a/resource_packs/files/utility/visual_waxed_copper_items/textures/blocks/waxed_oxidized_copper_chest_inventory_top.png
+++ b/resource_packs/files/utility/visual_waxed_copper_items/textures/blocks/waxed_oxidized_copper_chest_inventory_top.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f1da71ced8771b4924cdc327878fd8ae0e8d849f172d32f7d2acea125175ea8c
+size 541

--- a/resource_packs/files/utility/visual_waxed_copper_items/textures/blocks/waxed_oxidized_copper_lantern.png
+++ b/resource_packs/files/utility/visual_waxed_copper_items/textures/blocks/waxed_oxidized_copper_lantern.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8938289d2fda52d49fc60e1183348b56e194fbe47e6002ae57fc344cbb3fef1f
+size 536

--- a/resource_packs/files/utility/visual_waxed_copper_items/textures/blocks/waxed_oxidized_lightning_rod.png
+++ b/resource_packs/files/utility/visual_waxed_copper_items/textures/blocks/waxed_oxidized_lightning_rod.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:94ddff69cbb0ef171e83a20de23bcefd70cce4306ffe319c2c44cf96e42fb9b9
+size 495

--- a/resource_packs/files/utility/visual_waxed_copper_items/textures/blocks/waxed_weathered_copper_bars.png
+++ b/resource_packs/files/utility/visual_waxed_copper_items/textures/blocks/waxed_weathered_copper_bars.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:079cc7c0bc1189e94961095fad740ee7310143da4fa967aa588601378585a11a
+size 554

--- a/resource_packs/files/utility/visual_waxed_copper_items/textures/blocks/waxed_weathered_copper_chain.png
+++ b/resource_packs/files/utility/visual_waxed_copper_items/textures/blocks/waxed_weathered_copper_chain.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:93316ce794ec53889ca875d60642af85c8f07547d90faae43099105001ed2d0c
+size 493

--- a/resource_packs/files/utility/visual_waxed_copper_items/textures/blocks/waxed_weathered_copper_chest_inventory_front.png
+++ b/resource_packs/files/utility/visual_waxed_copper_items/textures/blocks/waxed_weathered_copper_chest_inventory_front.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:766116babc9eca6af94761c2e16e4f7419fad282af31cdaafe73b7ea10583640
+size 566

--- a/resource_packs/files/utility/visual_waxed_copper_items/textures/blocks/waxed_weathered_copper_chest_inventory_side.png
+++ b/resource_packs/files/utility/visual_waxed_copper_items/textures/blocks/waxed_weathered_copper_chest_inventory_side.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8bcc9cf6967c6b08ee2ab7c704c8bcad0f391d128aa65b99748501c1fc36ffa1
+size 549

--- a/resource_packs/files/utility/visual_waxed_copper_items/textures/blocks/waxed_weathered_copper_chest_inventory_top.png
+++ b/resource_packs/files/utility/visual_waxed_copper_items/textures/blocks/waxed_weathered_copper_chest_inventory_top.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f2ec761855472ddda01dfe86fdb1c099c0a57fa3ad4f62d62c9497a1915d7bd5
+size 546

--- a/resource_packs/files/utility/visual_waxed_copper_items/textures/blocks/waxed_weathered_copper_lantern.png
+++ b/resource_packs/files/utility/visual_waxed_copper_items/textures/blocks/waxed_weathered_copper_lantern.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dca109028a69386b89eb592375d3156e722d3412a6681493051b3f6c31ec916b
+size 529

--- a/resource_packs/files/utility/visual_waxed_copper_items/textures/blocks/waxed_weathered_lightning_rod.png
+++ b/resource_packs/files/utility/visual_waxed_copper_items/textures/blocks/waxed_weathered_lightning_rod.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:061ccc1e1b0025827612ff0d2a738c35bf4d3b3504295824219d58b00056d940
+size 501

--- a/resource_packs/files/utility/visual_waxed_copper_items/textures/terrain_texture.json
+++ b/resource_packs/files/utility/visual_waxed_copper_items/textures/terrain_texture.json
@@ -123,6 +123,126 @@
 		},
 		"waxed_weathered_copper_trapdoor": {
 			"textures": "textures/blocks/waxed_weathered_copper_trapdoor"
+		},
+		"waxed_copper_bars": {
+			"textures": "textures/blocks/waxed_copper_bars"
+		},
+		"waxed_copper_chain": {
+			"textures": "textures/blocks/waxed_copper_chain"
+		},
+		"waxed_copper_chest_inventory_top": {
+			"textures": [
+				"textures/blocks/waxed_copper_chest_inventory_top"
+			]
+		},
+		"waxed_copper_chest_inventory_side": {
+			"textures": [
+				"textures/blocks/waxed_copper_chest_inventory_side"
+			]
+		},
+		"waxed_copper_chest_inventory_front": {
+			"textures": [
+				"textures/blocks/waxed_copper_chest_inventory_front"
+			]
+		},
+		"waxed_copper_lantern": {
+			"textures": "textures/blocks/waxed_copper_lantern"
+		},
+		"waxed_exposed_copper_bars": {
+			"textures": "textures/blocks/waxed_exposed_copper_bars"
+		},
+		"waxed_exposed_copper_chain": {
+			"textures": "textures/blocks/waxed_exposed_copper_chain"
+		},
+		"waxed_exposed_copper_chest_inventory_top": {
+			"textures": [
+				"textures/blocks/waxed_exposed_copper_chest_inventory_top"
+			]
+		},
+		"waxed_exposed_copper_chest_inventory_side": {
+			"textures": [
+				"textures/blocks/waxed_exposed_copper_chest_inventory_side"
+			]
+		},
+		"waxed_exposed_copper_chest_inventory_front": {
+			"textures": [
+				"textures/blocks/waxed_exposed_copper_chest_inventory_front"
+			]
+		},
+		"waxed_exposed_copper_lantern": {
+			"textures": "textures/blocks/waxed_exposed_copper_lantern"
+		},
+		"waxed_oxidized_copper_bars": {
+			"textures": "textures/blocks/waxed_oxidized_copper_bars"
+		},
+		"waxed_oxidized_copper_chain": {
+			"textures": "textures/blocks/waxed_oxidized_copper_chain"
+		},
+		"waxed_oxidized_copper_chest_inventory_top": {
+			"textures": [
+				"textures/blocks/waxed_oxidized_copper_chest_inventory_top"
+			]
+		},
+		"waxed_oxidized_copper_chest_inventory_side": {
+			"textures": [
+				"textures/blocks/waxed_oxidized_copper_chest_inventory_side"
+			]
+		},
+		"waxed_oxidized_copper_chest_inventory_front": {
+			"textures": [
+				"textures/blocks/waxed_oxidized_copper_chest_inventory_front"
+			]
+		},
+		"waxed_oxidized_copper_lantern": {
+			"textures": "textures/blocks/waxed_oxidized_copper_lantern"
+		},
+		"waxed_weathered_copper_bars": {
+			"textures": "textures/blocks/waxed_weathered_copper_bars"
+		},
+		"waxed_weathered_copper_chain": {
+			"textures": "textures/blocks/waxed_weathered_copper_chain"
+		},
+		"waxed_weathered_copper_chest_inventory_top": {
+			"textures": [
+				"textures/blocks/waxed_weathered_copper_chest_inventory_top"
+			]
+		},
+		"waxed_weathered_copper_chest_inventory_side": {
+			"textures": [
+				"textures/blocks/waxed_weathered_copper_chest_inventory_side"
+			]
+		},
+		"waxed_weathered_copper_chest_inventory_front": {
+			"textures": [
+				"textures/blocks/waxed_weathered_copper_chest_inventory_front"
+			]
+		},
+		"waxed_weathered_copper_lantern": {
+			"textures": "textures/blocks/waxed_weathered_copper_lantern"
+		},
+		"waxed_exposed_lightning_rod": {
+			"textures": [
+				"textures/blocks/waxed_exposed_lightning_rod",
+				"textures/blocks/waxed_exposed_lightning_rod"
+			]
+		},
+		"waxed_lightning_rod": {
+			"textures": [
+				"textures/blocks/waxed_lightning_rod",
+				"textures/blocks/waxed_lightning_rod"
+			]
+		},
+		"waxed_oxidized_lightning_rod": {
+			"textures": [
+				"textures/blocks/waxed_oxidized_lightning_rod",
+				"textures/blocks/waxed_oxidized_lightning_rod"
+			]
+		},
+		"waxed_weathered_lightning_rod": {
+			"textures": [
+				"textures/blocks/waxed_weathered_lightning_rod",
+				"textures/blocks/waxed_weathered_lightning_rod"
+			]
 		}
 	}
 }


### PR DESCRIPTION
1. Update Visual Waxed Copper Items to include the new copper blocks and items
2. Waxed Copper Golem Statues and ~~Waxed Copper Lightning Rods~~ (Not anymore) are skipped due to not being able to change their carried texture using the usual way (Needs to be done)

Resolves #701

By checking the following boxes with an X, you ensure that:

- [X] The pack was tested ingame in at least one device.
- [X] The pack is an existing BT pack, is a missing pack from VT or is an accepted pack/change in a discussion.
- [X] The pack code follows the style guide.
- [X] The commits follow the contribution guidelines.
- [X] The PR follows the contribution guidelines.

- [X] (Optional) Tested in Windows
- [ ] (Optional) Tested in Android
- [ ] (Optional) Tested in iOS
- [ ] (Optional) Tested in any console
- [ ] (Optional) Tested in BDS
