### PR TITLE
update(files): Update Clearer Water and Old Water to 1.21.110

### DIFF
--- a/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/basalt_deltas.client_biome.json
+++ b/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/basalt_deltas.client_biome.json
@@ -1,8 +1,8 @@
 {
-	"format_version": "1.21.70",
+	"format_version": "1.21.110",
 	"minecraft:client_biome": {
 		"description": {
-			"identifier": "basalt_deltas"
+			"identifier": "minecraft:basalt_deltas"
 		},
 		"components": {
 			"minecraft:fog_appearance": {
@@ -27,6 +27,12 @@
 			},
 			"minecraft:water_identifier": {
 				"water_identifier": "minecraft:default_water"
+			},
+			"minecraft:precipitation": {
+				"white_ash": 2.0
+			},
+			"minecraft:biome_music": {
+				"music_definition": "basalt_deltas"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/cold_ocean.client_biome.json
+++ b/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/cold_ocean.client_biome.json
@@ -1,8 +1,8 @@
 {
-	"format_version": "1.21.70",
+	"format_version": "1.21.110",
 	"minecraft:client_biome": {
 		"description": {
-			"identifier": "cold_ocean"
+			"identifier": "minecraft:cold_ocean"
 		},
 		"components": {
 			"minecraft:fog_appearance": {
@@ -22,6 +22,9 @@
 			},
 			"minecraft:water_identifier": {
 				"water_identifier": "minecraft:default_water"
+			},
+			"minecraft:biome_music": {
+				"underwater_music": true
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/crimson_forest.client_biome.json
+++ b/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/crimson_forest.client_biome.json
@@ -1,8 +1,8 @@
 {
-	"format_version": "1.21.70",
+	"format_version": "1.21.110",
 	"minecraft:client_biome": {
 		"description": {
-			"identifier": "crimson_forest"
+			"identifier": "minecraft:crimson_forest"
 		},
 		"components": {
 			"minecraft:fog_appearance": {
@@ -27,6 +27,12 @@
 			},
 			"minecraft:water_identifier": {
 				"water_identifier": "minecraft:default_water"
+			},
+			"minecraft:precipitation": {
+				"red_spores": 0.25
+			},
+			"minecraft:biome_music": {
+				"music_definition": "crimson_forest"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/deep_cold_ocean.client_biome.json
+++ b/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/deep_cold_ocean.client_biome.json
@@ -1,8 +1,8 @@
 {
-	"format_version": "1.21.70",
+	"format_version": "1.21.110",
 	"minecraft:client_biome": {
 		"description": {
-			"identifier": "deep_cold_ocean"
+			"identifier": "minecraft:deep_cold_ocean"
 		},
 		"components": {
 			"minecraft:fog_appearance": {
@@ -22,6 +22,9 @@
 			},
 			"minecraft:water_identifier": {
 				"water_identifier": "minecraft:default_water"
+			},
+			"minecraft:biome_music": {
+				"underwater_music": true
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/deep_frozen_ocean.client_biome.json
+++ b/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/deep_frozen_ocean.client_biome.json
@@ -1,8 +1,8 @@
 {
-	"format_version": "1.21.70",
+	"format_version": "1.21.110",
 	"minecraft:client_biome": {
 		"description": {
-			"identifier": "deep_frozen_ocean"
+			"identifier": "minecraft:deep_frozen_ocean"
 		},
 		"components": {
 			"minecraft:fog_appearance": {
@@ -22,6 +22,9 @@
 			},
 			"minecraft:water_identifier": {
 				"water_identifier": "minecraft:default_water"
+			},
+			"minecraft:biome_music": {
+				"underwater_music": true
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/deep_lukewarm_ocean.client_biome.json
+++ b/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/deep_lukewarm_ocean.client_biome.json
@@ -1,8 +1,8 @@
 {
-	"format_version": "1.21.70",
+	"format_version": "1.21.110",
 	"minecraft:client_biome": {
 		"description": {
-			"identifier": "deep_lukewarm_ocean"
+			"identifier": "minecraft:deep_lukewarm_ocean"
 		},
 		"components": {
 			"minecraft:fog_appearance": {
@@ -22,6 +22,9 @@
 			},
 			"minecraft:water_identifier": {
 				"water_identifier": "minecraft:default_water"
+			},
+			"minecraft:biome_music": {
+				"underwater_music": true
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/deep_ocean.client_biome.json
+++ b/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/deep_ocean.client_biome.json
@@ -1,8 +1,8 @@
 {
-	"format_version": "1.21.70",
+	"format_version": "1.21.110",
 	"minecraft:client_biome": {
 		"description": {
-			"identifier": "deep_ocean"
+			"identifier": "minecraft:deep_ocean"
 		},
 		"components": {
 			"minecraft:fog_appearance": {
@@ -22,6 +22,9 @@
 			},
 			"minecraft:water_identifier": {
 				"water_identifier": "minecraft:default_water"
+			},
+			"minecraft:biome_music": {
+				"underwater_music": true
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/deep_warm_ocean.client_biome.json
+++ b/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/deep_warm_ocean.client_biome.json
@@ -1,8 +1,8 @@
 {
-	"format_version": "1.21.70",
+	"format_version": "1.21.110",
 	"minecraft:client_biome": {
 		"description": {
-			"identifier": "deep_warm_ocean"
+			"identifier": "minecraft:deep_warm_ocean"
 		},
 		"components": {
 			"minecraft:fog_appearance": {
@@ -22,6 +22,9 @@
 			},
 			"minecraft:water_identifier": {
 				"water_identifier": "minecraft:default_water"
+			},
+			"minecraft:biome_music": {
+				"underwater_music": true
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/forest.client_biome.json
+++ b/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/forest.client_biome.json
@@ -11,6 +11,9 @@
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
 			},
+			"minecraft:biome_music": {
+				"music_definition": "forest"
+			},
 			"minecraft:atmosphere_identifier": {
 				"atmosphere_identifier": "minecraft:default_atmospherics"
 			},

--- a/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/frozen_ocean.client_biome.json
+++ b/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/frozen_ocean.client_biome.json
@@ -1,8 +1,8 @@
 {
-	"format_version": "1.21.70",
+	"format_version": "1.21.110",
 	"minecraft:client_biome": {
 		"description": {
-			"identifier": "frozen_ocean"
+			"identifier": "minecraft:frozen_ocean"
 		},
 		"components": {
 			"minecraft:fog_appearance": {
@@ -22,6 +22,9 @@
 			},
 			"minecraft:water_identifier": {
 				"water_identifier": "minecraft:default_water"
+			},
+			"minecraft:biome_music": {
+				"underwater_music": true
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/frozen_river.client_biome.json
+++ b/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/frozen_river.client_biome.json
@@ -1,8 +1,8 @@
 {
-	"format_version": "1.21.70",
+	"format_version": "1.21.110",
 	"minecraft:client_biome": {
 		"description": {
-			"identifier": "frozen_river"
+			"identifier": "minecraft:frozen_river"
 		},
 		"components": {
 			"minecraft:fog_appearance": {
@@ -22,6 +22,9 @@
 			},
 			"minecraft:water_identifier": {
 				"water_identifier": "minecraft:default_water"
+			},
+			"minecraft:biome_music": {
+				"underwater_music": true
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/legacy_frozen_ocean.client_biome.json
+++ b/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/legacy_frozen_ocean.client_biome.json
@@ -1,8 +1,8 @@
 {
-	"format_version": "1.21.70",
+	"format_version": "1.21.110",
 	"minecraft:client_biome": {
 		"description": {
-			"identifier": "legacy_frozen_ocean"
+			"identifier": "minecraft:legacy_frozen_ocean"
 		},
 		"components": {
 			"minecraft:fog_appearance": {
@@ -22,6 +22,9 @@
 			},
 			"minecraft:water_identifier": {
 				"water_identifier": "minecraft:default_water"
+			},
+			"minecraft:biome_music": {
+				"underwater_music": true
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/lukewarm_ocean.client_biome.json
+++ b/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/lukewarm_ocean.client_biome.json
@@ -1,8 +1,8 @@
 {
-	"format_version": "1.21.70",
+	"format_version": "1.21.110",
 	"minecraft:client_biome": {
 		"description": {
-			"identifier": "lukewarm_ocean"
+			"identifier": "minecraft:lukewarm_ocean"
 		},
 		"components": {
 			"minecraft:fog_appearance": {
@@ -22,6 +22,9 @@
 			},
 			"minecraft:water_identifier": {
 				"water_identifier": "minecraft:default_water"
+			},
+			"minecraft:biome_music": {
+				"underwater_music": true
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/ocean.client_biome.json
+++ b/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/ocean.client_biome.json
@@ -1,8 +1,8 @@
 {
-	"format_version": "1.21.70",
+	"format_version": "1.21.110",
 	"minecraft:client_biome": {
 		"description": {
-			"identifier": "ocean"
+			"identifier": "minecraft:ocean"
 		},
 		"components": {
 			"minecraft:fog_appearance": {
@@ -22,6 +22,9 @@
 			},
 			"minecraft:water_identifier": {
 				"water_identifier": "minecraft:default_water"
+			},
+			"minecraft:biome_music": {
+				"underwater_music": true
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/river.client_biome.json
+++ b/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/river.client_biome.json
@@ -1,8 +1,8 @@
 {
-	"format_version": "1.21.70",
+	"format_version": "1.21.110",
 	"minecraft:client_biome": {
 		"description": {
-			"identifier": "river"
+			"identifier": "minecraft:river"
 		},
 		"components": {
 			"minecraft:fog_appearance": {
@@ -22,6 +22,9 @@
 			},
 			"minecraft:water_identifier": {
 				"water_identifier": "minecraft:default_water"
+			},
+			"minecraft:biome_music": {
+				"underwater_music": true
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/roofed_forest.client_biome.json
+++ b/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/roofed_forest.client_biome.json
@@ -28,6 +28,9 @@
 			},
 			"minecraft:grass_appearance": {
 				"grass_is_shaded": true
+			},
+			"minecraft:biome_music": {
+				"music_definition": "roofed_forest"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/soulsand_valley.client_biome.json
+++ b/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/soulsand_valley.client_biome.json
@@ -1,8 +1,8 @@
 {
-	"format_version": "1.21.70",
+	"format_version": "1.21.110",
 	"minecraft:client_biome": {
 		"description": {
-			"identifier": "soulsand_valley"
+			"identifier": "minecraft:soulsand_valley"
 		},
 		"components": {
 			"minecraft:fog_appearance": {
@@ -27,6 +27,12 @@
 			},
 			"minecraft:water_identifier": {
 				"water_identifier": "minecraft:default_water"
+			},
+			"minecraft:precipitation": {
+				"ash": 0.05
+			},
+			"minecraft:biome_music": {
+				"music_definition": "soulsand_valley"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/warm_ocean.client_biome.json
+++ b/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/warm_ocean.client_biome.json
@@ -1,8 +1,8 @@
 {
-	"format_version": "1.21.70",
+	"format_version": "1.21.110",
 	"minecraft:client_biome": {
 		"description": {
-			"identifier": "warm_ocean"
+			"identifier": "minecraft:warm_ocean"
 		},
 		"components": {
 			"minecraft:fog_appearance": {
@@ -23,6 +23,9 @@
 			},
 			"minecraft:water_identifier": {
 				"water_identifier": "minecraft:default_water"
+			},
+			"minecraft:biome_music": {
+				"underwater_music": true
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/warped_forest.client_biome.json
+++ b/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/warped_forest.client_biome.json
@@ -1,8 +1,8 @@
 {
-	"format_version": "1.21.70",
+	"format_version": "1.21.110",
 	"minecraft:client_biome": {
 		"description": {
-			"identifier": "warped_forest"
+			"identifier": "minecraft:warped_forest"
 		},
 		"components": {
 			"minecraft:fog_appearance": {
@@ -27,6 +27,12 @@
 			},
 			"minecraft:water_identifier": {
 				"water_identifier": "minecraft:default_water"
+			},
+			"minecraft:precipitation": {
+				"blue_spores": 0.25
+			},
+			"minecraft:biome_music": {
+				"music_definition": ""
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/old_clearer_water/biomes/basalt_deltas.client_biome.json
+++ b/resource_packs/extras/terrain/old_clearer_water/biomes/basalt_deltas.client_biome.json
@@ -1,8 +1,8 @@
 {
-	"format_version": "1.21.70",
+	"format_version": "1.21.110",
 	"minecraft:client_biome": {
 		"description": {
-			"identifier": "basalt_deltas"
+			"identifier": "minecraft:basalt_deltas"
 		},
 		"components": {
 			"minecraft:fog_appearance": {
@@ -27,6 +27,12 @@
 			},
 			"minecraft:water_identifier": {
 				"water_identifier": "minecraft:default_water"
+			},
+			"minecraft:precipitation": {
+				"white_ash": 2.0
+			},
+			"minecraft:biome_music": {
+				"music_definition": "basalt_deltas"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/old_clearer_water/biomes/cold_ocean.client_biome.json
+++ b/resource_packs/extras/terrain/old_clearer_water/biomes/cold_ocean.client_biome.json
@@ -1,8 +1,8 @@
 {
-	"format_version": "1.21.70",
+	"format_version": "1.21.110",
 	"minecraft:client_biome": {
 		"description": {
-			"identifier": "cold_ocean"
+			"identifier": "minecraft:cold_ocean"
 		},
 		"components": {
 			"minecraft:fog_appearance": {
@@ -22,6 +22,9 @@
 			},
 			"minecraft:water_identifier": {
 				"water_identifier": "minecraft:default_water"
+			},
+			"minecraft:biome_music": {
+				"underwater_music": true
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/old_clearer_water/biomes/crimson_forest.client_biome.json
+++ b/resource_packs/extras/terrain/old_clearer_water/biomes/crimson_forest.client_biome.json
@@ -1,8 +1,8 @@
 {
-	"format_version": "1.21.70",
+	"format_version": "1.21.110",
 	"minecraft:client_biome": {
 		"description": {
-			"identifier": "crimson_forest"
+			"identifier": "minecraft:crimson_forest"
 		},
 		"components": {
 			"minecraft:fog_appearance": {
@@ -27,6 +27,12 @@
 			},
 			"minecraft:water_identifier": {
 				"water_identifier": "minecraft:default_water"
+			},
+			"minecraft:precipitation": {
+				"red_spores": 0.25
+			},
+			"minecraft:biome_music": {
+				"music_definition": "crimson_forest"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/old_clearer_water/biomes/deep_cold_ocean.client_biome.json
+++ b/resource_packs/extras/terrain/old_clearer_water/biomes/deep_cold_ocean.client_biome.json
@@ -1,8 +1,8 @@
 {
-	"format_version": "1.21.70",
+	"format_version": "1.21.110",
 	"minecraft:client_biome": {
 		"description": {
-			"identifier": "deep_cold_ocean"
+			"identifier": "minecraft:deep_cold_ocean"
 		},
 		"components": {
 			"minecraft:fog_appearance": {
@@ -22,6 +22,9 @@
 			},
 			"minecraft:water_identifier": {
 				"water_identifier": "minecraft:default_water"
+			},
+			"minecraft:biome_music": {
+				"underwater_music": true
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/old_clearer_water/biomes/deep_frozen_ocean.client_biome.json
+++ b/resource_packs/extras/terrain/old_clearer_water/biomes/deep_frozen_ocean.client_biome.json
@@ -1,8 +1,8 @@
 {
-	"format_version": "1.21.70",
+	"format_version": "1.21.110",
 	"minecraft:client_biome": {
 		"description": {
-			"identifier": "deep_frozen_ocean"
+			"identifier": "minecraft:deep_frozen_ocean"
 		},
 		"components": {
 			"minecraft:fog_appearance": {
@@ -22,6 +22,9 @@
 			},
 			"minecraft:water_identifier": {
 				"water_identifier": "minecraft:default_water"
+			},
+			"minecraft:biome_music": {
+				"underwater_music": true
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/old_clearer_water/biomes/deep_lukewarm_ocean.client_biome.json
+++ b/resource_packs/extras/terrain/old_clearer_water/biomes/deep_lukewarm_ocean.client_biome.json
@@ -1,8 +1,8 @@
 {
-	"format_version": "1.21.70",
+	"format_version": "1.21.110",
 	"minecraft:client_biome": {
 		"description": {
-			"identifier": "deep_lukewarm_ocean"
+			"identifier": "minecraft:deep_lukewarm_ocean"
 		},
 		"components": {
 			"minecraft:fog_appearance": {
@@ -22,6 +22,9 @@
 			},
 			"minecraft:water_identifier": {
 				"water_identifier": "minecraft:default_water"
+			},
+			"minecraft:biome_music": {
+				"underwater_music": true
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/old_clearer_water/biomes/deep_ocean.client_biome.json
+++ b/resource_packs/extras/terrain/old_clearer_water/biomes/deep_ocean.client_biome.json
@@ -1,8 +1,8 @@
 {
-	"format_version": "1.21.70",
+	"format_version": "1.21.110",
 	"minecraft:client_biome": {
 		"description": {
-			"identifier": "deep_ocean"
+			"identifier": "minecraft:deep_ocean"
 		},
 		"components": {
 			"minecraft:fog_appearance": {
@@ -22,6 +22,9 @@
 			},
 			"minecraft:water_identifier": {
 				"water_identifier": "minecraft:default_water"
+			},
+			"minecraft:biome_music": {
+				"underwater_music": true
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/old_clearer_water/biomes/deep_warm_ocean.client_biome.json
+++ b/resource_packs/extras/terrain/old_clearer_water/biomes/deep_warm_ocean.client_biome.json
@@ -1,8 +1,8 @@
 {
-	"format_version": "1.21.70",
+	"format_version": "1.21.110",
 	"minecraft:client_biome": {
 		"description": {
-			"identifier": "deep_warm_ocean"
+			"identifier": "minecraft:deep_warm_ocean"
 		},
 		"components": {
 			"minecraft:fog_appearance": {
@@ -22,6 +22,9 @@
 			},
 			"minecraft:water_identifier": {
 				"water_identifier": "minecraft:default_water"
+			},
+			"minecraft:biome_music": {
+				"underwater_music": true
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/old_clearer_water/biomes/forest.client_biome.json
+++ b/resource_packs/extras/terrain/old_clearer_water/biomes/forest.client_biome.json
@@ -11,6 +11,9 @@
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
 			},
+			"minecraft:biome_music": {
+				"music_definition": "forest"
+			},
 			"minecraft:atmosphere_identifier": {
 				"atmosphere_identifier": "minecraft:default_atmospherics"
 			},

--- a/resource_packs/extras/terrain/old_clearer_water/biomes/frozen_ocean.client_biome.json
+++ b/resource_packs/extras/terrain/old_clearer_water/biomes/frozen_ocean.client_biome.json
@@ -1,8 +1,8 @@
 {
-	"format_version": "1.21.70",
+	"format_version": "1.21.110",
 	"minecraft:client_biome": {
 		"description": {
-			"identifier": "frozen_ocean"
+			"identifier": "minecraft:frozen_ocean"
 		},
 		"components": {
 			"minecraft:fog_appearance": {
@@ -22,6 +22,9 @@
 			},
 			"minecraft:water_identifier": {
 				"water_identifier": "minecraft:default_water"
+			},
+			"minecraft:biome_music": {
+				"underwater_music": true
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/old_clearer_water/biomes/frozen_river.client_biome.json
+++ b/resource_packs/extras/terrain/old_clearer_water/biomes/frozen_river.client_biome.json
@@ -1,8 +1,8 @@
 {
-	"format_version": "1.21.70",
+	"format_version": "1.21.110",
 	"minecraft:client_biome": {
 		"description": {
-			"identifier": "frozen_river"
+			"identifier": "minecraft:frozen_river"
 		},
 		"components": {
 			"minecraft:fog_appearance": {
@@ -22,6 +22,9 @@
 			},
 			"minecraft:water_identifier": {
 				"water_identifier": "minecraft:default_water"
+			},
+			"minecraft:biome_music": {
+				"underwater_music": true
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/old_clearer_water/biomes/legacy_frozen_ocean.client_biome.json
+++ b/resource_packs/extras/terrain/old_clearer_water/biomes/legacy_frozen_ocean.client_biome.json
@@ -1,8 +1,8 @@
 {
-	"format_version": "1.21.70",
+	"format_version": "1.21.110",
 	"minecraft:client_biome": {
 		"description": {
-			"identifier": "legacy_frozen_ocean"
+			"identifier": "minecraft:legacy_frozen_ocean"
 		},
 		"components": {
 			"minecraft:fog_appearance": {
@@ -22,6 +22,9 @@
 			},
 			"minecraft:water_identifier": {
 				"water_identifier": "minecraft:default_water"
+			},
+			"minecraft:biome_music": {
+				"underwater_music": true
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/old_clearer_water/biomes/lukewarm_ocean.client_biome.json
+++ b/resource_packs/extras/terrain/old_clearer_water/biomes/lukewarm_ocean.client_biome.json
@@ -1,8 +1,8 @@
 {
-	"format_version": "1.21.70",
+	"format_version": "1.21.110",
 	"minecraft:client_biome": {
 		"description": {
-			"identifier": "lukewarm_ocean"
+			"identifier": "minecraft:lukewarm_ocean"
 		},
 		"components": {
 			"minecraft:fog_appearance": {
@@ -22,6 +22,9 @@
 			},
 			"minecraft:water_identifier": {
 				"water_identifier": "minecraft:default_water"
+			},
+			"minecraft:biome_music": {
+				"underwater_music": true
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/old_clearer_water/biomes/ocean.client_biome.json
+++ b/resource_packs/extras/terrain/old_clearer_water/biomes/ocean.client_biome.json
@@ -1,8 +1,8 @@
 {
-	"format_version": "1.21.70",
+	"format_version": "1.21.110",
 	"minecraft:client_biome": {
 		"description": {
-			"identifier": "ocean"
+			"identifier": "minecraft:ocean"
 		},
 		"components": {
 			"minecraft:fog_appearance": {
@@ -22,6 +22,9 @@
 			},
 			"minecraft:water_identifier": {
 				"water_identifier": "minecraft:default_water"
+			},
+			"minecraft:biome_music": {
+				"underwater_music": true
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/old_clearer_water/biomes/river.client_biome.json
+++ b/resource_packs/extras/terrain/old_clearer_water/biomes/river.client_biome.json
@@ -1,8 +1,8 @@
 {
-	"format_version": "1.21.70",
+	"format_version": "1.21.110",
 	"minecraft:client_biome": {
 		"description": {
-			"identifier": "river"
+			"identifier": "minecraft:river"
 		},
 		"components": {
 			"minecraft:fog_appearance": {
@@ -22,6 +22,9 @@
 			},
 			"minecraft:water_identifier": {
 				"water_identifier": "minecraft:default_water"
+			},
+			"minecraft:biome_music": {
+				"underwater_music": true
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/old_clearer_water/biomes/roofed_forest.client_biome.json
+++ b/resource_packs/extras/terrain/old_clearer_water/biomes/roofed_forest.client_biome.json
@@ -28,6 +28,9 @@
 			},
 			"minecraft:grass_appearance": {
 				"grass_is_shaded": true
+			},
+			"minecraft:biome_music": {
+				"music_definition": "roofed_forest"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/old_clearer_water/biomes/soulsand_valley.client_biome.json
+++ b/resource_packs/extras/terrain/old_clearer_water/biomes/soulsand_valley.client_biome.json
@@ -1,8 +1,8 @@
 {
-	"format_version": "1.21.70",
+	"format_version": "1.21.110",
 	"minecraft:client_biome": {
 		"description": {
-			"identifier": "soulsand_valley"
+			"identifier": "minecraft:soulsand_valley"
 		},
 		"components": {
 			"minecraft:fog_appearance": {
@@ -27,6 +27,12 @@
 			},
 			"minecraft:water_identifier": {
 				"water_identifier": "minecraft:default_water"
+			},
+			"minecraft:precipitation": {
+				"ash": 0.05
+			},
+			"minecraft:biome_music": {
+				"music_definition": "soulsand_valley"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/old_clearer_water/biomes/warm_ocean.client_biome.json
+++ b/resource_packs/extras/terrain/old_clearer_water/biomes/warm_ocean.client_biome.json
@@ -1,8 +1,8 @@
 {
-	"format_version": "1.21.70",
+	"format_version": "1.21.110",
 	"minecraft:client_biome": {
 		"description": {
-			"identifier": "warm_ocean"
+			"identifier": "minecraft:warm_ocean"
 		},
 		"components": {
 			"minecraft:fog_appearance": {
@@ -23,6 +23,9 @@
 			},
 			"minecraft:water_identifier": {
 				"water_identifier": "minecraft:default_water"
+			},
+			"minecraft:biome_music": {
+				"underwater_music": true
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/old_clearer_water/biomes/warped_forest.client_biome.json
+++ b/resource_packs/extras/terrain/old_clearer_water/biomes/warped_forest.client_biome.json
@@ -1,8 +1,8 @@
 {
-	"format_version": "1.21.70",
+	"format_version": "1.21.110",
 	"minecraft:client_biome": {
 		"description": {
-			"identifier": "warped_forest"
+			"identifier": "minecraft:warped_forest"
 		},
 		"components": {
 			"minecraft:fog_appearance": {
@@ -27,6 +27,12 @@
 			},
 			"minecraft:water_identifier": {
 				"water_identifier": "minecraft:default_water"
+			},
+			"minecraft:precipitation": {
+				"blue_spores": 0.25
+			},
+			"minecraft:biome_music": {
+				"music_definition": ""
 			}
 		}
 	}

--- a/resource_packs/files/retro/old_water/biomes/basalt_deltas.client_biome.json
+++ b/resource_packs/files/retro/old_water/biomes/basalt_deltas.client_biome.json
@@ -1,8 +1,8 @@
 {
-	"format_version": "1.21.70",
+	"format_version": "1.21.110",
 	"minecraft:client_biome": {
 		"description": {
-			"identifier": "basalt_deltas"
+			"identifier": "minecraft:basalt_deltas"
 		},
 		"components": {
 			"minecraft:fog_appearance": {
@@ -27,6 +27,12 @@
 			},
 			"minecraft:water_identifier": {
 				"water_identifier": "minecraft:default_water"
+			},
+			"minecraft:precipitation": {
+				"white_ash": 2.0
+			},
+			"minecraft:biome_music": {
+				"music_definition": "basalt_deltas"
 			}
 		}
 	}

--- a/resource_packs/files/retro/old_water/biomes/cold_ocean.client_biome.json
+++ b/resource_packs/files/retro/old_water/biomes/cold_ocean.client_biome.json
@@ -1,8 +1,8 @@
 {
-	"format_version": "1.21.70",
+	"format_version": "1.21.110",
 	"minecraft:client_biome": {
 		"description": {
-			"identifier": "cold_ocean"
+			"identifier": "minecraft:cold_ocean"
 		},
 		"components": {
 			"minecraft:fog_appearance": {
@@ -22,6 +22,9 @@
 			},
 			"minecraft:water_identifier": {
 				"water_identifier": "minecraft:default_water"
+			},
+			"minecraft:biome_music": {
+				"underwater_music": true
 			}
 		}
 	}

--- a/resource_packs/files/retro/old_water/biomes/crimson_forest.client_biome.json
+++ b/resource_packs/files/retro/old_water/biomes/crimson_forest.client_biome.json
@@ -1,8 +1,8 @@
 {
-	"format_version": "1.21.70",
+	"format_version": "1.21.110",
 	"minecraft:client_biome": {
 		"description": {
-			"identifier": "crimson_forest"
+			"identifier": "minecraft:crimson_forest"
 		},
 		"components": {
 			"minecraft:fog_appearance": {
@@ -27,6 +27,12 @@
 			},
 			"minecraft:water_identifier": {
 				"water_identifier": "minecraft:default_water"
+			},
+			"minecraft:precipitation": {
+				"red_spores": 0.25
+			},
+			"minecraft:biome_music": {
+				"music_definition": "crimson_forest"
 			}
 		}
 	}

--- a/resource_packs/files/retro/old_water/biomes/deep_cold_ocean.client_biome.json
+++ b/resource_packs/files/retro/old_water/biomes/deep_cold_ocean.client_biome.json
@@ -1,8 +1,8 @@
 {
-	"format_version": "1.21.70",
+	"format_version": "1.21.110",
 	"minecraft:client_biome": {
 		"description": {
-			"identifier": "deep_cold_ocean"
+			"identifier": "minecraft:deep_cold_ocean"
 		},
 		"components": {
 			"minecraft:fog_appearance": {
@@ -22,6 +22,9 @@
 			},
 			"minecraft:water_identifier": {
 				"water_identifier": "minecraft:default_water"
+			},
+			"minecraft:biome_music": {
+				"underwater_music": true
 			}
 		}
 	}

--- a/resource_packs/files/retro/old_water/biomes/deep_frozen_ocean.client_biome.json
+++ b/resource_packs/files/retro/old_water/biomes/deep_frozen_ocean.client_biome.json
@@ -1,8 +1,8 @@
 {
-	"format_version": "1.21.70",
+	"format_version": "1.21.110",
 	"minecraft:client_biome": {
 		"description": {
-			"identifier": "deep_frozen_ocean"
+			"identifier": "minecraft:deep_frozen_ocean"
 		},
 		"components": {
 			"minecraft:fog_appearance": {
@@ -22,6 +22,9 @@
 			},
 			"minecraft:water_identifier": {
 				"water_identifier": "minecraft:default_water"
+			},
+			"minecraft:biome_music": {
+				"underwater_music": true
 			}
 		}
 	}

--- a/resource_packs/files/retro/old_water/biomes/deep_lukewarm_ocean.client_biome.json
+++ b/resource_packs/files/retro/old_water/biomes/deep_lukewarm_ocean.client_biome.json
@@ -1,8 +1,8 @@
 {
-	"format_version": "1.21.70",
+	"format_version": "1.21.110",
 	"minecraft:client_biome": {
 		"description": {
-			"identifier": "deep_lukewarm_ocean"
+			"identifier": "minecraft:deep_lukewarm_ocean"
 		},
 		"components": {
 			"minecraft:fog_appearance": {
@@ -22,6 +22,9 @@
 			},
 			"minecraft:water_identifier": {
 				"water_identifier": "minecraft:default_water"
+			},
+			"minecraft:biome_music": {
+				"underwater_music": true
 			}
 		}
 	}

--- a/resource_packs/files/retro/old_water/biomes/deep_ocean.client_biome.json
+++ b/resource_packs/files/retro/old_water/biomes/deep_ocean.client_biome.json
@@ -1,8 +1,8 @@
 {
-	"format_version": "1.21.70",
+	"format_version": "1.21.110",
 	"minecraft:client_biome": {
 		"description": {
-			"identifier": "deep_ocean"
+			"identifier": "minecraft:deep_ocean"
 		},
 		"components": {
 			"minecraft:fog_appearance": {
@@ -22,6 +22,9 @@
 			},
 			"minecraft:water_identifier": {
 				"water_identifier": "minecraft:default_water"
+			},
+			"minecraft:biome_music": {
+				"underwater_music": true
 			}
 		}
 	}

--- a/resource_packs/files/retro/old_water/biomes/deep_warm_ocean.client_biome.json
+++ b/resource_packs/files/retro/old_water/biomes/deep_warm_ocean.client_biome.json
@@ -1,8 +1,8 @@
 {
-	"format_version": "1.21.70",
+	"format_version": "1.21.110",
 	"minecraft:client_biome": {
 		"description": {
-			"identifier": "deep_warm_ocean"
+			"identifier": "minecraft:deep_warm_ocean"
 		},
 		"components": {
 			"minecraft:fog_appearance": {
@@ -22,6 +22,9 @@
 			},
 			"minecraft:water_identifier": {
 				"water_identifier": "minecraft:default_water"
+			},
+			"minecraft:biome_music": {
+				"underwater_music": true
 			}
 		}
 	}

--- a/resource_packs/files/retro/old_water/biomes/forest.client_biome.json
+++ b/resource_packs/files/retro/old_water/biomes/forest.client_biome.json
@@ -11,6 +11,9 @@
 			"minecraft:water_appearance": {
 				"surface_color": "#0056FF"
 			},
+			"minecraft:biome_music": {
+				"music_definition": "forest"
+			},
 			"minecraft:atmosphere_identifier": {
 				"atmosphere_identifier": "minecraft:default_atmospherics"
 			},

--- a/resource_packs/files/retro/old_water/biomes/frozen_ocean.client_biome.json
+++ b/resource_packs/files/retro/old_water/biomes/frozen_ocean.client_biome.json
@@ -1,8 +1,8 @@
 {
-	"format_version": "1.21.70",
+	"format_version": "1.21.110",
 	"minecraft:client_biome": {
 		"description": {
-			"identifier": "frozen_ocean"
+			"identifier": "minecraft:frozen_ocean"
 		},
 		"components": {
 			"minecraft:fog_appearance": {
@@ -22,6 +22,9 @@
 			},
 			"minecraft:water_identifier": {
 				"water_identifier": "minecraft:default_water"
+			},
+			"minecraft:biome_music": {
+				"underwater_music": true
 			}
 		}
 	}

--- a/resource_packs/files/retro/old_water/biomes/frozen_river.client_biome.json
+++ b/resource_packs/files/retro/old_water/biomes/frozen_river.client_biome.json
@@ -1,8 +1,8 @@
 {
-	"format_version": "1.21.70",
+	"format_version": "1.21.110",
 	"minecraft:client_biome": {
 		"description": {
-			"identifier": "frozen_river"
+			"identifier": "minecraft:frozen_river"
 		},
 		"components": {
 			"minecraft:fog_appearance": {
@@ -22,6 +22,9 @@
 			},
 			"minecraft:water_identifier": {
 				"water_identifier": "minecraft:default_water"
+			},
+			"minecraft:biome_music": {
+				"underwater_music": true
 			}
 		}
 	}

--- a/resource_packs/files/retro/old_water/biomes/legacy_frozen_ocean.client_biome.json
+++ b/resource_packs/files/retro/old_water/biomes/legacy_frozen_ocean.client_biome.json
@@ -1,8 +1,8 @@
 {
-	"format_version": "1.21.70",
+	"format_version": "1.21.110",
 	"minecraft:client_biome": {
 		"description": {
-			"identifier": "legacy_frozen_ocean"
+			"identifier": "minecraft:legacy_frozen_ocean"
 		},
 		"components": {
 			"minecraft:fog_appearance": {
@@ -22,6 +22,9 @@
 			},
 			"minecraft:water_identifier": {
 				"water_identifier": "minecraft:default_water"
+			},
+			"minecraft:biome_music": {
+				"underwater_music": true
 			}
 		}
 	}

--- a/resource_packs/files/retro/old_water/biomes/lukewarm_ocean.client_biome.json
+++ b/resource_packs/files/retro/old_water/biomes/lukewarm_ocean.client_biome.json
@@ -1,8 +1,8 @@
 {
-	"format_version": "1.21.70",
+	"format_version": "1.21.110",
 	"minecraft:client_biome": {
 		"description": {
-			"identifier": "lukewarm_ocean"
+			"identifier": "minecraft:lukewarm_ocean"
 		},
 		"components": {
 			"minecraft:fog_appearance": {
@@ -22,6 +22,9 @@
 			},
 			"minecraft:water_identifier": {
 				"water_identifier": "minecraft:default_water"
+			},
+			"minecraft:biome_music": {
+				"underwater_music": true
 			}
 		}
 	}

--- a/resource_packs/files/retro/old_water/biomes/ocean.client_biome.json
+++ b/resource_packs/files/retro/old_water/biomes/ocean.client_biome.json
@@ -1,8 +1,8 @@
 {
-	"format_version": "1.21.70",
+	"format_version": "1.21.110",
 	"minecraft:client_biome": {
 		"description": {
-			"identifier": "ocean"
+			"identifier": "minecraft:ocean"
 		},
 		"components": {
 			"minecraft:fog_appearance": {
@@ -22,6 +22,9 @@
 			},
 			"minecraft:water_identifier": {
 				"water_identifier": "minecraft:default_water"
+			},
+			"minecraft:biome_music": {
+				"underwater_music": true
 			}
 		}
 	}

--- a/resource_packs/files/retro/old_water/biomes/river.client_biome.json
+++ b/resource_packs/files/retro/old_water/biomes/river.client_biome.json
@@ -1,8 +1,8 @@
 {
-	"format_version": "1.21.70",
+	"format_version": "1.21.110",
 	"minecraft:client_biome": {
 		"description": {
-			"identifier": "river"
+			"identifier": "minecraft:river"
 		},
 		"components": {
 			"minecraft:fog_appearance": {
@@ -22,6 +22,9 @@
 			},
 			"minecraft:water_identifier": {
 				"water_identifier": "minecraft:default_water"
+			},
+			"minecraft:biome_music": {
+				"underwater_music": true
 			}
 		}
 	}

--- a/resource_packs/files/retro/old_water/biomes/roofed_forest.client_biome.json
+++ b/resource_packs/files/retro/old_water/biomes/roofed_forest.client_biome.json
@@ -28,6 +28,9 @@
 			},
 			"minecraft:grass_appearance": {
 				"grass_is_shaded": true
+			},
+			"minecraft:biome_music": {
+				"music_definition": "roofed_forest"
 			}
 		}
 	}

--- a/resource_packs/files/retro/old_water/biomes/soulsand_valley.client_biome.json
+++ b/resource_packs/files/retro/old_water/biomes/soulsand_valley.client_biome.json
@@ -1,8 +1,8 @@
 {
-	"format_version": "1.21.70",
+	"format_version": "1.21.110",
 	"minecraft:client_biome": {
 		"description": {
-			"identifier": "soulsand_valley"
+			"identifier": "minecraft:soulsand_valley"
 		},
 		"components": {
 			"minecraft:fog_appearance": {
@@ -27,6 +27,12 @@
 			},
 			"minecraft:water_identifier": {
 				"water_identifier": "minecraft:default_water"
+			},
+			"minecraft:precipitation": {
+				"ash": 0.05
+			},
+			"minecraft:biome_music": {
+				"music_definition": "soulsand_valley"
 			}
 		}
 	}

--- a/resource_packs/files/retro/old_water/biomes/warm_ocean.client_biome.json
+++ b/resource_packs/files/retro/old_water/biomes/warm_ocean.client_biome.json
@@ -1,8 +1,8 @@
 {
-	"format_version": "1.21.70",
+	"format_version": "1.21.110",
 	"minecraft:client_biome": {
 		"description": {
-			"identifier": "warm_ocean"
+			"identifier": "minecraft:warm_ocean"
 		},
 		"components": {
 			"minecraft:fog_appearance": {
@@ -23,6 +23,9 @@
 			},
 			"minecraft:water_identifier": {
 				"water_identifier": "minecraft:default_water"
+			},
+			"minecraft:biome_music": {
+				"underwater_music": true
 			}
 		}
 	}

--- a/resource_packs/files/retro/old_water/biomes/warped_forest.client_biome.json
+++ b/resource_packs/files/retro/old_water/biomes/warped_forest.client_biome.json
@@ -1,8 +1,8 @@
 {
-	"format_version": "1.21.70",
+	"format_version": "1.21.110",
 	"minecraft:client_biome": {
 		"description": {
-			"identifier": "warped_forest"
+			"identifier": "minecraft:warped_forest"
 		},
 		"components": {
 			"minecraft:fog_appearance": {
@@ -27,6 +27,12 @@
 			},
 			"minecraft:water_identifier": {
 				"water_identifier": "minecraft:default_water"
+			},
+			"minecraft:precipitation": {
+				"blue_spores": 0.25
+			},
+			"minecraft:biome_music": {
+				"music_definition": ""
 			}
 		}
 	}

--- a/resource_packs/files/terrain/clearer_water/biomes/basalt_deltas.client_biome.json
+++ b/resource_packs/files/terrain/clearer_water/biomes/basalt_deltas.client_biome.json
@@ -1,8 +1,8 @@
 {
-	"format_version": "1.21.70",
+	"format_version": "1.21.110",
 	"minecraft:client_biome": {
 		"description": {
-			"identifier": "basalt_deltas"
+			"identifier": "minecraft:basalt_deltas"
 		},
 		"components": {
 			"minecraft:fog_appearance": {
@@ -27,6 +27,12 @@
 			},
 			"minecraft:water_identifier": {
 				"water_identifier": "minecraft:default_water"
+			},
+			"minecraft:precipitation": {
+				"white_ash": 2.0
+			},
+			"minecraft:biome_music": {
+				"music_definition": "basalt_deltas"
 			}
 		}
 	}

--- a/resource_packs/files/terrain/clearer_water/biomes/cold_ocean.client_biome.json
+++ b/resource_packs/files/terrain/clearer_water/biomes/cold_ocean.client_biome.json
@@ -1,8 +1,8 @@
 {
-	"format_version": "1.21.70",
+	"format_version": "1.21.110",
 	"minecraft:client_biome": {
 		"description": {
-			"identifier": "cold_ocean"
+			"identifier": "minecraft:cold_ocean"
 		},
 		"components": {
 			"minecraft:fog_appearance": {
@@ -22,6 +22,9 @@
 			},
 			"minecraft:water_identifier": {
 				"water_identifier": "minecraft:default_water"
+			},
+			"minecraft:biome_music": {
+				"underwater_music": true
 			}
 		}
 	}

--- a/resource_packs/files/terrain/clearer_water/biomes/crimson_forest.client_biome.json
+++ b/resource_packs/files/terrain/clearer_water/biomes/crimson_forest.client_biome.json
@@ -1,8 +1,8 @@
 {
-	"format_version": "1.21.70",
+	"format_version": "1.21.110",
 	"minecraft:client_biome": {
 		"description": {
-			"identifier": "crimson_forest"
+			"identifier": "minecraft:crimson_forest"
 		},
 		"components": {
 			"minecraft:fog_appearance": {
@@ -27,6 +27,12 @@
 			},
 			"minecraft:water_identifier": {
 				"water_identifier": "minecraft:default_water"
+			},
+			"minecraft:precipitation": {
+				"red_spores": 0.25
+			},
+			"minecraft:biome_music": {
+				"music_definition": "crimson_forest"
 			}
 		}
 	}

--- a/resource_packs/files/terrain/clearer_water/biomes/deep_cold_ocean.client_biome.json
+++ b/resource_packs/files/terrain/clearer_water/biomes/deep_cold_ocean.client_biome.json
@@ -1,8 +1,8 @@
 {
-	"format_version": "1.21.70",
+	"format_version": "1.21.110",
 	"minecraft:client_biome": {
 		"description": {
-			"identifier": "deep_cold_ocean"
+			"identifier": "minecraft:deep_cold_ocean"
 		},
 		"components": {
 			"minecraft:fog_appearance": {
@@ -22,6 +22,9 @@
 			},
 			"minecraft:water_identifier": {
 				"water_identifier": "minecraft:default_water"
+			},
+			"minecraft:biome_music": {
+				"underwater_music": true
 			}
 		}
 	}

--- a/resource_packs/files/terrain/clearer_water/biomes/deep_frozen_ocean.client_biome.json
+++ b/resource_packs/files/terrain/clearer_water/biomes/deep_frozen_ocean.client_biome.json
@@ -1,8 +1,8 @@
 {
-	"format_version": "1.21.70",
+	"format_version": "1.21.110",
 	"minecraft:client_biome": {
 		"description": {
-			"identifier": "deep_frozen_ocean"
+			"identifier": "minecraft:deep_frozen_ocean"
 		},
 		"components": {
 			"minecraft:fog_appearance": {
@@ -22,6 +22,9 @@
 			},
 			"minecraft:water_identifier": {
 				"water_identifier": "minecraft:default_water"
+			},
+			"minecraft:biome_music": {
+				"underwater_music": true
 			}
 		}
 	}

--- a/resource_packs/files/terrain/clearer_water/biomes/deep_lukewarm_ocean.client_biome.json
+++ b/resource_packs/files/terrain/clearer_water/biomes/deep_lukewarm_ocean.client_biome.json
@@ -1,8 +1,8 @@
 {
-	"format_version": "1.21.70",
+	"format_version": "1.21.110",
 	"minecraft:client_biome": {
 		"description": {
-			"identifier": "deep_lukewarm_ocean"
+			"identifier": "minecraft:deep_lukewarm_ocean"
 		},
 		"components": {
 			"minecraft:fog_appearance": {
@@ -22,6 +22,9 @@
 			},
 			"minecraft:water_identifier": {
 				"water_identifier": "minecraft:default_water"
+			},
+			"minecraft:biome_music": {
+				"underwater_music": true
 			}
 		}
 	}

--- a/resource_packs/files/terrain/clearer_water/biomes/deep_ocean.client_biome.json
+++ b/resource_packs/files/terrain/clearer_water/biomes/deep_ocean.client_biome.json
@@ -1,8 +1,8 @@
 {
-	"format_version": "1.21.70",
+	"format_version": "1.21.110",
 	"minecraft:client_biome": {
 		"description": {
-			"identifier": "deep_ocean"
+			"identifier": "minecraft:deep_ocean"
 		},
 		"components": {
 			"minecraft:fog_appearance": {
@@ -22,6 +22,9 @@
 			},
 			"minecraft:water_identifier": {
 				"water_identifier": "minecraft:default_water"
+			},
+			"minecraft:biome_music": {
+				"underwater_music": true
 			}
 		}
 	}

--- a/resource_packs/files/terrain/clearer_water/biomes/deep_warm_ocean.client_biome.json
+++ b/resource_packs/files/terrain/clearer_water/biomes/deep_warm_ocean.client_biome.json
@@ -1,8 +1,8 @@
 {
-	"format_version": "1.21.70",
+	"format_version": "1.21.110",
 	"minecraft:client_biome": {
 		"description": {
-			"identifier": "deep_warm_ocean"
+			"identifier": "minecraft:deep_warm_ocean"
 		},
 		"components": {
 			"minecraft:fog_appearance": {
@@ -22,6 +22,9 @@
 			},
 			"minecraft:water_identifier": {
 				"water_identifier": "minecraft:default_water"
+			},
+			"minecraft:biome_music": {
+				"underwater_music": true
 			}
 		}
 	}

--- a/resource_packs/files/terrain/clearer_water/biomes/forest.client_biome.json
+++ b/resource_packs/files/terrain/clearer_water/biomes/forest.client_biome.json
@@ -11,6 +11,9 @@
 			"minecraft:water_appearance": {
 				"surface_color": "#1E97F2"
 			},
+			"minecraft:biome_music": {
+				"music_definition": "forest"
+			},
 			"minecraft:atmosphere_identifier": {
 				"atmosphere_identifier": "minecraft:default_atmospherics"
 			},

--- a/resource_packs/files/terrain/clearer_water/biomes/frozen_ocean.client_biome.json
+++ b/resource_packs/files/terrain/clearer_water/biomes/frozen_ocean.client_biome.json
@@ -1,8 +1,8 @@
 {
-	"format_version": "1.21.70",
+	"format_version": "1.21.110",
 	"minecraft:client_biome": {
 		"description": {
-			"identifier": "frozen_ocean"
+			"identifier": "minecraft:frozen_ocean"
 		},
 		"components": {
 			"minecraft:fog_appearance": {
@@ -22,6 +22,9 @@
 			},
 			"minecraft:water_identifier": {
 				"water_identifier": "minecraft:default_water"
+			},
+			"minecraft:biome_music": {
+				"underwater_music": true
 			}
 		}
 	}

--- a/resource_packs/files/terrain/clearer_water/biomes/frozen_river.client_biome.json
+++ b/resource_packs/files/terrain/clearer_water/biomes/frozen_river.client_biome.json
@@ -1,8 +1,8 @@
 {
-	"format_version": "1.21.70",
+	"format_version": "1.21.110",
 	"minecraft:client_biome": {
 		"description": {
-			"identifier": "frozen_river"
+			"identifier": "minecraft:frozen_river"
 		},
 		"components": {
 			"minecraft:fog_appearance": {
@@ -22,6 +22,9 @@
 			},
 			"minecraft:water_identifier": {
 				"water_identifier": "minecraft:default_water"
+			},
+			"minecraft:biome_music": {
+				"underwater_music": true
 			}
 		}
 	}

--- a/resource_packs/files/terrain/clearer_water/biomes/legacy_frozen_ocean.client_biome.json
+++ b/resource_packs/files/terrain/clearer_water/biomes/legacy_frozen_ocean.client_biome.json
@@ -1,8 +1,8 @@
 {
-	"format_version": "1.21.70",
+	"format_version": "1.21.110",
 	"minecraft:client_biome": {
 		"description": {
-			"identifier": "legacy_frozen_ocean"
+			"identifier": "minecraft:legacy_frozen_ocean"
 		},
 		"components": {
 			"minecraft:fog_appearance": {
@@ -22,6 +22,9 @@
 			},
 			"minecraft:water_identifier": {
 				"water_identifier": "minecraft:default_water"
+			},
+			"minecraft:biome_music": {
+				"underwater_music": true
 			}
 		}
 	}

--- a/resource_packs/files/terrain/clearer_water/biomes/lukewarm_ocean.client_biome.json
+++ b/resource_packs/files/terrain/clearer_water/biomes/lukewarm_ocean.client_biome.json
@@ -1,8 +1,8 @@
 {
-	"format_version": "1.21.70",
+	"format_version": "1.21.110",
 	"minecraft:client_biome": {
 		"description": {
-			"identifier": "lukewarm_ocean"
+			"identifier": "minecraft:lukewarm_ocean"
 		},
 		"components": {
 			"minecraft:fog_appearance": {
@@ -22,6 +22,9 @@
 			},
 			"minecraft:water_identifier": {
 				"water_identifier": "minecraft:default_water"
+			},
+			"minecraft:biome_music": {
+				"underwater_music": true
 			}
 		}
 	}

--- a/resource_packs/files/terrain/clearer_water/biomes/ocean.client_biome.json
+++ b/resource_packs/files/terrain/clearer_water/biomes/ocean.client_biome.json
@@ -1,8 +1,8 @@
 {
-	"format_version": "1.21.70",
+	"format_version": "1.21.110",
 	"minecraft:client_biome": {
 		"description": {
-			"identifier": "ocean"
+			"identifier": "minecraft:ocean"
 		},
 		"components": {
 			"minecraft:fog_appearance": {
@@ -22,6 +22,9 @@
 			},
 			"minecraft:water_identifier": {
 				"water_identifier": "minecraft:default_water"
+			},
+			"minecraft:biome_music": {
+				"underwater_music": true
 			}
 		}
 	}

--- a/resource_packs/files/terrain/clearer_water/biomes/river.client_biome.json
+++ b/resource_packs/files/terrain/clearer_water/biomes/river.client_biome.json
@@ -1,8 +1,8 @@
 {
-	"format_version": "1.21.70",
+	"format_version": "1.21.110",
 	"minecraft:client_biome": {
 		"description": {
-			"identifier": "river"
+			"identifier": "minecraft:river"
 		},
 		"components": {
 			"minecraft:fog_appearance": {
@@ -22,6 +22,9 @@
 			},
 			"minecraft:water_identifier": {
 				"water_identifier": "minecraft:default_water"
+			},
+			"minecraft:biome_music": {
+				"underwater_music": true
 			}
 		}
 	}

--- a/resource_packs/files/terrain/clearer_water/biomes/roofed_forest.client_biome.json
+++ b/resource_packs/files/terrain/clearer_water/biomes/roofed_forest.client_biome.json
@@ -28,6 +28,9 @@
 			},
 			"minecraft:grass_appearance": {
 				"grass_is_shaded": true
+			},
+			"minecraft:biome_music": {
+				"music_definition": "roofed_forest"
 			}
 		}
 	}

--- a/resource_packs/files/terrain/clearer_water/biomes/soulsand_valley.client_biome.json
+++ b/resource_packs/files/terrain/clearer_water/biomes/soulsand_valley.client_biome.json
@@ -1,8 +1,8 @@
 {
-	"format_version": "1.21.70",
+	"format_version": "1.21.110",
 	"minecraft:client_biome": {
 		"description": {
-			"identifier": "soulsand_valley"
+			"identifier": "minecraft:soulsand_valley"
 		},
 		"components": {
 			"minecraft:fog_appearance": {
@@ -27,6 +27,12 @@
 			},
 			"minecraft:water_identifier": {
 				"water_identifier": "minecraft:default_water"
+			},
+			"minecraft:precipitation": {
+				"ash": 0.05
+			},
+			"minecraft:biome_music": {
+				"music_definition": "soulsand_valley"
 			}
 		}
 	}

--- a/resource_packs/files/terrain/clearer_water/biomes/warm_ocean.client_biome.json
+++ b/resource_packs/files/terrain/clearer_water/biomes/warm_ocean.client_biome.json
@@ -1,8 +1,8 @@
 {
-	"format_version": "1.21.70",
+	"format_version": "1.21.110",
 	"minecraft:client_biome": {
 		"description": {
-			"identifier": "warm_ocean"
+			"identifier": "minecraft:warm_ocean"
 		},
 		"components": {
 			"minecraft:fog_appearance": {
@@ -23,6 +23,9 @@
 			},
 			"minecraft:water_identifier": {
 				"water_identifier": "minecraft:default_water"
+			},
+			"minecraft:biome_music": {
+				"underwater_music": true
 			}
 		}
 	}

--- a/resource_packs/files/terrain/clearer_water/biomes/warped_forest.client_biome.json
+++ b/resource_packs/files/terrain/clearer_water/biomes/warped_forest.client_biome.json
@@ -1,8 +1,8 @@
 {
-	"format_version": "1.21.70",
+	"format_version": "1.21.110",
 	"minecraft:client_biome": {
 		"description": {
-			"identifier": "warped_forest"
+			"identifier": "minecraft:warped_forest"
 		},
 		"components": {
 			"minecraft:fog_appearance": {
@@ -27,6 +27,12 @@
 			},
 			"minecraft:water_identifier": {
 				"water_identifier": "minecraft:default_water"
+			},
+			"minecraft:precipitation": {
+				"blue_spores": 0.25
+			},
+			"minecraft:biome_music": {
+				"music_definition": ""
 			}
 		}
 	}


### PR DESCRIPTION
1. Update all the client biomes in Clearer Water and Old Water to 1.21.110 to match bedrock samples
2. Update all the client biomes in `lush_grass_old_clearer_water` and `old_clearer_water` combinations to match bedrock samples

By checking the following boxes with an X, you ensure that:

- [X] The pack was tested ingame in at least one device.
- [X] The pack is an existing BT pack, is a missing pack from VT or is an accepted pack/change in a discussion.
- [X] The pack code follows the style guide.
- [X] The commits follow the contribution guidelines.
- [X] The PR follows the contribution guidelines.

- [X] (Optional) Tested in Windows
- [ ] (Optional) Tested in Android
- [ ] (Optional) Tested in iOS
- [ ] (Optional) Tested in any console
- [ ] (Optional) Tested in BDS
