### PR TITLE
chore(files): Remove obsolete Green Jungle Wood

### DIFF
--- a/resource_packs/files/aesthetic/green_jungle_wood/pack_icon.png
+++ b/resource_packs/files/aesthetic/green_jungle_wood/pack_icon.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:79c74e86e3706556dfc36e93f48b7fa5844e694448a3f3377bc47d29c2b293d4
-size 2972

--- a/resource_packs/files/aesthetic/green_jungle_wood/textures/blocks/door_jungle_lower.png
+++ b/resource_packs/files/aesthetic/green_jungle_wood/textures/blocks/door_jungle_lower.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:fd6fed246a1ef4b1e87f4495c10f93105a87fada65ac991b44ebbb1183b1049a
-size 301

--- a/resource_packs/files/aesthetic/green_jungle_wood/textures/blocks/door_jungle_upper.png
+++ b/resource_packs/files/aesthetic/green_jungle_wood/textures/blocks/door_jungle_upper.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:bc1d6263401bf59b258e559314a64a55ce2e30ef3dab859e23ae85202134f4bd
-size 530

--- a/resource_packs/files/aesthetic/green_jungle_wood/textures/blocks/jungle_planks/0.png
+++ b/resource_packs/files/aesthetic/green_jungle_wood/textures/blocks/jungle_planks/0.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:02850e674b64fcb35e6e57fcbb942e4b55869169aa101b599d1a22fcff891bc4
-size 282

--- a/resource_packs/files/aesthetic/green_jungle_wood/textures/blocks/jungle_planks/1.png
+++ b/resource_packs/files/aesthetic/green_jungle_wood/textures/blocks/jungle_planks/1.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d94cefeaeec001afadabed6c4473d5a7b3368ea88c67e43a529671c39ea4888d
-size 282

--- a/resource_packs/files/aesthetic/green_jungle_wood/textures/blocks/jungle_planks/10.png
+++ b/resource_packs/files/aesthetic/green_jungle_wood/textures/blocks/jungle_planks/10.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c39275f44e2d2018082618e4b22aa52e977b4632a41fd35701f55eb57f5d4c6d
-size 286

--- a/resource_packs/files/aesthetic/green_jungle_wood/textures/blocks/jungle_planks/11.png
+++ b/resource_packs/files/aesthetic/green_jungle_wood/textures/blocks/jungle_planks/11.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:bdb7ad14c07be0daec7e929fc2b7cc7b040d367a751564cefc29757f28c6e69e
-size 286

--- a/resource_packs/files/aesthetic/green_jungle_wood/textures/blocks/jungle_planks/12.png
+++ b/resource_packs/files/aesthetic/green_jungle_wood/textures/blocks/jungle_planks/12.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:58e494903af5a69e3395fd06ac137396f51de26879391d62238db0c696aece34
-size 283

--- a/resource_packs/files/aesthetic/green_jungle_wood/textures/blocks/jungle_planks/13.png
+++ b/resource_packs/files/aesthetic/green_jungle_wood/textures/blocks/jungle_planks/13.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:beca1f01968fd09394e87f8b6fb3039713755827fbe77cb2c89467d75716f3e6
-size 281

--- a/resource_packs/files/aesthetic/green_jungle_wood/textures/blocks/jungle_planks/14.png
+++ b/resource_packs/files/aesthetic/green_jungle_wood/textures/blocks/jungle_planks/14.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:21f9b45d6643962ddadbfde2c23ac0889be6f2044d7d18d1098396bb5cadf51e
-size 289

--- a/resource_packs/files/aesthetic/green_jungle_wood/textures/blocks/jungle_planks/15.png
+++ b/resource_packs/files/aesthetic/green_jungle_wood/textures/blocks/jungle_planks/15.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e4d127e7d0ee6bb837dd520c5107974f3c7fa03648cca95f12526d6c4335133e
-size 287

--- a/resource_packs/files/aesthetic/green_jungle_wood/textures/blocks/jungle_planks/2.png
+++ b/resource_packs/files/aesthetic/green_jungle_wood/textures/blocks/jungle_planks/2.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d645c16d951f06ce6196e73d11a7002570c76b6edc631c464b1291fd99a34d18
-size 281

--- a/resource_packs/files/aesthetic/green_jungle_wood/textures/blocks/jungle_planks/3.png
+++ b/resource_packs/files/aesthetic/green_jungle_wood/textures/blocks/jungle_planks/3.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:1c6e82daa2ec50906acdeb55df4bbbe39c3fdbdf3c2ef6051d7a0c4e866378a9
-size 286

--- a/resource_packs/files/aesthetic/green_jungle_wood/textures/blocks/jungle_planks/4.png
+++ b/resource_packs/files/aesthetic/green_jungle_wood/textures/blocks/jungle_planks/4.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:301323e1aee67dc537f58847eee0fa569ef676a986e5fcdd4ce0dae081f8d811
-size 288

--- a/resource_packs/files/aesthetic/green_jungle_wood/textures/blocks/jungle_planks/5.png
+++ b/resource_packs/files/aesthetic/green_jungle_wood/textures/blocks/jungle_planks/5.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c8e01603b125a54b21f715eb8d75a0c484fd0e4178b5dc66c4c7b113c9287ae9
-size 284

