### PR TITLE
update(files): Update Dark UI to 26.10

### DIFF
--- a/resource_packs/files/gui/dark_ui/textures/ui/empty_nautilus_slot_armor.png
+++ b/resource_packs/files/gui/dark_ui/textures/ui/empty_nautilus_slot_armor.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0fb877ea54057a8f5b24e9b551ffe1feb2748f2ca9e13baf3312a7b7cc8a73f5
+size 437

--- a/resource_packs/files/gui/dark_ui/textures/ui/socialbuttonicon/social-default-icon.png
+++ b/resource_packs/files/gui/dark_ui/textures/ui/socialbuttonicon/social-default-icon.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:96c354cd7da6ada3bb8653b21734887b945bb723280c10d4cb731b62c90c32b0
+size 419

--- a/resource_packs/files/gui/dark_ui/textures/ui/socialbuttonicon/social-hover-icon.png
+++ b/resource_packs/files/gui/dark_ui/textures/ui/socialbuttonicon/social-hover-icon.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:96c354cd7da6ada3bb8653b21734887b945bb723280c10d4cb731b62c90c32b0
+size 419


### PR DESCRIPTION
1. Nautilus Inventory UI is added to Dark UI
2. Social Button Icon is now textured to be white

Resolves #820 

By checking the following boxes with an X, you ensure that:

- [X] The pack was tested ingame in at least one device.
- [X] The pack is an existing BT pack, is a missing pack from VT or is an accepted pack/change in a discussion.
- [X] The pack code follows the style guide.
- [X] The commits follow the contribution guidelines.
- [X] The PR follows the contribution guidelines.

- [X] (Optional) Tested in Windows
- [ ] (Optional) Tested in Android
- [ ] (Optional) Tested in iOS
- [ ] (Optional) Tested in any console
- [ ] (Optional) Tested in BDS
