### PR TITLE
chore(files): Old Spawn Eggs overwrite other spawn egg packs

### DIFF
--- a/resource_packs/packs.json
+++ b/resource_packs/packs.json
@@ -1891,7 +1891,6 @@
 					"id": "happy_ghasts_panorama",
 					"name": "Happy Ghasts Panorama",
 					"description": "Replaces the default Minecraft menu panorama with a 360° view of Happy Ghasts flying around a valley! (from 1.21.90)"
-					
 				},
 				{
 					"id": "pale_garden_panorama",
@@ -2119,7 +2118,8 @@
 				{
 					"id": "old_spawn_eggs",
 					"name": "Old Spawn Eggs",
-					"description": "Reverts Spawn Eggs to their classic polka-dot textures"
+					"description": "Reverts Spawn Eggs to their classic polka-dot textures",
+					"priority": 1
 				},
 				{
 					"id": "snoutless_pigs",
@@ -2270,8 +2270,7 @@
 				{
 					"id": "stridey_striders",
 					"name": "Stridey Striders",
-					"description": "Awful pack that makes Striders look like Stridey, Sorry",
-					"priority": 1
+					"description": "Awful pack that makes Striders look like Stridey, Sorry"
 				},
 				{
 					"id": "emeralds_to_rubies",


### PR DESCRIPTION
1. Old Spawn Eggs will take priority over other packs containing spawn eggs
2. Removed the priority of 1 from Stridey Striders so that Old Spawn Eggs overwrite it
