### PR TITLE
fix(files): redstone wire fix now fixes all dust shapes instead of just fixing straight lines

### DIFF
--- a/resource_packs/files/fixes_and_consistency/redstone_wire_fix/textures/blocks/redstone_dust_cross.png
+++ b/resource_packs/files/fixes_and_consistency/redstone_wire_fix/textures/blocks/redstone_dust_cross.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:898cad6dc479c199a74b21491a959c357d9d80c3e9cb1803b2481c0c31f8fe4b
+size 299


### PR DESCRIPTION
<description_pr>
Fixes: #836
By checking the following boxes with an X, you ensure that:

- [X] The pack was tested ingame in at least one device.
- [X] The pack is an existing BT pack, is a missing pack from VT or is an accepted pack/change in a discussion.
- [X] The pack code follows the style guide.
- [X] The commits follow the contribution guidelines.
- [X] The PR follows the contribution guidelines.

- [ ] (Optional) Tested in Windows
- [X] (Optional) Tested in Android
- [ ] (Optional) Tested in iOS
- [ ] (Optional) Tested in any console
- [ ] (Optional) Tested in BDS
