### PR TITLE
feat(files): Add Xisuma's Hermitcraft Season 10 Base Panorama pack

### DIFF
--- a/resource_packs/files/gui/menu_panoramas/xisumas_hermitcraft_bases/season_10/pack_icon.png
+++ b/resource_packs/files/gui/menu_panoramas/xisumas_hermitcraft_bases/season_10/pack_icon.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bc14601b638b18e18706519a28127eecf33785b65efa6282881ea7ad2ea2b04d
+size 12826

--- a/resource_packs/files/gui/menu_panoramas/xisumas_hermitcraft_bases/season_10/textures/ui/panorama_0.png
+++ b/resource_packs/files/gui/menu_panoramas/xisumas_hermitcraft_bases/season_10/textures/ui/panorama_0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:57ee266a9537433299e6c5d69f795cd680b5538a13d923bb53b74654570b8ad1
+size 935304

--- a/resource_packs/files/gui/menu_panoramas/xisumas_hermitcraft_bases/season_10/textures/ui/panorama_1.png
+++ b/resource_packs/files/gui/menu_panoramas/xisumas_hermitcraft_bases/season_10/textures/ui/panorama_1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a9bd9108b062644a42e60fd76ee0a4bcce173750f89524d5b52f980ee1459d3d
+size 835481

--- a/resource_packs/files/gui/menu_panoramas/xisumas_hermitcraft_bases/season_10/textures/ui/panorama_2.png
+++ b/resource_packs/files/gui/menu_panoramas/xisumas_hermitcraft_bases/season_10/textures/ui/panorama_2.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0c00613b178ec821339b9d2ecc1926f5b9101346cbc6165d58ee6e5eb579ee45
+size 826047

--- a/resource_packs/files/gui/menu_panoramas/xisumas_hermitcraft_bases/season_10/textures/ui/panorama_3.png
+++ b/resource_packs/files/gui/menu_panoramas/xisumas_hermitcraft_bases/season_10/textures/ui/panorama_3.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4f57a937c95d0b2a1cec1c2650a22255b1e12cd341813a82563ee77dc5b37f36
+size 780861

--- a/resource_packs/files/gui/menu_panoramas/xisumas_hermitcraft_bases/season_10/textures/ui/panorama_4.png
+++ b/resource_packs/files/gui/menu_panoramas/xisumas_hermitcraft_bases/season_10/textures/ui/panorama_4.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1b1c71bd4c1d269843ae5b9958c3e59deb68d93d35d161a1426d55fa75c63287
+size 408419

--- a/resource_packs/files/gui/menu_panoramas/xisumas_hermitcraft_bases/season_10/textures/ui/panorama_5.png
+++ b/resource_packs/files/gui/menu_panoramas/xisumas_hermitcraft_bases/season_10/textures/ui/panorama_5.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:86eb822840ec30b05d2608cc987ccec41e4bd01f03c5e9c5d00a9f5648e462ad
+size 165065

--- a/resource_packs/files/gui/menu_panoramas/xisumas_hermitcraft_bases/season_10/textures/ui/panoramahdr_0.hdr
+++ b/resource_packs/files/gui/menu_panoramas/xisumas_hermitcraft_bases/season_10/textures/ui/panoramahdr_0.hdr
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e53ced6d91a9b526f75b7194e4003e57089d7fb9c042952880923ecef2bde85a
+size 2871010

--- a/resource_packs/files/gui/menu_panoramas/xisumas_hermitcraft_bases/season_10/textures/ui/panoramahdr_1.hdr
+++ b/resource_packs/files/gui/menu_panoramas/xisumas_hermitcraft_bases/season_10/textures/ui/panoramahdr_1.hdr
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2150a05ac0d31ecc535a82c20323ec7dad7dc900e14b6d87cf88a160011dac50
+size 2745713

