### PR TITLE
update(files): Update Circular Sun and Moon to 1.21.110

### DIFF
--- a/resource_packs/files/terrain/circular_sun_and_moon/textures/environment/sun.png
+++ b/resource_packs/files/terrain/circular_sun_and_moon/textures/environment/sun.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f7ac0dd2673092954fb972a7cea54aa05698d07d0700037541c17a507b55cb27
-size 444
+oid sha256:23cea8d39378d73432fb07adc8068a286f16e1bdde2ddfdd4d7d439d9aeb7a3c
+size 1177


### PR DESCRIPTION
1. Update the sun texture in Circular Sun and Moon to add the fade out dark textures to match bedrock samples

By checking the following boxes with an X, you ensure that:

- [X] The pack was tested ingame in at least one device.
- [X] The pack is an existing BT pack, is a missing pack from VT or is an accepted pack/change in a discussion.
- [X] The pack code follows the style guide.
- [X] The commits follow the contribution guidelines.
- [X] The PR follows the contribution guidelines.

- [X] (Optional) Tested in Windows
- [ ] (Optional) Tested in Android
- [ ] (Optional) Tested in iOS
- [ ] (Optional) Tested in any console
- [ ] (Optional) Tested in BDS
