### PR TITLE
fix(files): Fix Variated Cobblestone not variating the cobblestone wall

### DIFF
--- a/resource_packs/files/variation/variated_cobblestone/textures/terrain_texture.json
+++ b/resource_packs/files/variation/variated_cobblestone/textures/terrain_texture.json
@@ -76,6 +76,42 @@
 				]
 			}
 		},
+		"flattened_cobblestone_wall": {
+			"textures": {
+				"variations": [
+					{
+						"path": "textures/blocks/cobblestone/0"
+					},
+					{
+						"path": "textures/blocks/cobblestone/1"
+					},
+					{
+						"path": "textures/blocks/cobblestone/2"
+					},
+					{
+						"path": "textures/blocks/cobblestone/3"
+					},
+					{
+						"path": "textures/blocks/cobblestone/4"
+					},
+					{
+						"path": "textures/blocks/cobblestone/5"
+					},
+					{
+						"path": "textures/blocks/cobblestone/6"
+					},
+					{
+						"path": "textures/blocks/cobblestone/7"
+					},
+					{
+						"path": "textures/blocks/cobblestone/8"
+					},
+					{
+						"path": "textures/blocks/cobblestone/9"
+					}
+				]
+			}
+		},
 		"infested_cobblestone": {
 			"textures": {
 				"variations": [

--- a/resource_packs/packs.json
+++ b/resource_packs/packs.json
@@ -455,7 +455,7 @@
 				{
 					"id": "variated_cobblestone",
 					"name": "Variated Cobblestone",
-					"description": "Cobblestone will be randomized using a selection of 7 textures"
+					"description": "Cobblestone will be randomized using a selection of 10 textures"
 				},
 				{
 					"id": "variated_moss",

--- a/resource_packs/packs.json
+++ b/resource_packs/packs.json
@@ -480,7 +480,7 @@
 				{
 					"id": "variated_end_stone",
 					"name": "Variated End Stone",
-					"description": "End Stone will be randomized using a selection of 5 textures"
+					"description": "End Stone will be randomized using a selection of 9 textures"
 				},
 				{
 					"id": "variated_gravel",


### PR DESCRIPTION
1. Added variation to the cobblestone wall
2. Update the variated cobblestone pack's description as the pack is using 10 randomized textures so the description should reflect that
3. Update the variated endstone pack's description as the pack is using 10 randomized textures so the description should reflect that (didnt really want to create a new pr for one word change like this)

Resolves #890

By checking the following boxes with an X, you ensure that:

- [X] The pack was tested ingame in at least one device.
- [X] The pack is an existing BT pack, is a missing pack from VT or is an accepted pack/change in a discussion.
- [X] The pack code follows the style guide.
- [X] The commits follow the contribution guidelines.
- [X] The PR follows the contribution guidelines.

- [X] (Optional) Tested in Windows
- [ ] (Optional) Tested in Android
- [ ] (Optional) Tested in iOS
- [ ] (Optional) Tested in any console
- [ ] (Optional) Tested in BDS