--- a/resource_packs/files/gui/menu_panoramas/xisumas_hermitcraft_bases/season_10/textures/ui/panoramahdr_2.hdr
+++ b/resource_packs/files/gui/menu_panoramas/xisumas_hermitcraft_bases/season_10/textures/ui/panoramahdr_2.hdr
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:278aaeb2cb9661e49e2e90ae6e4c8e002a3dec0d827d8157ca0b0e373cd08d1e
+size 2756751

--- a/resource_packs/files/gui/menu_panoramas/xisumas_hermitcraft_bases/season_10/textures/ui/panoramahdr_3.hdr
+++ b/resource_packs/files/gui/menu_panoramas/xisumas_hermitcraft_bases/season_10/textures/ui/panoramahdr_3.hdr
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:55b322ff57ea74e8afb1747754fc875b97081341a504596ec906e925f79e74bd
+size 2683554

--- a/resource_packs/files/gui/menu_panoramas/xisumas_hermitcraft_bases/season_10/textures/ui/panoramahdr_4.hdr
+++ b/resource_packs/files/gui/menu_panoramas/xisumas_hermitcraft_bases/season_10/textures/ui/panoramahdr_4.hdr
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d5ccd6ac217f71cb427caa5c48d55a41f698e3c78846d9c701638ffc05aff6f6
+size 2328944

--- a/resource_packs/files/gui/menu_panoramas/xisumas_hermitcraft_bases/season_10/textures/ui/panoramahdr_5.hdr
+++ b/resource_packs/files/gui/menu_panoramas/xisumas_hermitcraft_bases/season_10/textures/ui/panoramahdr_5.hdr
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:aa89cd6daf55e3b4cb0e0a561b532b987800b581b25656ccbe1940fb48209e72
+size 1291289

--- a/resource_packs/files/gui/menu_panoramas/xisumas_hermitcraft_bases/season_10/ui/start_screen.json
+++ b/resource_packs/files/gui/menu_panoramas/xisumas_hermitcraft_bases/season_10/ui/start_screen.json
@@ -1,0 +1,26 @@
+{
+	"namespace": "start",
+	"panorama_overlay_image": {
+		"type": "image",
+		"size": [
+			"fill",
+			"fill"
+		],
+		"texture": "textures/ui/panorama_overlay"
+	},
+	"start_screen_content": {
+		"modifications": [
+			{
+				"array_name": "controls",
+				"operation": "insert_back",
+				"value": [
+					{
+						"panorama_overlay@start.panorama_overlay_image": {
+							"layer": -10
+						}
+					}
+				]
+			}
+		]
+	}
+}

--- a/resource_packs/packs.json
+++ b/resource_packs/packs.json
@@ -1891,7 +1891,6 @@
 					"id": "happy_ghasts_panorama",
 					"name": "Happy Ghasts Panorama",
 					"description": "Replaces the default Minecraft menu panorama with a 360° view of Happy Ghasts flying around a valley! (from 1.21.90)"
-					
 				},
 				{
 					"id": "pale_garden_panorama",
@@ -2003,6 +2002,11 @@
 					"id": "season_9",
 					"name": "Season 9",
 					"description": "Replaces the default Minecraft menu panorama with a 360° view of Xisuma's base from Hermitcraft Season 9"
+				},
+				{
+					"id": "season_10",
+					"name": "Season 10",
+					"description": "Replaces the default Minecraft menu panorama with a 360° view of Xisuma's base from Hermitcraft Season 10"
 				}
 			]
 		},


### PR DESCRIPTION
1. Add Season 10 pack to GUI / Menu Panoramas / Xisuma's Hermitcraft Bases category

Resolves #721

By checking the following boxes with an X, you ensure that:

- [X] The pack was tested ingame in at least one device.
- [X] The pack is an existing BT pack, is a missing pack from VT or is an accepted pack/change in a discussion.
- [X] The pack code follows the style guide.
- [X] The commits follow the contribution guidelines.
- [X] The PR follows the contribution guidelines.

- [X] (Optional) Tested in Windows
- [ ] (Optional) Tested in Android
- [ ] (Optional) Tested in iOS
- [ ] (Optional) Tested in any console
- [ ] (Optional) Tested in BDS