--- a/resource_packs/files/aesthetic/green_jungle_wood/textures/blocks/jungle_planks/6.png
+++ b/resource_packs/files/aesthetic/green_jungle_wood/textures/blocks/jungle_planks/6.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:83faa041e2cbd86ea182a9af15c0a8127094cb1185c59d485821562d9e0cd56d
-size 280

--- a/resource_packs/files/aesthetic/green_jungle_wood/textures/blocks/jungle_planks/7.png
+++ b/resource_packs/files/aesthetic/green_jungle_wood/textures/blocks/jungle_planks/7.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:077d4de8d609678a6e10d2f972c621bd226f82b7eee559bae53fda3b6e25339e
-size 288

--- a/resource_packs/files/aesthetic/green_jungle_wood/textures/blocks/jungle_planks/8.png
+++ b/resource_packs/files/aesthetic/green_jungle_wood/textures/blocks/jungle_planks/8.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:805c7c4739e90926a8e0b47b9caeea5427f0113e56eaa181e3880b602127651c
-size 280

--- a/resource_packs/files/aesthetic/green_jungle_wood/textures/blocks/jungle_planks/9.png
+++ b/resource_packs/files/aesthetic/green_jungle_wood/textures/blocks/jungle_planks/9.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:71be2e27b63bb541bf6ddf46152efad83b431c6b7478b1c53fd54cda21d9acea
-size 284

--- a/resource_packs/files/aesthetic/green_jungle_wood/textures/blocks/jungle_trapdoor.png
+++ b/resource_packs/files/aesthetic/green_jungle_wood/textures/blocks/jungle_trapdoor.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c20665734ea5e4a3bab3cc68a5187f4199afcb6740c0e7731d493b921dc50f39
-size 471

--- a/resource_packs/files/aesthetic/green_jungle_wood/textures/blocks/log_jungle_top.png
+++ b/resource_packs/files/aesthetic/green_jungle_wood/textures/blocks/log_jungle_top.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:68bce56f062219861f8ae21433ebd4234ea93ec59f51712ff3e6801730b3b187
-size 301

--- a/resource_packs/files/aesthetic/green_jungle_wood/textures/blocks/planks_jungle.png
+++ b/resource_packs/files/aesthetic/green_jungle_wood/textures/blocks/planks_jungle.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:24fa35c978c947eb4be6284da69fbdc593d53c6f80fc58976da86bbe0943c5cf
-size 282

--- a/resource_packs/files/aesthetic/green_jungle_wood/textures/blocks/stripped_jungle_log.png
+++ b/resource_packs/files/aesthetic/green_jungle_wood/textures/blocks/stripped_jungle_log.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:8a38405893b5a38c9c78c474be1dd2b1f074d2d39e98e6d3dd3326284a52684a
-size 281

--- a/resource_packs/files/aesthetic/green_jungle_wood/textures/blocks/stripped_jungle_log_top.png
+++ b/resource_packs/files/aesthetic/green_jungle_wood/textures/blocks/stripped_jungle_log_top.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:72f5398b0172f0be9ae2ada121c2c3c721896bbb49dafb960c2a4a581eb748f5
-size 273

--- a/resource_packs/files/aesthetic/green_jungle_wood/textures/entity/boat/boat_jungle.png
+++ b/resource_packs/files/aesthetic/green_jungle_wood/textures/entity/boat/boat_jungle.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:fe9a50b36ad838dd6cd474e52176c819e1cf0ff0801c62f4aa263637101a19ce
-size 2403

--- a/resource_packs/files/aesthetic/green_jungle_wood/textures/entity/sign_jungle.png
+++ b/resource_packs/files/aesthetic/green_jungle_wood/textures/entity/sign_jungle.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:19b8be7f8ae6c67b9c5f5422a853ab3ec6cf5216e8e6496b3ee5970fe3a7cb0a
-size 974

--- a/resource_packs/files/aesthetic/green_jungle_wood/textures/items/boat_jungle.png
+++ b/resource_packs/files/aesthetic/green_jungle_wood/textures/items/boat_jungle.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:9e6136118a4c4f813c4d3cccb4b92425a161acaa6e0a05816626374adf6e167d
-size 530

--- a/resource_packs/files/aesthetic/green_jungle_wood/textures/items/door_jungle.png
+++ b/resource_packs/files/aesthetic/green_jungle_wood/textures/items/door_jungle.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:1f71c79da13409a8689f81d962592d6c2871d8cd458de9c19ff2968783985359
-size 220

--- a/resource_packs/files/aesthetic/green_jungle_wood/textures/items/sign_jungle.png
+++ b/resource_packs/files/aesthetic/green_jungle_wood/textures/items/sign_jungle.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:4a9adf9105b8d9f8e1d7f2ae79a271935ac37c21b410fa3c1acaca528bd67df2
-size 268


### PR DESCRIPTION
1. Removed `green_jungle_wood` from aesthetics as they are no longer used and pretty much obsolete (This was actually a pack before but due to the addition of bamboos, was delisted as it would have caused confusion between both of them)
