### PR TITLE
feat(files): Add a combination between Dark UI and Numbered Hotbar

### DIFF
--- a/resource_packs/extras/gui/dark_numbered_hotbar/textures/ui/numbered_hotbar/hotbar_1.png
+++ b/resource_packs/extras/gui/dark_numbered_hotbar/textures/ui/numbered_hotbar/hotbar_1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:452de7b6544fe3b8589f3b66b3cb4a4b38cb0b5c3a3395cc124ab872d14ccae5
+size 168

--- a/resource_packs/extras/gui/dark_numbered_hotbar/textures/ui/numbered_hotbar/hotbar_2.png
+++ b/resource_packs/extras/gui/dark_numbered_hotbar/textures/ui/numbered_hotbar/hotbar_2.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:32160d6d413a38254f7d70058a7a872c015b302ae4f504fb39105244fc53bb50
+size 182

--- a/resource_packs/extras/gui/dark_numbered_hotbar/textures/ui/numbered_hotbar/hotbar_3.png
+++ b/resource_packs/extras/gui/dark_numbered_hotbar/textures/ui/numbered_hotbar/hotbar_3.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5d2185b6a1bb95684c73bb7ba259feb11e8463e9c6c32f1792b1d925585c9b81
+size 163

--- a/resource_packs/extras/gui/dark_numbered_hotbar/textures/ui/numbered_hotbar/hotbar_4.png
+++ b/resource_packs/extras/gui/dark_numbered_hotbar/textures/ui/numbered_hotbar/hotbar_4.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:240b641673f4bad8b7ec7f4da98c1ee31bdbc104afd0c3df1a9c2d6c8771e13c
+size 183

--- a/resource_packs/extras/gui/dark_numbered_hotbar/textures/ui/numbered_hotbar/hotbar_5.png
+++ b/resource_packs/extras/gui/dark_numbered_hotbar/textures/ui/numbered_hotbar/hotbar_5.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4f10ab3b990ee88bb310ae62f830b5797c85a12e9d2928223312b424e33594e3
+size 191

--- a/resource_packs/extras/gui/dark_numbered_hotbar/textures/ui/numbered_hotbar/hotbar_6.png
+++ b/resource_packs/extras/gui/dark_numbered_hotbar/textures/ui/numbered_hotbar/hotbar_6.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:355e80941bbe91b5f3a7e391697557910c5f990c43a5d9cce1a17b3ce180c781
+size 171

--- a/resource_packs/extras/gui/dark_numbered_hotbar/textures/ui/numbered_hotbar/hotbar_7.png
+++ b/resource_packs/extras/gui/dark_numbered_hotbar/textures/ui/numbered_hotbar/hotbar_7.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ed6f984f1d7700b238beaf32d2dc6c5c799828b6ccc6440995c80ee4a8c30166
+size 166

--- a/resource_packs/extras/gui/dark_numbered_hotbar/textures/ui/numbered_hotbar/hotbar_8.png
+++ b/resource_packs/extras/gui/dark_numbered_hotbar/textures/ui/numbered_hotbar/hotbar_8.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:edb76248abf8bbe809b73c184ce0fdecbe55dd30d06bbd638896b1b2d289c656
+size 161

--- a/resource_packs/extras/gui/dark_numbered_hotbar/textures/ui/numbered_hotbar/hotbar_9.png
+++ b/resource_packs/extras/gui/dark_numbered_hotbar/textures/ui/numbered_hotbar/hotbar_9.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fafa710ef56916b2e162506f9695dfb3be9d236d54836274379a7894c79db0f1
+size 183

--- a/resource_packs/packs.json
+++ b/resource_packs/packs.json
@@ -1891,7 +1891,6 @@
 					"id": "happy_ghasts_panorama",
 					"name": "Happy Ghasts Panorama",
 					"description": "Replaces the default Minecraft menu panorama with a 360° view of Happy Ghasts flying around a valley! (from 1.21.90)"
-					
 				},
 				{
 					"id": "pale_garden_panorama",
@@ -2986,6 +2985,13 @@
 			"combines": [
 				"terrain/whiter_snow",
 				"terrain/lower_and_full_sides/full_snowy_grass_sides"
+			]
+		},
+		{
+			"id": "extras/gui/dark_numbered_hotbar",
+			"combines": [
+				"gui/dark_ui",
+				"gui/numbered_hotbar"
 			]
 		},
 		{


### PR DESCRIPTION
1. This just tweaks the hud hotbar numbered textures so that they are more visible when using Dark UI and Numbered Hotbar

By checking the following boxes with an X, you ensure that:

- [X] The pack was tested ingame in at least one device.
- [X] The pack is an existing BT pack, is a missing pack from VT or is an accepted pack/change in a discussion.
- [X] The pack code follows the style guide.
- [X] The commits follow the contribution guidelines.
- [X] The PR follows the contribution guidelines.

- [X] (Optional) Tested in Windows
- [ ] (Optional) Tested in Android
- [ ] (Optional) Tested in iOS
- [ ] (Optional) Tested in any console
- [ ] (Optional) Tested in BDS
