### PR TITLE
update(files): Update Super Smash Bros Enderman to change the enderman spawn egg

### DIFF
--- a/resource_packs/files/parity/super_smash_bros_enderman/textures/items/spawn_eggs/spawn_egg_enderman.png
+++ b/resource_packs/files/parity/super_smash_bros_enderman/textures/items/spawn_eggs/spawn_egg_enderman.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:56deacb215bace418ec4730b4a92557dc6c5b50cee4b9df44a7a5da0751741f3
+size 552


### PR DESCRIPTION
1. Update Super Smash Bros Enderman to change the enderman spawn egg

By checking the following boxes with an X, you ensure that:

- [X] The pack was tested ingame in at least one device.
- [X] The pack is an existing BT pack, is a missing pack from VT or is an accepted pack/change in a discussion.
- [X] The pack code follows the style guide.
- [X] The commits follow the contribution guidelines.
- [X] The PR follows the contribution guidelines.

- [X] (Optional) Tested in Windows
- [ ] (Optional) Tested in Android
- [ ] (Optional) Tested in iOS
- [ ] (Optional) Tested in any console
- [ ] (Optional) Tested in BDS
