### PR TITLE
chore(files): Remove the bloat from `sound_definitions.json`

### DIFF
--- a/resource_packs/files/peace_and_quiet/mobs/quieter_armadillos/sounds/sound_definitions.json
+++ b/resource_packs/files/peace_and_quiet/mobs/quieter_armadillos/sounds/sound_definitions.json
@@ -2,9 +2,6 @@
 	"format_version": "1.20.20",
 	"sound_definitions": {
 		"mob.armadillo.roll": {
-			"category": "neutral",
-			"max_distance": null,
-			"min_distance": null,
 			"sounds": [
 				{
 					"name": "sounds/mob/armadillo/roll1",
@@ -25,9 +22,6 @@
 			]
 		},
 		"mob.armadillo.land": {
-			"category": "neutral",
-			"max_distance": null,
-			"min_distance": null,
 			"sounds": [
 				{
 					"name": "sounds/mob/armadillo/land1",
@@ -48,9 +42,6 @@
 			]
 		},
 		"mob.armadillo.peek": {
-			"category": "neutral",
-			"max_distance": null,
-			"min_distance": null,
 			"sounds": [
 				{
 					"name": "sounds/mob/armadillo/peek",
@@ -59,9 +50,6 @@
 			]
 		},
 		"mob.armadillo.unroll_start": {
-			"category": "neutral",
-			"max_distance": null,
-			"min_distance": null,
 			"sounds": [
 				{
 					"name": "sounds/mob/armadillo/unroll_start",
@@ -70,9 +58,6 @@
 			]
 		},
 		"mob.armadillo.unroll_finish": {
-			"category": "neutral",
-			"max_distance": null,
-			"min_distance": null,
 			"sounds": [
 				{
 					"name": "sounds/mob/armadillo/unroll_finish1",

--- a/resource_packs/files/peace_and_quiet/mobs/quieter_breezes/sounds/sound_definitions.json
+++ b/resource_packs/files/peace_and_quiet/mobs/quieter_breezes/sounds/sound_definitions.json
@@ -2,9 +2,6 @@
 	"format_version": "1.20.20",
 	"sound_definitions": {
 		"mob.breeze.charge": {
-			"category": "hostile",
-			"max_distance": 16.0,
-			"min_distance": null,
 			"sounds": [
 				{
 					"name": "sounds/mob/breeze/charge1",
@@ -24,9 +21,6 @@
 			]
 		},
 		"mob.breeze.inhale": {
-			"category": "hostile",
-			"max_distance": 16.0,
-			"min_distance": null,
 			"sounds": [
 				{
 					"name": "sounds/mob/breeze/inhale1",
@@ -51,9 +45,6 @@
 			]
 		},
 		"mob.breeze.slide": {
-			"category": "hostile",
-			"max_distance": 16.0,
-			"min_distance": null,
 			"sounds": [
 				{
 					"name": "sounds/mob/breeze/slide1",
@@ -78,9 +69,6 @@
 			]
 		},
 		"mob.breeze.whirl": {
-			"category": "hostile",
-			"max_distance": 16.0,
-			"min_distance": null,
 			"sounds": [
 				{
 					"name": "sounds/mob/breeze/whirl1",
@@ -105,9 +93,6 @@
 			]
 		},
 		"mob.breeze.idle_ground": {
-			"category": "hostile",
-			"max_distance": null,
-			"min_distance": null,
 			"sounds": [
 				{
 					"name": "sounds/mob/breeze/idle1",

--- a/resource_packs/files/peace_and_quiet/mobs/quieter_camels/sounds/sound_definitions.json
+++ b/resource_packs/files/peace_and_quiet/mobs/quieter_camels/sounds/sound_definitions.json
@@ -2,9 +2,6 @@
 	"format_version": "1.20.20",
 	"sound_definitions": {
 		"mob.camel.sit": {
-			"category": "neutral",
-			"max_distance": null,
-			"min_distance": null,
 			"sounds": [
 				{
 					"name": "sounds/mob/camel/sit1",
@@ -25,9 +22,6 @@
 			]
 		},
 		"mob.camel.stand": {
-			"category": "neutral",
-			"max_distance": null,
-			"min_distance": null,
 			"sounds": [
 				{
 					"name": "sounds/mob/camel/stand1",
@@ -52,9 +46,6 @@
 			]
 		},
 		"mob.camel.dash": {
-			"category": "neutral",
-			"max_distance": null,
-			"min_distance": null,
 			"sounds": [
 				{
 					"name": "sounds/mob/camel/dash1",

--- a/resource_packs/files/peace_and_quiet/mobs/quieter_creakings/sounds/sound_definitions.json
+++ b/resource_packs/files/peace_and_quiet/mobs/quieter_creakings/sounds/sound_definitions.json
@@ -2,10 +2,6 @@
 	"format_version": "1.20.20",
 	"sound_definitions": {
 		"mob.creaking.sway": {
-			"__use_legacy_max_distance": "true",
-			"category": "hostile",
-			"max_distance": null,
-			"min_distance": null,
 			"sounds": [
 				{
 					"name": "sounds/mob/creaking/sway1",
@@ -26,10 +22,6 @@
 			]
 		},
 		"mob.creaking.twitch": {
-			"__use_legacy_max_distance": "true",
-			"category": "hostile",
-			"max_distance": 16.0,
-			"min_distance": null,
 			"sounds": [
 				{
 					"name": "sounds/mob/creaking/twitch",

--- a/resource_packs/files/peace_and_quiet/mobs/quieter_sniffers/sounds/sound_definitions.json
+++ b/resource_packs/files/peace_and_quiet/mobs/quieter_sniffers/sounds/sound_definitions.json
@@ -2,9 +2,6 @@
 	"format_version": "1.20.20",
 	"sound_definitions": {
 		"mob.sniffer.drop_seed": {
-			"category": "neutral",
-			"max_distance": null,
-			"min_distance": null,
 			"sounds": [
 				{
 					"name": "sounds/random/pop",
@@ -24,9 +21,6 @@
 			]
 		},
 		"mob.sniffer.sniffsniff": {
-			"category": "neutral",
-			"max_distance": null,
-			"min_distance": null,
 			"sounds": [
 				{
 					"name": "sounds/mob/sniffer/scenting1",
@@ -43,9 +37,6 @@
 			]
 		},
 		"mob.sniffer.searching": {
-			"category": "neutral",
-			"max_distance": null,
-			"min_distance": null,
 			"sounds": [
 				{
 					"name": "sounds/mob/sniffer/searching1",
@@ -98,9 +89,6 @@
 			]
 		},
 		"mob.sniffer.long_sniff": {
-			"category": "neutral",
-			"max_distance": null,
-			"min_distance": null,
 			"sounds": [
 				{
 					"name": "sounds/mob/sniffer/sniffing1",
@@ -117,9 +105,6 @@
 			]
 		},
 		"mob.sniffer.digging": {
-			"category": "neutral",
-			"max_distance": null,
-			"min_distance": null,
 			"sounds": [
 				{
 					"name": "sounds/mob/sniffer/longdig1",
@@ -132,9 +117,6 @@
 			]
 		},
 		"mob.sniffer.stand_up": {
-			"category": "neutral",
-			"max_distance": null,
-			"min_distance": null,
 			"sounds": [
 				{
 					"name": "sounds/mob/sniffer/digging_stop1",
@@ -147,9 +129,6 @@
 			]
 		},
 		"mob.sniffer.happy": {
-			"category": "neutral",
-			"max_distance": null,
-			"min_distance": null,
 			"sounds": [
 				{
 					"name": "sounds/mob/sniffer/happy1",

--- a/resource_packs/files/peace_and_quiet/mobs/quieter_wardens/sounds/sound_definitions.json
+++ b/resource_packs/files/peace_and_quiet/mobs/quieter_wardens/sounds/sound_definitions.json
@@ -2,9 +2,6 @@
 	"format_version": "1.20.20",
 	"sound_definitions": {
 		"mob.warden.emerge": {
-			"category": "hostile",
-			"max_distance": 80.0,
-			"min_distance": null,
 			"sounds": [
 				{
 					"name": "sounds/mob/warden/emerge",
@@ -13,9 +10,6 @@
 			]
 		},
 		"mob.warden.sniff": {
-			"category": "hostile",
-			"max_distance": 80.0,
-			"min_distance": null,
 			"sounds": [
 				{
 					"name": "sounds/mob/warden/sniff_1",
@@ -36,9 +30,6 @@
 			]
 		},
 		"mob.warden.dig": {
-			"category": "hostile",
-			"max_distance": 80.0,
-			"min_distance": null,
 			"sounds": [
 				{
 					"name": "sounds/mob/warden/dig",
@@ -47,9 +38,6 @@
 			]
 		},
 		"mob.warden.roar": {
-			"category": "hostile",
-			"max_distance": 48.0,
-			"min_distance": null,
 			"sounds": [
 				{
 					"name": "sounds/mob/warden/roar_1",
@@ -74,9 +62,6 @@
 			]
 		},
 		"mob.warden.clicking": {
-			"category": "hostile",
-			"max_distance": 80.0,
-			"min_distance": null,
 			"sounds": [
 				{
 					"name": "sounds/mob/warden/tendril_clicks_1",

--- a/resource_packs/files/peace_and_quiet/quieter_dispensers_and_droppers/sounds/sound_definitions.json
+++ b/resource_packs/files/peace_and_quiet/quieter_dispensers_and_droppers/sounds/sound_definitions.json
@@ -2,9 +2,6 @@
 	"format_version": "1.20.20",
 	"sound_definitions": {
 		"block.click": {
-			"category": "block",
-			"max_distance": null,
-			"min_distance": null,
 			"sounds": [
 				{
 					"name": "sounds/random/click",

--- a/resource_packs/files/peace_and_quiet/quieter_rain/sounds/sound_definitions.json
+++ b/resource_packs/files/peace_and_quiet/quieter_rain/sounds/sound_definitions.json
@@ -2,10 +2,6 @@
 	"format_version": "1.20.20",
 	"sound_definitions": {
 		"ambient.weather.rain": {
-			"__use_legacy_max_distance": "true",
-			"category": "weather",
-			"max_distance": null,
-			"min_distance": 100.0,
 			"sounds": [
 				{
 					"load_on_low_memory": true,


### PR DESCRIPTION
1. Removed the bloats from all `sound_definitions.json` files as they are not needed

By checking the following boxes with an X, you ensure that:

- [X] The pack was tested ingame in at least one device.
- [X] The pack is an existing BT pack, is a missing pack from VT or is an accepted pack/change in a discussion.
- [X] The pack code follows the style guide.
- [X] The commits follow the contribution guidelines.
- [X] The PR follows the contribution guidelines.

- [X] (Optional) Tested in Windows
- [ ] (Optional) Tested in Android
- [ ] (Optional) Tested in iOS
- [ ] (Optional) Tested in any console
- [ ] (Optional) Tested in BDS
