### PR TITLE
fix(files): Fix Anti-Alias Font to use the correct backslash font instead of using the same font as slash

### DIFF
--- a/resource_packs/files/gui/fonts/anti_alias_font/font/default8.png
+++ b/resource_packs/files/gui/fonts/anti_alias_font/font/default8.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:5be75e4282b1966a49ec1b37c11b9abb522b366abd6c2770d4663545c6c9f006
-size 4052
+oid sha256:0220d197c5e7b12eca938a8e70b0bfb51354ba611d164f14006bc4100c6e90f4
+size 4053


### PR DESCRIPTION
1. Fix Anti-Alias Font to use the correct backslash font instead of using the same font as slash

This was actually a bug in Vanilla Tweaks which is now mirrored to Bedrock Tweaks

Resolves #709

By checking the following boxes with an X, you ensure that:

- [X] The pack was tested ingame in at least one device.
- [X] The pack is an existing BT pack, is a missing pack from VT or is an accepted pack/change in a discussion.
- [X] The pack code follows the style guide.
- [X] The commits follow the contribution guidelines.
- [X] The PR follows the contribution guidelines.

- [X] (Optional) Tested in Windows
- [ ] (Optional) Tested in Android
- [ ] (Optional) Tested in iOS
- [ ] (Optional) Tested in any console
- [ ] (Optional) Tested in BDS
