### PR TITLE
update(files): Improve the animation of Lower Shield

### DIFF
--- a/resource_packs/files/unobtrusive/lower_shield/animations/shield.animation.json
+++ b/resource_packs/files/unobtrusive/lower_shield/animations/shield.animation.json
@@ -25,7 +25,7 @@
 					"position": [
 						-14.0,
 						17.0,
-						"(query.get_equipped_item_name == 'bow') && (query.main_hand_item_use_duration > 0.0f) ? -25.0 : 2.0"
+						"variable.is_using_bow ? -25.0 : 2.0"
 					],
 					"rotation": [
 						0.0,
@@ -33,26 +33,62 @@
 						178.0
 					],
 					"scale": [
-						-1.0,
+						1.0,
 						1.0,
 						1.0
 					]
 				}
 			}
 		},
-		"animation.shield.wield_first_person_blocking": {
-			"loop": true,
+		"animation.shield.wield_main_hand_first_person_blocking": {
+			"loop": "hold_on_last_frame",
 			"bones": {
 				"shield": {
-					"position": [
-						3.0,
-						"c.item_slot != 'main_hand' ? (-1) + q.shield_blocking_bob : q.shield_blocking_bob",
-						2.0
-					],
+					"position": {
+						"0": [
+							-10.0,
+							13.5,
+							-12.0
+						],
+						"0.1": [
+							-10.0,
+							11.5,
+							-14.0
+						]
+					},
+					"rotation": [
+						76.0,
+						-131.0,
+						-34.0
+					]
+				}
+			}
+		},
+		"animation.shield.wield_off_hand_first_person_blocking": {
+			"loop": "hold_on_last_frame",
+			"bones": {
+				"shield": {
+					"position": {
+						"0": [
+							-10.0,
+							17.0,
+							"variable.is_using_bow ? -25.0 : 2.0"
+						],
+						"0.1": [
+							-10.0,
+							20.2,
+							"variable.is_using_bow ? -25.0 : 3.5"
+						]
+					},
 					"rotation": [
 						0.0,
-						0.0,
-						10.0
+						185.0,
+						188.0
+					],
+					"scale": [
+						1.0,
+						1.0,
+						1.0
 					]
 				}
 			}


### PR DESCRIPTION
1. Improve the animation of Lower Shield by rewriting 2 of 4 animations
2. Fixed a bug where the shield was inverted when a banner is applied to it resulting into banner being visible in offhand and not activating

Resolves #761

By checking the following boxes with an X, you ensure that:

- [X] The pack was tested ingame in at least one device.
- [X] The pack is an existing BT pack, is a missing pack from VT or is an accepted pack/change in a discussion.
- [X] The pack code follows the style guide.
- [X] The commits follow the contribution guidelines.
- [X] The PR follows the contribution guidelines.

- [X] (Optional) Tested in Windows
- [ ] (Optional) Tested in Android
- [ ] (Optional) Tested in iOS
- [ ] (Optional) Tested in any console
- [ ] (Optional) Tested in BDS
