### PR TITLE
fix(files): Fix waxed copper trapdoors don't have a glass texture in item icon when using Visual Waxed Copper (Items) and Glass Doors and Trapdoors

### DIFF
--- a/resource_packs/extras/utility/visual_waxed_glass_doors_and_trapdoors/textures/blocks/waxed_copper_trapdoor.png
+++ b/resource_packs/extras/utility/visual_waxed_glass_doors_and_trapdoors/textures/blocks/waxed_copper_trapdoor.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4d9e7d973803d2d7d83d8d9b4bc46d5d5213dac02921aa68c2660af696e39e70
+size 583

--- a/resource_packs/extras/utility/visual_waxed_glass_doors_and_trapdoors/textures/blocks/waxed_exposed_copper_trapdoor.png
+++ b/resource_packs/extras/utility/visual_waxed_glass_doors_and_trapdoors/textures/blocks/waxed_exposed_copper_trapdoor.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bd3af972ef28021f4b6a4e9a918c9de702a5195e071acc0c10a808b29ef79b35
+size 588

--- a/resource_packs/extras/utility/visual_waxed_glass_doors_and_trapdoors/textures/blocks/waxed_oxidized_copper_trapdoor.png
+++ b/resource_packs/extras/utility/visual_waxed_glass_doors_and_trapdoors/textures/blocks/waxed_oxidized_copper_trapdoor.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:135e94cabdbad0eab38516b4b5de7a21f96a63d62123fad10503aa0f599d432b
+size 572

--- a/resource_packs/extras/utility/visual_waxed_glass_doors_and_trapdoors/textures/blocks/waxed_weathered_copper_trapdoor.png
+++ b/resource_packs/extras/utility/visual_waxed_glass_doors_and_trapdoors/textures/blocks/waxed_weathered_copper_trapdoor.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e815dfc6b4938ac8cbaecedcdaab9dfd7ed6f4235dbad2fbadf42f3c11658ed8
+size 581


### PR DESCRIPTION
1. Fix waxed copper trapdoors don't have a glass texture in item icon when using Visual Waxed Copper (Items) and Glass Doors and Trapdoors

Resolves #793

By checking the following boxes with an X, you ensure that:

- [X] The pack was tested ingame in at least one device.
- [X] The pack is an existing BT pack, is a missing pack from VT or is an accepted pack/change in a discussion.
- [X] The pack code follows the style guide.
- [X] The commits follow the contribution guidelines.
- [X] The PR follows the contribution guidelines.

- [X] (Optional) Tested in Windows
- [ ] (Optional) Tested in Android
- [ ] (Optional) Tested in iOS
- [ ] (Optional) Tested in any console
- [ ] (Optional) Tested in BDS
