### PR TITLE
chore(files): Remove the auto deploy when a PR is merged

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,8 +1,6 @@
 name: Deploy
 
 on:
-  push:
-    branches: [ "main", "devel" ]
   workflow_dispatch:
     inputs:
       branch:


### PR DESCRIPTION
1. This is bad as it will exhaust Git LFS quota very quickly and its recommended to just trigger it manually after all the PRs are merged
