### PR TITLE
chore(files): Remove Brewing Stand Icons Fix pack as no longer required in 1.21.120

### DIFF
--- a/resource_packs/extras/gui/dark_brewing_stand_icons_fix/textures/ui/bottle_empty.png
+++ b/resource_packs/extras/gui/dark_brewing_stand_icons_fix/textures/ui/bottle_empty.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:5ec579a72140a67014f64761eb5d84354d7946fe61560e116fd5a2fec7e645ed
-size 132

--- a/resource_packs/files/fixes_and_consistency/brewing_stand_icons_fix/pack_icon.png
+++ b/resource_packs/files/fixes_and_consistency/brewing_stand_icons_fix/pack_icon.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:bf11d6eeff587698d7ffdcd26c8068c3e5ca34338652f8a172d1f81960ea4756
-size 1742

--- a/resource_packs/files/fixes_and_consistency/brewing_stand_icons_fix/textures/ui/bottle_empty.png
+++ b/resource_packs/files/fixes_and_consistency/brewing_stand_icons_fix/textures/ui/bottle_empty.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c8c53fe6c2b67c2e80b07db46f2e806b1567258085bf750f9bb0bd5c131897c7
-size 209

--- a/resource_packs/packs.json
+++ b/resource_packs/packs.json
@@ -2771,11 +2771,6 @@
 					"description": "Fixes the Blaze's rods' color on the bottom face"
 				},
 				{
-					"id": "brewing_stand_icons_fix",
-					"name": "Brewing Stand Icons Fix",
-					"description": "Removes the extra pixels on the Brewing Stand's potion slot icons"
-				},
-				{
 					"id": "nicer_fast_leaves",
 					"name": "Nicer Fast Leaves",
 					"description": "Replaces the random green parts in leaves to a darker green when having fancy leaves disabled"
@@ -3002,13 +2997,6 @@
 			"combines": [
 				"gui/dark_ui",
 				"gui/numbered_hotbar"
-			]
-		},
-		{
-			"id": "extras/gui/dark_brewing_stand_icons_fix",
-			"combines": [
-				"gui/dark_ui",
-				"fixes_and_consistency/brewing_stand_icons_fix"
 			]
 		},
 		{


### PR DESCRIPTION
1. This pack is no longer needed as this is actually fixed in 1.21.120 by Mojang so now it is bye bye for this pack
2. Removed `dark_brewing_stand_icons_fix` combination
3. Removed `brewing_stand_icons_fix` pack
4. Removed the entries from `packs.json`

From the changelogs of 1.21.120:
<img width="866" height="70" alt="image" src="https://github.com/user-attachments/assets/ea4fdc7e-e01f-467a-8c30-4e90e190f2c0" />