### PR TITLE
fix(files):fixed variated pack definitions to have the correct number of textures

### DIFF
--- a/resource_packs/packs.json
+++ b/resource_packs/packs.json
@@ -490,7 +490,7 @@
 				{
 					"id": "variated_mycelium",
 					"name": "Variated Mycelium",
-					"description": "Mycelium will be randomized using a selection of 16 textures"
+					"description": "Mycelium will be randomized using a selection of 6 textures"
 				},
 				{
 					"id": "variated_planks",
@@ -500,12 +500,12 @@
 				{
 					"id": "variated_stone",
 					"name": "Variated Stone",
-					"description": "Stone will be randomized using a selection of 16 textures"
+					"description": "Stone will be randomized using a selection of 6 textures"
 				},
 				{
 					"id": "variated_terracotta",
 					"name": "Variated Terracotta",
-					"description": "Terracotta will be randomized using a selection of 16 textures"
+					"description": "Terracotta will be randomized using a selection of 7 textures"
 				},
 				{
 					"id": "variated_unpolished_stones",


### PR DESCRIPTION
<description_pr>

By checking the following boxes with an X, you ensure that:

- [ ] The pack was tested ingame in at least one device.
- [X] The pack is an existing BT pack, is a missing pack from VT or is an accepted pack/change in a discussion.
- [X] The pack code follows the style guide.
- [X] The commits follow the contribution guidelines.
- [X] The PR follows the contribution guidelines.

- [ ] (Optional) Tested in Windows
- [ ] (Optional) Tested in Android
- [ ] (Optional) Tested in iOS
- [ ] (Optional) Tested in any console
- [ ] (Optional) Tested in BDS
