### PR TITLE
update(files): Update Dungeons Creeper to change the creeper spawn egg to dungeon style

### DIFF
--- a/resource_packs/files/parity/dungeons_creepers/textures/items/spawn_eggs/spawn_egg_creeper.png
+++ b/resource_packs/files/parity/dungeons_creepers/textures/items/spawn_eggs/spawn_egg_creeper.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:703c1fd13e441053bbc82c98c22e047574945527e12a76accf5e085a2d7829fc
+size 500


### PR DESCRIPTION
1. Update Dungeons Creeper to change the creeper spawn egg to dungeon style

By checking the following boxes with an X, you ensure that:

- [X] The pack was tested ingame in at least one device.
- [X] The pack is an existing BT pack, is a missing pack from VT or is an accepted pack/change in a discussion.
- [X] The pack code follows the style guide.
- [X] The commits follow the contribution guidelines.
- [X] The PR follows the contribution guidelines.

- [X] (Optional) Tested in Windows
- [ ] (Optional) Tested in Android
- [ ] (Optional) Tested in iOS
- [ ] (Optional) Tested in any console
- [ ] (Optional) Tested in BDS
