### PR TITLE
feat(files): Add a combination between Visual Waxed Copper Items and Glass Doors & Trapdoors

### DIFF
--- a/resource_packs/extras/utility/visual_waxed_glass_doors_and_trapdoors/textures/items/waxed_copper_door.png
+++ b/resource_packs/extras/utility/visual_waxed_glass_doors_and_trapdoors/textures/items/waxed_copper_door.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c048144e41ed89b5c216d05514de5fa389e4c953eef73c8c5639d8bc981cb0ce
+size 504

--- a/resource_packs/extras/utility/visual_waxed_glass_doors_and_trapdoors/textures/items/waxed_exposed_copper_door.png
+++ b/resource_packs/extras/utility/visual_waxed_glass_doors_and_trapdoors/textures/items/waxed_exposed_copper_door.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c1a94dec344aac4310d375153872903815751f945676fdc54b5aee0d8e156431
+size 520

--- a/resource_packs/extras/utility/visual_waxed_glass_doors_and_trapdoors/textures/items/waxed_oxidized_copper_door.png
+++ b/resource_packs/extras/utility/visual_waxed_glass_doors_and_trapdoors/textures/items/waxed_oxidized_copper_door.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4a333e680a116ef8f785f075644b83c16c596e59dd0ada13698bbc1339294079
+size 520

--- a/resource_packs/extras/utility/visual_waxed_glass_doors_and_trapdoors/textures/items/waxed_weathered_copper_door.png
+++ b/resource_packs/extras/utility/visual_waxed_glass_doors_and_trapdoors/textures/items/waxed_weathered_copper_door.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b9a13f1b58fa045b559f19e8f2b8ee065de7a9ef70d09cea64a056216a1afeb4
+size 520

--- a/resource_packs/packs.json
+++ b/resource_packs/packs.json
@@ -1891,7 +1891,6 @@
 					"id": "happy_ghasts_panorama",
 					"name": "Happy Ghasts Panorama",
 					"description": "Replaces the default Minecraft menu panorama with a 360° view of Happy Ghasts flying around a valley! (from 1.21.90)"
-					
 				},
 				{
 					"id": "pale_garden_panorama",
@@ -3269,6 +3268,13 @@
 			"combines": [
 				"utility/visual_waxed_copper_items",
 				"aesthetic/alternate_cut_copper"
+			]
+		},
+		{
+			"id": "extras/utility/visual_waxed_glass_doors_and_trapdoors",
+			"combines": [
+				"utility/visual_waxed_copper_items",
+				"aesthetic/glass_doors_and_trapdoors"
 			]
 		},
 		{


### PR DESCRIPTION
1. Waxed copper doors didn't have a compatibility between Visual Waxed Copper Items and Glass Doors & Items resulted into waxed copper doors to look different than normal copper doors which is now fixed by adding this combination

Resolves #758

By checking the following boxes with an X, you ensure that:

- [X] The pack was tested ingame in at least one device.
- [X] The pack is an existing BT pack, is a missing pack from VT or is an accepted pack/change in a discussion.
- [X] The pack code follows the style guide.
- [X] The commits follow the contribution guidelines.
- [X] The PR follows the contribution guidelines.

- [X] (Optional) Tested in Windows
- [ ] (Optional) Tested in Android
- [ ] (Optional) Tested in iOS
- [ ] (Optional) Tested in any console
- [ ] (Optional) Tested in BDS
