### PR TITLE
update(files): Update Double Slab Fix to 1.21.110

### DIFF
--- a/resource_packs/files/fixes_and_consistency/double_slab_fix/blocks.json
+++ b/resource_packs/files/fixes_and_consistency/double_slab_fix/blocks.json
@@ -1,5 +1,21 @@
 {
 	"format_version": "1.21.40",
+	"cut_red_sandstone_double_slab": {
+		"sound": "stone",
+		"textures": {
+			"down": "cut_red_sandstone_slab_top",
+			"side": "cut_red_sandstone_double_slab",
+			"up": "cut_red_sandstone_slab_top"
+		}
+	},
+	"cut_sandstone_double_slab": {
+		"sound": "stone",
+		"textures": {
+			"down": "cut_sandstone_slab_top",
+			"side": "cut_sandstone_double_slab",
+			"up": "cut_sandstone_slab_top"
+		}
+	},
 	"polished_andesite_double_slab": {
 		"sound": "stone",
 		"textures": {
@@ -55,6 +71,30 @@
 			"down": "polished_tuff",
 			"side": "polished_tuff_double_slab",
 			"up": "polished_tuff"
+		}
+	},
+	"quartz_double_slab": {
+		"sound": "stone",
+		"textures": {
+			"down": "quartz_slab_bottom",
+			"side": "quartz_double_slab",
+			"up": "quartz_slab_top"
+		}
+	},
+	"red_sandstone_double_slab": {
+		"sound": "stone",
+		"textures": {
+			"down": "red_sandstone_slab_bottom",
+			"side": "red_sandstone_double_slab",
+			"up": "red_sandstone_slab_top"
+		}
+	},
+	"sandstone_double_slab": {
+		"sound": "stone",
+		"textures": {
+			"down": "sandstone_slab_bottom",
+			"side": "sandstone_double_slab",
+			"up": "sandstone_slab_top"
 		}
 	}
 }

--- a/resource_packs/files/fixes_and_consistency/double_slab_fix/textures/terrain_texture.json
+++ b/resource_packs/files/fixes_and_consistency/double_slab_fix/textures/terrain_texture.json
@@ -4,14 +4,11 @@
 	"padding": 8,
 	"num_mip_levels": 4,
 	"texture_data": {
-		"stone_slab_side_4": {
-			"textures": [
-				"textures/blocks/stonebrick_mossy",
-				"textures/blocks/quartz_block_bottom",
-				"textures/blocks/stone",
-				"textures/blocks/slab_sides/cut_sandstone_slab_side",
-				"textures/blocks/slab_sides/cut_red_sandstone_slab_side"
-			]
+		"cut_red_sandstone_double_slab": {
+			"textures": "textures/blocks/slab_sides/cut_red_sandstone_slab_side"
+		},
+		"cut_sandstone_double_slab": {
+			"textures": "textures/blocks/slab_sides/cut_sandstone_slab_side"
 		},
 		"polished_andesite_double_slab": {
 			"textures": "textures/blocks/slab_sides/polished_andesite_slab_side"
@@ -25,15 +22,6 @@
 		"prismarine_brick_double_slab": {
 			"textures": "textures/blocks/slab_sides/prismarine_brick_slab_side"
 		},
-		"sandstone_slab_side": {
-			"textures": "textures/blocks/slab_sides/sandstone_slab_side"
-		},
-		"red_sandstone_slab_side": {
-			"textures": "textures/blocks/slab_sides/red_sandstone_slab_side"
-		},
-		"quartz_slab_side": {
-			"textures": "textures/blocks/slab_sides/quartz_block_slab_side"
-		},
 		"polished_blackstone_double_slab": {
 			"textures": "textures/blocks/slab_sides/polished_blackstone_slab_side"
 		},
@@ -42,6 +30,15 @@
 		},
 		"polished_tuff_double_slab": {
 			"textures": "textures/blocks/slab_sides/polished_tuff_slab_side"
+		},
+		"quartz_double_slab": {
+			"textures": "textures/blocks/slab_sides/quartz_block_slab_side"
+		},
+		"red_sandstone_double_slab": {
+			"textures": "textures/blocks/slab_sides/red_sandstone_slab_side"
+		},
+		"sandstone_double_slab": {
+			"textures": "textures/blocks/slab_sides/sandstone_slab_side"
 		}
 	}
 }


### PR DESCRIPTION
1. Updated cut red sandstone double slab and cut sandstone double slab to use its own entry as they were flattened in 1.21.110
2. Fixed a bug where I accidentally applied the double slab textures to non-double slabs variants of quartz, red sandstone and sandstone (oopsie)

By checking the following boxes with an X, you ensure that:

- [X] The pack was tested ingame in at least one device.
- [X] The pack is an existing BT pack, is a missing pack from VT or is an accepted pack/change in a discussion.
- [X] The pack code follows the style guide.
- [X] The commits follow the contribution guidelines.
- [X] The PR follows the contribution guidelines.

- [X] (Optional) Tested in Windows
- [ ] (Optional) Tested in Android
- [ ] (Optional) Tested in iOS
- [ ] (Optional) Tested in any console
- [ ] (Optional) Tested in BDS
