### PR TITLE
update(files): Update Dark UI to 1.21.120

### DIFF
--- a/resource_packs/files/gui/dark_ui/textures/gui/controls/jump_dpad.png
+++ b/resource_packs/files/gui/dark_ui/textures/gui/controls/jump_dpad.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:94b6e0310502000a0435c0c43a5f3254b84be24cbe232d0d67fe8a1ec83f9d0b
+size 473

--- a/resource_packs/files/gui/dark_ui/textures/gui/controls/jump_dpad_pressed.png
+++ b/resource_packs/files/gui/dark_ui/textures/gui/controls/jump_dpad_pressed.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a0556a0666065942913ba411a8d6542583beecfb0c65ef30d9455ac5acfb49ba
+size 476

--- a/resource_packs/files/gui/dark_ui/textures/ui/armors_and_tools_slot_overlay.png
+++ b/resource_packs/files/gui/dark_ui/textures/ui/armors_and_tools_slot_overlay.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f7b536945073390215034dd27b28d0ad7ea39db1b2130b31fb3ae0994de12442
-size 473
+oid sha256:79988113aecce577e9cbd8897916478106f43cee411848ace6eacc94feaa0f58
+size 666

--- a/resource_packs/files/gui/dark_ui/textures/ui/armors_slot_overlay.png
+++ b/resource_packs/files/gui/dark_ui/textures/ui/armors_slot_overlay.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a9c3c5918a5fd38df440e98eafef9faeaa8cc7a19605bf9ac07643cdbbdf453a
-size 255
+oid sha256:58b2324777ac302b4490839dd023362560c75c4f2620d5029106fcd6e27d3fac
+size 502

--- a/resource_packs/files/gui/dark_ui/textures/ui/bottle_empty.png
+++ b/resource_packs/files/gui/dark_ui/textures/ui/bottle_empty.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a69944f0960443182188a122a3003883498e2f9f02f2518ee9546deb4bd346bd
-size 134
+oid sha256:ba28a933aed18056a5cb6370798eaf756df8703b770db030d727da2f3a59a4ef
+size 420

--- a/resource_packs/files/gui/dark_ui/textures/ui/empty_armor_slot_chestplate.png
+++ b/resource_packs/files/gui/dark_ui/textures/ui/empty_armor_slot_chestplate.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:dca0647ff206256cf0b700b5fcc760784ca158eb1bdf25e5fc3d0aaee3e4a477
-size 197
+oid sha256:50131ae1e7cb2c84f6ddaef81ae32b1ae242925aadf48cc084b9745477e3c22d
+size 429

--- a/resource_packs/files/gui/dark_ui/textures/ui/mpp_banner_background_default.png
+++ b/resource_packs/files/gui/dark_ui/textures/ui/mpp_banner_background_default.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4d0c4c7fb941f1e1feee03dfd4ab0677e5a1fcf8d451d3f02e3018f7de889155
+size 362

--- a/resource_packs/files/gui/dark_ui/textures/ui/mpp_banner_background_hover.png
+++ b/resource_packs/files/gui/dark_ui/textures/ui/mpp_banner_background_hover.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:941780d2149b57b8b724c92402d4e1243d8253daadf4f5dee6c2f4ce0e2365a9
+size 372

--- a/resource_packs/files/gui/dark_ui/textures/ui/slider_video_menu.png
+++ b/resource_packs/files/gui/dark_ui/textures/ui/slider_video_menu.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c2f9b3eb4f1dc6194f87613c01c8bb5fda642e8e97138a6c54fb915ac1a0ab54
+size 359


### PR DESCRIPTION
1. Textured new `jump_dpad_pressed` and `jump_dpad` touch control buttons
2. Textured new empty chestplate overlay in `armors_and_tools_slot_overlay`, `armors_slot_overlay` and `empty_armor_slot_chestplate`
3. Textured new brewing stand empty bottle icon in `bottle_empty`
4. Textured new marketplace pass banner background default and hover in `mpp_banner_background_default` and `mpp_banner_background_hover`
5. Textured new slider background textures for video settings in `slider_video_menu`

By checking the following boxes with an X, you ensure that:

- [X] The pack was tested ingame in at least one device.
- [X] The pack is an existing BT pack, is a missing pack from VT or is an accepted pack/change in a discussion.
- [X] The pack code follows the style guide.
- [X] The commits follow the contribution guidelines.
- [X] The PR follows the contribution guidelines.

- [X] (Optional) Tested in Windows
- [X] (Optional) Tested in Android
- [ ] (Optional) Tested in iOS
- [ ] (Optional) Tested in any console
- [ ] (Optional) Tested in BDS
