### PR TITLE
update(files): Update 3D Sun & Moon to 1.21.110

### DIFF
--- a/resource_packs/files/3d/3d_sun_and_moon/textures/environment/sun.png
+++ b/resource_packs/files/3d/3d_sun_and_moon/textures/environment/sun.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:88e5c0af46f0f00b882c8f55995e1f75271d9652e9bbcaf6b514424887e9f2c7
-size 35485
+oid sha256:53c1a66f72b64863aa89715a5d42328b7f03f9a39fcb55784093f8d3cbb0ef76
+size 212680


### PR DESCRIPTION
1. Update the sun texture in 3D Sun & Moon to add the fade out dark textures to match bedrock samples

By checking the following boxes with an X, you ensure that:

- [X] The pack was tested ingame in at least one device.
- [X] The pack is an existing BT pack, is a missing pack from VT or is an accepted pack/change in a discussion.
- [X] The pack code follows the style guide.
- [X] The commits follow the contribution guidelines.
- [X] The PR follows the contribution guidelines.

- [X] (Optional) Tested in Windows
- [ ] (Optional) Tested in Android
- [ ] (Optional) Tested in iOS
- [ ] (Optional) Tested in any console
- [ ] (Optional) Tested in BDS
