### PR TITLE
feat(files): Added pack to bring back old stripped spruce logs

### DIFF
--- a/resource_packs/files/retro/pre_26_0_stripped_spruce/pack_icon.png
+++ b/resource_packs/files/retro/pre_26_0_stripped_spruce/pack_icon.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:764ca60c54487ab339e4f1e5734d68cc58b6c4e8bd2e2f2c67c45cb6e599f81f
+size 4610

--- a/resource_packs/files/retro/pre_26_0_stripped_spruce/textures/blocks/stripped_spruce_log.png
+++ b/resource_packs/files/retro/pre_26_0_stripped_spruce/textures/blocks/stripped_spruce_log.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d761405c1dd7ba56743092df9f44019c006f80113a2c333fbcb4d47c3479c252
+size 387

--- a/resource_packs/files/retro/pre_26_0_stripped_spruce/textures/blocks/stripped_spruce_log_top.png
+++ b/resource_packs/files/retro/pre_26_0_stripped_spruce/textures/blocks/stripped_spruce_log_top.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:498d69f5b48b9b59bd2181a718058a6516cf41689ed2fc7468c13001dda6d317
+size 312

--- a/resource_packs/packs.json
+++ b/resource_packs/packs.json
@@ -2230,6 +2230,11 @@
 					"id": "old_dyes",
 					"name": "Old Dyes",
 					"description": "Reverts all dyes to their pre-1.21.100 textures"
+				},
+				{
+					"id": "pre_26_0_stripped_spruce",
+					"name": "Pre-26.0 Stripped Spruce",
+					"description": "Reverts stripped spruce to use its pre-26.0 texture"
 				}
 			]
 		},


### PR DESCRIPTION
<description_pr>

By checking the following boxes with an X, you ensure that:

- [X] The pack was tested ingame in at least one device.
- [X] The pack is an existing BT pack, is a missing pack from VT or is an accepted pack/change in a discussion.
- [X] The pack code follows the style guide.
- [X] The commits follow the contribution guidelines.
- [X] The PR follows the contribution guidelines.

- [ ] (Optional) Tested in Windows
- [X] (Optional) Tested in Android
- [ ] (Optional) Tested in iOS
- [ ] (Optional) Tested in any console
- [ ] (Optional) Tested in BDS
