### PR TITLE
update(files): Update Clearer Water, Old Water and Lush Grass All 'Round! to 26.20

### DIFF
--- a/resource_packs/extras/terrain/lush_grass_clearer_water/biomes/cherry_grove.client_biome.json
+++ b/resource_packs/extras/terrain/lush_grass_clearer_water/biomes/cherry_grove.client_biome.json
@@ -36,6 +36,9 @@
 					"chance": 0.01
 				},
 				"underwater_loop": "ambient.underwater.loop"
+			},
+			"minecraft:biome_music": {
+				"music_definition": "cherry_grove"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/lush_grass_clearer_water/biomes/mesa.client_biome.json
+++ b/resource_packs/extras/terrain/lush_grass_clearer_water/biomes/mesa.client_biome.json
@@ -36,6 +36,9 @@
 					"chance": 0.01
 				},
 				"underwater_loop": "ambient.underwater.loop"
+			},
+			"minecraft:biome_music": {
+				"music_definition": "mesa"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/lush_grass_clearer_water/biomes/mesa_plateau_mutated.client_biome.json
+++ b/resource_packs/extras/terrain/lush_grass_clearer_water/biomes/mesa_plateau_mutated.client_biome.json
@@ -36,6 +36,9 @@
 					"chance": 0.01
 				},
 				"underwater_loop": "ambient.underwater.loop"
+			},
+			"minecraft:biome_music": {
+				"music_definition": "mesa_plateau_mutated"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/bamboo_jungle.client_biome.json
+++ b/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/bamboo_jungle.client_biome.json
@@ -30,6 +30,9 @@
 					"chance": 0.01
 				},
 				"underwater_loop": "ambient.underwater.loop"
+			},
+			"minecraft:biome_music": {
+				"music_definition": "bamboo_jungle"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/bamboo_jungle_hills.client_biome.json
+++ b/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/bamboo_jungle_hills.client_biome.json
@@ -30,6 +30,9 @@
 					"chance": 0.01
 				},
 				"underwater_loop": "ambient.underwater.loop"
+			},
+			"minecraft:biome_music": {
+				"music_definition": "bamboo_jungle_hills"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/birch_forest.client_biome.json
+++ b/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/birch_forest.client_biome.json
@@ -30,6 +30,9 @@
 					"chance": 0.01
 				},
 				"underwater_loop": "ambient.underwater.loop"
+			},
+			"minecraft:biome_music": {
+				"music_definition": "birch_forest"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/birch_forest_hills.client_biome.json
+++ b/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/birch_forest_hills.client_biome.json
@@ -30,6 +30,9 @@
 					"chance": 0.01
 				},
 				"underwater_loop": "ambient.underwater.loop"
+			},
+			"minecraft:biome_music": {
+				"music_definition": "birch_forest_hills"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/birch_forest_mutated.client_biome.json
+++ b/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/birch_forest_mutated.client_biome.json
@@ -30,6 +30,9 @@
 					"chance": 0.01
 				},
 				"underwater_loop": "ambient.underwater.loop"
+			},
+			"minecraft:biome_music": {
+				"music_definition": "birch_forest_mutated"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/cherry_grove.client_biome.json
+++ b/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/cherry_grove.client_biome.json
@@ -36,6 +36,9 @@
 					"chance": 0.01
 				},
 				"underwater_loop": "ambient.underwater.loop"
+			},
+			"minecraft:biome_music": {
+				"music_definition": "cherry_grove"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/deep_dark.client_biome.json
+++ b/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/deep_dark.client_biome.json
@@ -30,6 +30,9 @@
 					"chance": 0.01
 				},
 				"underwater_loop": "ambient.underwater.loop"
+			},
+			"minecraft:biome_music": {
+				"music_definition": "deep_dark"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/desert.client_biome.json
+++ b/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/desert.client_biome.json
@@ -30,6 +30,9 @@
 					"chance": 0.01
 				},
 				"underwater_loop": "ambient.underwater.loop"
+			},
+			"minecraft:biome_music": {
+				"music_definition": "desert"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/desert_hills.client_biome.json
+++ b/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/desert_hills.client_biome.json
@@ -30,6 +30,9 @@
 					"chance": 0.01
 				},
 				"underwater_loop": "ambient.underwater.loop"
+			},
+			"minecraft:biome_music": {
+				"music_definition": "desert_hills"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/desert_mutated.client_biome.json
+++ b/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/desert_mutated.client_biome.json
@@ -30,6 +30,9 @@
 					"chance": 0.01
 				},
 				"underwater_loop": "ambient.underwater.loop"
+			},
+			"minecraft:biome_music": {
+				"music_definition": "desert_mutated"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/dripstone_caves.client_biome.json
+++ b/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/dripstone_caves.client_biome.json
@@ -30,6 +30,9 @@
 					"chance": 0.01
 				},
 				"underwater_loop": "ambient.underwater.loop"
+			},
+			"minecraft:biome_music": {
+				"music_definition": "dripstone_caves"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/flower_forest.client_biome.json
+++ b/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/flower_forest.client_biome.json
@@ -30,6 +30,9 @@
 					"chance": 0.01
 				},
 				"underwater_loop": "ambient.underwater.loop"
+			},
+			"minecraft:biome_music": {
+				"music_definition": "flower_forest"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/frozen_peaks.client_biome.json
+++ b/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/frozen_peaks.client_biome.json
@@ -30,6 +30,9 @@
 					"chance": 0.01
 				},
 				"underwater_loop": "ambient.underwater.loop"
+			},
+			"minecraft:biome_music": {
+				"music_definition": "frozen_peaks"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/grove.client_biome.json
+++ b/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/grove.client_biome.json
@@ -30,6 +30,9 @@
 					"chance": 0.01
 				},
 				"underwater_loop": "ambient.underwater.loop"
+			},
+			"minecraft:biome_music": {
+				"music_definition": "grove"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/hell.client_biome.json
+++ b/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/hell.client_biome.json
@@ -36,6 +36,9 @@
 			},
 			"minecraft:water_identifier": {
 				"water_identifier": "minecraft:default_water"
+			},
+			"minecraft:biome_music": {
+				"music_definition": "hell"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/jagged_peaks.client_biome.json
+++ b/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/jagged_peaks.client_biome.json
@@ -30,6 +30,9 @@
 					"chance": 0.01
 				},
 				"underwater_loop": "ambient.underwater.loop"
+			},
+			"minecraft:biome_music": {
+				"music_definition": "jagged_peaks"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/jungle.client_biome.json
+++ b/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/jungle.client_biome.json
@@ -30,6 +30,9 @@
 					"chance": 0.01
 				},
 				"underwater_loop": "ambient.underwater.loop"
+			},
+			"minecraft:biome_music": {
+				"music_definition": "jungle"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/jungle_edge.client_biome.json
+++ b/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/jungle_edge.client_biome.json
@@ -30,6 +30,9 @@
 					"chance": 0.01
 				},
 				"underwater_loop": "ambient.underwater.loop"
+			},
+			"minecraft:biome_music": {
+				"music_definition": "jungle_edge"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/jungle_hills.client_biome.json
+++ b/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/jungle_hills.client_biome.json
@@ -30,6 +30,9 @@
 					"chance": 0.01
 				},
 				"underwater_loop": "ambient.underwater.loop"
+			},
+			"minecraft:biome_music": {
+				"music_definition": "jungle_hills"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/jungle_mutated.client_biome.json
+++ b/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/jungle_mutated.client_biome.json
@@ -30,6 +30,9 @@
 					"chance": 0.01
 				},
 				"underwater_loop": "ambient.underwater.loop"
+			},
+			"minecraft:biome_music": {
+				"music_definition": "jungle_mutated"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/lush_caves.client_biome.json
+++ b/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/lush_caves.client_biome.json
@@ -30,6 +30,9 @@
 					"chance": 0.01
 				},
 				"underwater_loop": "ambient.underwater.loop"
+			},
+			"minecraft:biome_music": {
+				"music_definition": "lush_caves"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/meadow.client_biome.json
+++ b/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/meadow.client_biome.json
@@ -30,6 +30,9 @@
 					"chance": 0.01
 				},
 				"underwater_loop": "ambient.underwater.loop"
+			},
+			"minecraft:biome_music": {
+				"music_definition": "meadow"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/mega_taiga.client_biome.json
+++ b/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/mega_taiga.client_biome.json
@@ -30,6 +30,9 @@
 					"chance": 0.01
 				},
 				"underwater_loop": "ambient.underwater.loop"
+			},
+			"minecraft:biome_music": {
+				"music_definition": "mega_taiga"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/mesa.client_biome.json
+++ b/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/mesa.client_biome.json
@@ -36,6 +36,9 @@
 					"chance": 0.01
 				},
 				"underwater_loop": "ambient.underwater.loop"
+			},
+			"minecraft:biome_music": {
+				"music_definition": "mesa"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/mesa_plateau.client_biome.json
+++ b/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/mesa_plateau.client_biome.json
@@ -30,6 +30,9 @@
 					"chance": 0.01
 				},
 				"underwater_loop": "ambient.underwater.loop"
+			},
+			"minecraft:biome_music": {
+				"music_definition": "mesa_plateau"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/mesa_plateau_mutated.client_biome.json
+++ b/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/mesa_plateau_mutated.client_biome.json
@@ -36,6 +36,9 @@
 					"chance": 0.01
 				},
 				"underwater_loop": "ambient.underwater.loop"
+			},
+			"minecraft:biome_music": {
+				"music_definition": "mesa_plateau_mutated"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/redwood_taiga_hills_mutated.client_biome.json
+++ b/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/redwood_taiga_hills_mutated.client_biome.json
@@ -30,6 +30,9 @@
 					"chance": 0.01
 				},
 				"underwater_loop": "ambient.underwater.loop"
+			},
+			"minecraft:biome_music": {
+				"music_definition": "redwood_taiga_hills_mutated"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/redwood_taiga_mutated.client_biome.json
+++ b/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/redwood_taiga_mutated.client_biome.json
@@ -30,6 +30,9 @@
 					"chance": 0.01
 				},
 				"underwater_loop": "ambient.underwater.loop"
+			},
+			"minecraft:biome_music": {
+				"music_definition": "redwood_taiga_mutated"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/roofed_forest_mutated.client_biome.json
+++ b/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/roofed_forest_mutated.client_biome.json
@@ -33,6 +33,9 @@
 					"chance": 0.01
 				},
 				"underwater_loop": "ambient.underwater.loop"
+			},
+			"minecraft:biome_music": {
+				"music_definition": "roofed_forest_mutated"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/snowy_slopes.client_biome.json
+++ b/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/snowy_slopes.client_biome.json
@@ -30,6 +30,9 @@
 					"chance": 0.01
 				},
 				"underwater_loop": "ambient.underwater.loop"
+			},
+			"minecraft:biome_music": {
+				"music_definition": "snowy_slopes"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/stony_peaks.client_biome.json
+++ b/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/stony_peaks.client_biome.json
@@ -30,6 +30,9 @@
 					"chance": 0.01
 				},
 				"underwater_loop": "ambient.underwater.loop"
+			},
+			"minecraft:biome_music": {
+				"music_definition": "stony_peaks"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/swampland.client_biome.json
+++ b/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/swampland.client_biome.json
@@ -43,6 +43,9 @@
 					"chance": 0.01
 				},
 				"underwater_loop": "ambient.underwater.loop"
+			},
+			"minecraft:biome_music": {
+				"music_definition": "swampland"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/swampland_mutated.client_biome.json
+++ b/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/swampland_mutated.client_biome.json
@@ -43,6 +43,9 @@
 					"chance": 0.01
 				},
 				"underwater_loop": "ambient.underwater.loop"
+			},
+			"minecraft:biome_music": {
+				"music_definition": "swampland_mutated"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/the_end.client_biome.json
+++ b/resource_packs/extras/terrain/lush_grass_old_clearer_water/biomes/the_end.client_biome.json
@@ -33,6 +33,9 @@
 					"chance": 0.01
 				},
 				"underwater_loop": "ambient.underwater.loop"
+			},
+			"minecraft:biome_music": {
+				"music_definition": "end"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/lush_grass_old_water/biomes/cherry_grove.client_biome.json
+++ b/resource_packs/extras/terrain/lush_grass_old_water/biomes/cherry_grove.client_biome.json
@@ -35,6 +35,9 @@
 					"chance": 0.01
 				},
 				"underwater_loop": "ambient.underwater.loop"
+			},
+			"minecraft:biome_music": {
+				"music_definition": "cherry_grove"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/lush_grass_old_water/biomes/mesa.client_biome.json
+++ b/resource_packs/extras/terrain/lush_grass_old_water/biomes/mesa.client_biome.json
@@ -35,6 +35,9 @@
 					"chance": 0.01
 				},
 				"underwater_loop": "ambient.underwater.loop"
+			},
+			"minecraft:biome_music": {
+				"music_definition": "mesa"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/lush_grass_old_water/biomes/mesa_plateau_mutated.client_biome.json
+++ b/resource_packs/extras/terrain/lush_grass_old_water/biomes/mesa_plateau_mutated.client_biome.json
@@ -35,6 +35,9 @@
 					"chance": 0.01
 				},
 				"underwater_loop": "ambient.underwater.loop"
+			},
+			"minecraft:biome_music": {
+				"music_definition": "mesa_plateau_mutated"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/old_clearer_water/biomes/bamboo_jungle.client_biome.json
+++ b/resource_packs/extras/terrain/old_clearer_water/biomes/bamboo_jungle.client_biome.json
@@ -30,6 +30,9 @@
 					"chance": 0.01
 				},
 				"underwater_loop": "ambient.underwater.loop"
+			},
+			"minecraft:biome_music": {
+				"music_definition": "bamboo_jungle"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/old_clearer_water/biomes/bamboo_jungle_hills.client_biome.json
+++ b/resource_packs/extras/terrain/old_clearer_water/biomes/bamboo_jungle_hills.client_biome.json
@@ -30,6 +30,9 @@
 					"chance": 0.01
 				},
 				"underwater_loop": "ambient.underwater.loop"
+			},
+			"minecraft:biome_music": {
+				"music_definition": "bamboo_jungle_hills"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/old_clearer_water/biomes/birch_forest.client_biome.json
+++ b/resource_packs/extras/terrain/old_clearer_water/biomes/birch_forest.client_biome.json
@@ -30,6 +30,9 @@
 					"chance": 0.01
 				},
 				"underwater_loop": "ambient.underwater.loop"
+			},
+			"minecraft:biome_music": {
+				"music_definition": "birch_forest"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/old_clearer_water/biomes/birch_forest_hills.client_biome.json
+++ b/resource_packs/extras/terrain/old_clearer_water/biomes/birch_forest_hills.client_biome.json
@@ -30,6 +30,9 @@
 					"chance": 0.01
 				},
 				"underwater_loop": "ambient.underwater.loop"
+			},
+			"minecraft:biome_music": {
+				"music_definition": "birch_forest_hills"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/old_clearer_water/biomes/birch_forest_mutated.client_biome.json
+++ b/resource_packs/extras/terrain/old_clearer_water/biomes/birch_forest_mutated.client_biome.json
@@ -30,6 +30,9 @@
 					"chance": 0.01
 				},
 				"underwater_loop": "ambient.underwater.loop"
+			},
+			"minecraft:biome_music": {
+				"music_definition": "birch_forest_mutated"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/old_clearer_water/biomes/cherry_grove.client_biome.json
+++ b/resource_packs/extras/terrain/old_clearer_water/biomes/cherry_grove.client_biome.json
@@ -36,6 +36,9 @@
 					"chance": 0.01
 				},
 				"underwater_loop": "ambient.underwater.loop"
+			},
+			"minecraft:biome_music": {
+				"music_definition": "cherry_grove"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/old_clearer_water/biomes/deep_dark.client_biome.json
+++ b/resource_packs/extras/terrain/old_clearer_water/biomes/deep_dark.client_biome.json
@@ -30,6 +30,9 @@
 					"chance": 0.01
 				},
 				"underwater_loop": "ambient.underwater.loop"
+			},
+			"minecraft:biome_music": {
+				"music_definition": "deep_dark"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/old_clearer_water/biomes/desert.client_biome.json
+++ b/resource_packs/extras/terrain/old_clearer_water/biomes/desert.client_biome.json
@@ -30,6 +30,9 @@
 					"chance": 0.01
 				},
 				"underwater_loop": "ambient.underwater.loop"
+			},
+			"minecraft:biome_music": {
+				"music_definition": "desert"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/old_clearer_water/biomes/desert_hills.client_biome.json
+++ b/resource_packs/extras/terrain/old_clearer_water/biomes/desert_hills.client_biome.json
@@ -30,6 +30,9 @@
 					"chance": 0.01
 				},
 				"underwater_loop": "ambient.underwater.loop"
+			},
+			"minecraft:biome_music": {
+				"music_definition": "desert_hills"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/old_clearer_water/biomes/desert_mutated.client_biome.json
+++ b/resource_packs/extras/terrain/old_clearer_water/biomes/desert_mutated.client_biome.json
@@ -30,6 +30,9 @@
 					"chance": 0.01
 				},
 				"underwater_loop": "ambient.underwater.loop"
+			},
+			"minecraft:biome_music": {
+				"music_definition": "desert_mutated"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/old_clearer_water/biomes/dripstone_caves.client_biome.json
+++ b/resource_packs/extras/terrain/old_clearer_water/biomes/dripstone_caves.client_biome.json
@@ -30,6 +30,9 @@
 					"chance": 0.01
 				},
 				"underwater_loop": "ambient.underwater.loop"
+			},
+			"minecraft:biome_music": {
+				"music_definition": "dripstone_caves"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/old_clearer_water/biomes/flower_forest.client_biome.json
+++ b/resource_packs/extras/terrain/old_clearer_water/biomes/flower_forest.client_biome.json
@@ -30,6 +30,9 @@
 					"chance": 0.01
 				},
 				"underwater_loop": "ambient.underwater.loop"
+			},
+			"minecraft:biome_music": {
+				"music_definition": "flower_forest"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/old_clearer_water/biomes/frozen_peaks.client_biome.json
+++ b/resource_packs/extras/terrain/old_clearer_water/biomes/frozen_peaks.client_biome.json
@@ -30,6 +30,9 @@
 					"chance": 0.01
 				},
 				"underwater_loop": "ambient.underwater.loop"
+			},
+			"minecraft:biome_music": {
+				"music_definition": "frozen_peaks"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/old_clearer_water/biomes/grove.client_biome.json
+++ b/resource_packs/extras/terrain/old_clearer_water/biomes/grove.client_biome.json
@@ -30,6 +30,9 @@
 					"chance": 0.01
 				},
 				"underwater_loop": "ambient.underwater.loop"
+			},
+			"minecraft:biome_music": {
+				"music_definition": "grove"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/old_clearer_water/biomes/hell.client_biome.json
+++ b/resource_packs/extras/terrain/old_clearer_water/biomes/hell.client_biome.json
@@ -36,6 +36,9 @@
 			},
 			"minecraft:water_identifier": {
 				"water_identifier": "minecraft:default_water"
+			},
+			"minecraft:biome_music": {
+				"music_definition": "hell"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/old_clearer_water/biomes/jagged_peaks.client_biome.json
+++ b/resource_packs/extras/terrain/old_clearer_water/biomes/jagged_peaks.client_biome.json
@@ -30,6 +30,9 @@
 					"chance": 0.01
 				},
 				"underwater_loop": "ambient.underwater.loop"
+			},
+			"minecraft:biome_music": {
+				"music_definition": "jagged_peaks"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/old_clearer_water/biomes/jungle.client_biome.json
+++ b/resource_packs/extras/terrain/old_clearer_water/biomes/jungle.client_biome.json
@@ -30,6 +30,9 @@
 					"chance": 0.01
 				},
 				"underwater_loop": "ambient.underwater.loop"
+			},
+			"minecraft:biome_music": {
+				"music_definition": "jungle"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/old_clearer_water/biomes/jungle_edge.client_biome.json
+++ b/resource_packs/extras/terrain/old_clearer_water/biomes/jungle_edge.client_biome.json
@@ -30,6 +30,9 @@
 					"chance": 0.01
 				},
 				"underwater_loop": "ambient.underwater.loop"
+			},
+			"minecraft:biome_music": {
+				"music_definition": "jungle_edge"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/old_clearer_water/biomes/jungle_hills.client_biome.json
+++ b/resource_packs/extras/terrain/old_clearer_water/biomes/jungle_hills.client_biome.json
@@ -30,6 +30,9 @@
 					"chance": 0.01
 				},
 				"underwater_loop": "ambient.underwater.loop"
+			},
+			"minecraft:biome_music": {
+				"music_definition": "jungle_hills"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/old_clearer_water/biomes/jungle_mutated.client_biome.json
+++ b/resource_packs/extras/terrain/old_clearer_water/biomes/jungle_mutated.client_biome.json
@@ -30,6 +30,9 @@
 					"chance": 0.01
 				},
 				"underwater_loop": "ambient.underwater.loop"
+			},
+			"minecraft:biome_music": {
+				"music_definition": "jungle_mutated"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/old_clearer_water/biomes/lush_caves.client_biome.json
+++ b/resource_packs/extras/terrain/old_clearer_water/biomes/lush_caves.client_biome.json
@@ -30,6 +30,9 @@
 					"chance": 0.01
 				},
 				"underwater_loop": "ambient.underwater.loop"
+			},
+			"minecraft:biome_music": {
+				"music_definition": "lush_caves"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/old_clearer_water/biomes/meadow.client_biome.json
+++ b/resource_packs/extras/terrain/old_clearer_water/biomes/meadow.client_biome.json
@@ -30,6 +30,9 @@
 					"chance": 0.01
 				},
 				"underwater_loop": "ambient.underwater.loop"
+			},
+			"minecraft:biome_music": {
+				"music_definition": "meadow"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/old_clearer_water/biomes/mega_taiga.client_biome.json
+++ b/resource_packs/extras/terrain/old_clearer_water/biomes/mega_taiga.client_biome.json
@@ -30,6 +30,9 @@
 					"chance": 0.01
 				},
 				"underwater_loop": "ambient.underwater.loop"
+			},
+			"minecraft:biome_music": {
+				"music_definition": "mega_taiga"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/old_clearer_water/biomes/mesa.client_biome.json
+++ b/resource_packs/extras/terrain/old_clearer_water/biomes/mesa.client_biome.json
@@ -36,6 +36,9 @@
 					"chance": 0.01
 				},
 				"underwater_loop": "ambient.underwater.loop"
+			},
+			"minecraft:biome_music": {
+				"music_definition": "mesa"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/old_clearer_water/biomes/mesa_plateau.client_biome.json
+++ b/resource_packs/extras/terrain/old_clearer_water/biomes/mesa_plateau.client_biome.json
@@ -30,6 +30,9 @@
 					"chance": 0.01
 				},
 				"underwater_loop": "ambient.underwater.loop"
+			},
+			"minecraft:biome_music": {
+				"music_definition": "mesa_plateau"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/old_clearer_water/biomes/mesa_plateau_mutated.client_biome.json
+++ b/resource_packs/extras/terrain/old_clearer_water/biomes/mesa_plateau_mutated.client_biome.json
@@ -36,6 +36,9 @@
 					"chance": 0.01
 				},
 				"underwater_loop": "ambient.underwater.loop"
+			},
+			"minecraft:biome_music": {
+				"music_definition": "mesa_plateau_mutated"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/old_clearer_water/biomes/redwood_taiga_hills_mutated.client_biome.json
+++ b/resource_packs/extras/terrain/old_clearer_water/biomes/redwood_taiga_hills_mutated.client_biome.json
@@ -30,6 +30,9 @@
 					"chance": 0.01
 				},
 				"underwater_loop": "ambient.underwater.loop"
+			},
+			"minecraft:biome_music": {
+				"music_definition": "redwood_taiga_hills_mutated"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/old_clearer_water/biomes/redwood_taiga_mutated.client_biome.json
+++ b/resource_packs/extras/terrain/old_clearer_water/biomes/redwood_taiga_mutated.client_biome.json
@@ -30,6 +30,9 @@
 					"chance": 0.01
 				},
 				"underwater_loop": "ambient.underwater.loop"
+			},
+			"minecraft:biome_music": {
+				"music_definition": "redwood_taiga_mutated"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/old_clearer_water/biomes/roofed_forest_mutated.client_biome.json
+++ b/resource_packs/extras/terrain/old_clearer_water/biomes/roofed_forest_mutated.client_biome.json
@@ -33,6 +33,9 @@
 					"chance": 0.01
 				},
 				"underwater_loop": "ambient.underwater.loop"
+			},
+			"minecraft:biome_music": {
+				"music_definition": "roofed_forest_mutated"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/old_clearer_water/biomes/snowy_slopes.client_biome.json
+++ b/resource_packs/extras/terrain/old_clearer_water/biomes/snowy_slopes.client_biome.json
@@ -30,6 +30,9 @@
 					"chance": 0.01
 				},
 				"underwater_loop": "ambient.underwater.loop"
+			},
+			"minecraft:biome_music": {
+				"music_definition": "snowy_slopes"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/old_clearer_water/biomes/stony_peaks.client_biome.json
+++ b/resource_packs/extras/terrain/old_clearer_water/biomes/stony_peaks.client_biome.json
@@ -30,6 +30,9 @@
 					"chance": 0.01
 				},
 				"underwater_loop": "ambient.underwater.loop"
+			},
+			"minecraft:biome_music": {
+				"music_definition": "stony_peaks"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/old_clearer_water/biomes/swampland.client_biome.json
+++ b/resource_packs/extras/terrain/old_clearer_water/biomes/swampland.client_biome.json
@@ -43,6 +43,9 @@
 					"chance": 0.01
 				},
 				"underwater_loop": "ambient.underwater.loop"
+			},
+			"minecraft:biome_music": {
+				"music_definition": "swampland"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/old_clearer_water/biomes/swampland_mutated.client_biome.json
+++ b/resource_packs/extras/terrain/old_clearer_water/biomes/swampland_mutated.client_biome.json
@@ -43,6 +43,9 @@
 					"chance": 0.01
 				},
 				"underwater_loop": "ambient.underwater.loop"
+			},
+			"minecraft:biome_music": {
+				"music_definition": "swampland_mutated"
 			}
 		}
 	}

--- a/resource_packs/extras/terrain/old_clearer_water/biomes/the_end.client_biome.json
+++ b/resource_packs/extras/terrain/old_clearer_water/biomes/the_end.client_biome.json
@@ -33,6 +33,9 @@
 					"chance": 0.01
 				},
 				"underwater_loop": "ambient.underwater.loop"
+			},
+			"minecraft:biome_music": {
+				"music_definition": "end"
 			}
 		}
 	}

--- a/resource_packs/files/retro/old_water/biomes/bamboo_jungle.client_biome.json
+++ b/resource_packs/files/retro/old_water/biomes/bamboo_jungle.client_biome.json
@@ -29,6 +29,9 @@
 					"chance": 0.01
 				},
 				"underwater_loop": "ambient.underwater.loop"
+			},
+			"minecraft:biome_music": {
+				"music_definition": "bamboo_jungle"
 			}
 		}
 	}

--- a/resource_packs/files/retro/old_water/biomes/bamboo_jungle_hills.client_biome.json
+++ b/resource_packs/files/retro/old_water/biomes/bamboo_jungle_hills.client_biome.json
@@ -29,6 +29,9 @@
 					"chance": 0.01
 				},
 				"underwater_loop": "ambient.underwater.loop"
+			},
+			"minecraft:biome_music": {
+				"music_definition": "bamboo_jungle_hills"
 			}
 		}
 	}

--- a/resource_packs/files/retro/old_water/biomes/birch_forest.client_biome.json
+++ b/resource_packs/files/retro/old_water/biomes/birch_forest.client_biome.json
@@ -29,6 +29,9 @@
 					"chance": 0.01
 				},
 				"underwater_loop": "ambient.underwater.loop"
+			},
+			"minecraft:biome_music": {
+				"music_definition": "birch_forest"
 			}
 		}
 	}

--- a/resource_packs/files/retro/old_water/biomes/birch_forest_hills.client_biome.json
+++ b/resource_packs/files/retro/old_water/biomes/birch_forest_hills.client_biome.json
@@ -29,6 +29,9 @@
 					"chance": 0.01
 				},
 				"underwater_loop": "ambient.underwater.loop"
+			},
+			"minecraft:biome_music": {
+				"music_definition": "birch_forest_hills"
 			}
 		}
 	}

--- a/resource_packs/files/retro/old_water/biomes/birch_forest_mutated.client_biome.json
+++ b/resource_packs/files/retro/old_water/biomes/birch_forest_mutated.client_biome.json
@@ -29,6 +29,9 @@
 					"chance": 0.01
 				},
 				"underwater_loop": "ambient.underwater.loop"
+			},
+			"minecraft:biome_music": {
+				"music_definition": "birch_forest_mutated"
 			}
 		}
 	}

--- a/resource_packs/files/retro/old_water/biomes/cherry_grove.client_biome.json
+++ b/resource_packs/files/retro/old_water/biomes/cherry_grove.client_biome.json
@@ -35,6 +35,9 @@
 					"chance": 0.01
 				},
 				"underwater_loop": "ambient.underwater.loop"
+			},
+			"minecraft:biome_music": {
+				"music_definition": "cherry_grove"
 			}
 		}
 	}

--- a/resource_packs/files/retro/old_water/biomes/deep_dark.client_biome.json
+++ b/resource_packs/files/retro/old_water/biomes/deep_dark.client_biome.json
@@ -29,6 +29,9 @@
 					"chance": 0.01
 				},
 				"underwater_loop": "ambient.underwater.loop"
+			},
+			"minecraft:biome_music": {
+				"music_definition": "deep_dark"
 			}
 		}
 	}

--- a/resource_packs/files/retro/old_water/biomes/desert.client_biome.json
+++ b/resource_packs/files/retro/old_water/biomes/desert.client_biome.json
@@ -29,6 +29,9 @@
 					"chance": 0.01
 				},
 				"underwater_loop": "ambient.underwater.loop"
+			},
+			"minecraft:biome_music": {
+				"music_definition": "desert"
 			}
 		}
 	}

--- a/resource_packs/files/retro/old_water/biomes/desert_hills.client_biome.json
+++ b/resource_packs/files/retro/old_water/biomes/desert_hills.client_biome.json
@@ -29,6 +29,9 @@
 					"chance": 0.01
 				},
 				"underwater_loop": "ambient.underwater.loop"
+			},
+			"minecraft:biome_music": {
+				"music_definition": "desert_hills"
 			}
 		}
 	}

--- a/resource_packs/files/retro/old_water/biomes/desert_mutated.client_biome.json
+++ b/resource_packs/files/retro/old_water/biomes/desert_mutated.client_biome.json
@@ -29,6 +29,9 @@
 					"chance": 0.01
 				},
 				"underwater_loop": "ambient.underwater.loop"
+			},
+			"minecraft:biome_music": {
+				"music_definition": "desert_mutated"
 			}
 		}
 	}

--- a/resource_packs/files/retro/old_water/biomes/dripstone_caves.client_biome.json
+++ b/resource_packs/files/retro/old_water/biomes/dripstone_caves.client_biome.json
@@ -29,6 +29,9 @@
 					"chance": 0.01
 				},
 				"underwater_loop": "ambient.underwater.loop"
+			},
+			"minecraft:biome_music": {
+				"music_definition": "dripstone_caves"
 			}
 		}
 	}

--- a/resource_packs/files/retro/old_water/biomes/flower_forest.client_biome.json
+++ b/resource_packs/files/retro/old_water/biomes/flower_forest.client_biome.json
@@ -29,6 +29,9 @@
 					"chance": 0.01
 				},
 				"underwater_loop": "ambient.underwater.loop"
+			},
+			"minecraft:biome_music": {
+				"music_definition": "flower_forest"
 			}
 		}
 	}

--- a/resource_packs/files/retro/old_water/biomes/frozen_peaks.client_biome.json
+++ b/resource_packs/files/retro/old_water/biomes/frozen_peaks.client_biome.json
@@ -29,6 +29,9 @@
 					"chance": 0.01
 				},
 				"underwater_loop": "ambient.underwater.loop"
+			},
+			"minecraft:biome_music": {
+				"music_definition": "frozen_peaks"
 			}
 		}
 	}

--- a/resource_packs/files/retro/old_water/biomes/grove.client_biome.json
+++ b/resource_packs/files/retro/old_water/biomes/grove.client_biome.json
@@ -29,6 +29,9 @@
 					"chance": 0.01
 				},
 				"underwater_loop": "ambient.underwater.loop"
+			},
+			"minecraft:biome_music": {
+				"music_definition": "grove"
 			}
 		}
 	}

--- a/resource_packs/files/retro/old_water/biomes/hell.client_biome.json
+++ b/resource_packs/files/retro/old_water/biomes/hell.client_biome.json
@@ -35,6 +35,9 @@
 			},
 			"minecraft:water_identifier": {
 				"water_identifier": "minecraft:default_water"
+			},
+			"minecraft:biome_music": {
+				"music_definition": "hell"
 			}
 		}
 	}

--- a/resource_packs/files/retro/old_water/biomes/jagged_peaks.client_biome.json
+++ b/resource_packs/files/retro/old_water/biomes/jagged_peaks.client_biome.json
@@ -29,6 +29,9 @@
 					"chance": 0.01
 				},
 				"underwater_loop": "ambient.underwater.loop"
+			},
+			"minecraft:biome_music": {
+				"music_definition": "jagged_peaks"
 			}
 		}
 	}

--- a/resource_packs/files/retro/old_water/biomes/jungle.client_biome.json
+++ b/resource_packs/files/retro/old_water/biomes/jungle.client_biome.json
@@ -29,6 +29,9 @@
 					"chance": 0.01
 				},
 				"underwater_loop": "ambient.underwater.loop"
+			},
+			"minecraft:biome_music": {
+				"music_definition": "jungle"
 			}
 		}
 	}

--- a/resource_packs/files/retro/old_water/biomes/jungle_edge.client_biome.json
+++ b/resource_packs/files/retro/old_water/biomes/jungle_edge.client_biome.json
@@ -29,6 +29,9 @@
 					"chance": 0.01
 				},
 				"underwater_loop": "ambient.underwater.loop"
+			},
+			"minecraft:biome_music": {
+				"music_definition": "jungle_edge"
 			}
 		}
 	}

--- a/resource_packs/files/retro/old_water/biomes/jungle_hills.client_biome.json
+++ b/resource_packs/files/retro/old_water/biomes/jungle_hills.client_biome.json
@@ -29,6 +29,9 @@
 					"chance": 0.01
 				},
 				"underwater_loop": "ambient.underwater.loop"
+			},
+			"minecraft:biome_music": {
+				"music_definition": "jungle_hills"
 			}
 		}
 	}

--- a/resource_packs/files/retro/old_water/biomes/jungle_mutated.client_biome.json
+++ b/resource_packs/files/retro/old_water/biomes/jungle_mutated.client_biome.json
@@ -29,6 +29,9 @@
 					"chance": 0.01
 				},
 				"underwater_loop": "ambient.underwater.loop"
+			},
+			"minecraft:biome_music": {
+				"music_definition": "jungle_mutated"
 			}
 		}
 	}

--- a/resource_packs/files/retro/old_water/biomes/lush_caves.client_biome.json
+++ b/resource_packs/files/retro/old_water/biomes/lush_caves.client_biome.json
@@ -29,6 +29,9 @@
 					"chance": 0.01
 				},
 				"underwater_loop": "ambient.underwater.loop"
+			},
+			"minecraft:biome_music": {
+				"music_definition": "lush_caves"
 			}
 		}
 	}

--- a/resource_packs/files/retro/old_water/biomes/meadow.client_biome.json
+++ b/resource_packs/files/retro/old_water/biomes/meadow.client_biome.json
@@ -29,6 +29,9 @@
 					"chance": 0.01
 				},
 				"underwater_loop": "ambient.underwater.loop"
+			},
+			"minecraft:biome_music": {
+				"music_definition": "meadow"
 			}
 		}
 	}

--- a/resource_packs/files/retro/old_water/biomes/mega_taiga.client_biome.json
+++ b/resource_packs/files/retro/old_water/biomes/mega_taiga.client_biome.json
@@ -29,6 +29,9 @@
 					"chance": 0.01
 				},
 				"underwater_loop": "ambient.underwater.loop"
+			},
+			"minecraft:biome_music": {
+				"music_definition": "mega_taiga"
 			}
 		}
 	}

--- a/resource_packs/files/retro/old_water/biomes/mesa.client_biome.json
+++ b/resource_packs/files/retro/old_water/biomes/mesa.client_biome.json
@@ -35,6 +35,9 @@
 					"chance": 0.01
 				},
 				"underwater_loop": "ambient.underwater.loop"
+			},
+			"minecraft:biome_music": {
+				"music_definition": "mesa"
 			}
 		}
 	}

--- a/resource_packs/files/retro/old_water/biomes/mesa_plateau.client_biome.json
+++ b/resource_packs/files/retro/old_water/biomes/mesa_plateau.client_biome.json
@@ -29,6 +29,9 @@
 					"chance": 0.01
 				},
 				"underwater_loop": "ambient.underwater.loop"
+			},
+			"minecraft:biome_music": {
+				"music_definition": "mesa_plateau"
 			}
 		}
 	}

--- a/resource_packs/files/retro/old_water/biomes/mesa_plateau_mutated.client_biome.json
+++ b/resource_packs/files/retro/old_water/biomes/mesa_plateau_mutated.client_biome.json
@@ -35,6 +35,9 @@
 					"chance": 0.01
 				},
 				"underwater_loop": "ambient.underwater.loop"
+			},
+			"minecraft:biome_music": {
+				"music_definition": "mesa_plateau_mutated"
 			}
 		}
 	}

--- a/resource_packs/files/retro/old_water/biomes/redwood_taiga_hills_mutated.client_biome.json
+++ b/resource_packs/files/retro/old_water/biomes/redwood_taiga_hills_mutated.client_biome.json
@@ -29,6 +29,9 @@
 					"chance": 0.01
 				},
 				"underwater_loop": "ambient.underwater.loop"
+			},
+			"minecraft:biome_music": {
+				"music_definition": "redwood_taiga_hills_mutated"
 			}
 		}
 	}

--- a/resource_packs/files/retro/old_water/biomes/redwood_taiga_mutated.client_biome.json
+++ b/resource_packs/files/retro/old_water/biomes/redwood_taiga_mutated.client_biome.json
@@ -29,6 +29,9 @@
 					"chance": 0.01
 				},
 				"underwater_loop": "ambient.underwater.loop"
+			},
+			"minecraft:biome_music": {
+				"music_definition": "redwood_taiga_mutated"
 			}
 		}
 	}

--- a/resource_packs/files/retro/old_water/biomes/roofed_forest_mutated.client_biome.json
+++ b/resource_packs/files/retro/old_water/biomes/roofed_forest_mutated.client_biome.json
@@ -32,6 +32,9 @@
 					"chance": 0.01
 				},
 				"underwater_loop": "ambient.underwater.loop"
+			},
+			"minecraft:biome_music": {
+				"music_definition": "roofed_forest_mutated"
 			}
 		}
 	}

--- a/resource_packs/files/retro/old_water/biomes/snowy_slopes.client_biome.json
+++ b/resource_packs/files/retro/old_water/biomes/snowy_slopes.client_biome.json
@@ -29,6 +29,9 @@
 					"chance": 0.01
 				},
 				"underwater_loop": "ambient.underwater.loop"
+			},
+			"minecraft:biome_music": {
+				"music_definition": "snowy_slopes"
 			}
 		}
 	}

--- a/resource_packs/files/retro/old_water/biomes/stony_peaks.client_biome.json
+++ b/resource_packs/files/retro/old_water/biomes/stony_peaks.client_biome.json
@@ -29,6 +29,9 @@
 					"chance": 0.01
 				},
 				"underwater_loop": "ambient.underwater.loop"
+			},
+			"minecraft:biome_music": {
+				"music_definition": "stony_peaks"
 			}
 		}
 	}

--- a/resource_packs/files/retro/old_water/biomes/swampland.client_biome.json
+++ b/resource_packs/files/retro/old_water/biomes/swampland.client_biome.json
@@ -43,6 +43,9 @@
 					"chance": 0.01
 				},
 				"underwater_loop": "ambient.underwater.loop"
+			},
+			"minecraft:biome_music": {
+				"music_definition": "swampland"
 			}
 		}
 	}

--- a/resource_packs/files/retro/old_water/biomes/swampland_mutated.client_biome.json
+++ b/resource_packs/files/retro/old_water/biomes/swampland_mutated.client_biome.json
@@ -43,6 +43,9 @@
 					"chance": 0.01
 				},
 				"underwater_loop": "ambient.underwater.loop"
+			},
+			"minecraft:biome_music": {
+				"music_definition": "swampland_mutated"
 			}
 		}
 	}

--- a/resource_packs/files/retro/old_water/biomes/the_end.client_biome.json
+++ b/resource_packs/files/retro/old_water/biomes/the_end.client_biome.json
@@ -32,6 +32,9 @@
 					"chance": 0.01
 				},
 				"underwater_loop": "ambient.underwater.loop"
+			},
+			"minecraft:biome_music": {
+				"music_definition": "end"
 			}
 		}
 	}

--- a/resource_packs/files/terrain/clearer_water/biomes/bamboo_jungle.client_biome.json
+++ b/resource_packs/files/terrain/clearer_water/biomes/bamboo_jungle.client_biome.json
@@ -30,6 +30,9 @@
 					"chance": 0.01
 				},
 				"underwater_loop": "ambient.underwater.loop"
+			},
+			"minecraft:biome_music": {
+				"music_definition": "bamboo_jungle"
 			}
 		}
 	}

--- a/resource_packs/files/terrain/clearer_water/biomes/bamboo_jungle_hills.client_biome.json
+++ b/resource_packs/files/terrain/clearer_water/biomes/bamboo_jungle_hills.client_biome.json
@@ -30,6 +30,9 @@
 					"chance": 0.01
 				},
 				"underwater_loop": "ambient.underwater.loop"
+			},
+			"minecraft:biome_music": {
+				"music_definition": "bamboo_jungle_hills"
 			}
 		}
 	}

--- a/resource_packs/files/terrain/clearer_water/biomes/birch_forest.client_biome.json
+++ b/resource_packs/files/terrain/clearer_water/biomes/birch_forest.client_biome.json
@@ -30,6 +30,9 @@
 					"chance": 0.01
 				},
 				"underwater_loop": "ambient.underwater.loop"
+			},
+			"minecraft:biome_music": {
+				"music_definition": "birch_forest"
 			}
 		}
 	}

--- a/resource_packs/files/terrain/clearer_water/biomes/birch_forest_hills.client_biome.json
+++ b/resource_packs/files/terrain/clearer_water/biomes/birch_forest_hills.client_biome.json
@@ -30,6 +30,9 @@
 					"chance": 0.01
 				},
 				"underwater_loop": "ambient.underwater.loop"
+			},
+			"minecraft:biome_music": {
+				"music_definition": "birch_forest_hills"
 			}
 		}
 	}

--- a/resource_packs/files/terrain/clearer_water/biomes/birch_forest_mutated.client_biome.json
+++ b/resource_packs/files/terrain/clearer_water/biomes/birch_forest_mutated.client_biome.json
@@ -30,6 +30,9 @@
 					"chance": 0.01
 				},
 				"underwater_loop": "ambient.underwater.loop"
+			},
+			"minecraft:biome_music": {
+				"music_definition": "birch_forest_mutated"
 			}
 		}
 	}

--- a/resource_packs/files/terrain/clearer_water/biomes/cherry_grove.client_biome.json
+++ b/resource_packs/files/terrain/clearer_water/biomes/cherry_grove.client_biome.json
@@ -36,6 +36,9 @@
 					"chance": 0.01
 				},
 				"underwater_loop": "ambient.underwater.loop"
+			},
+			"minecraft:biome_music": {
+				"music_definition": "cherry_grove"
 			}
 		}
 	}

--- a/resource_packs/files/terrain/clearer_water/biomes/deep_dark.client_biome.json
+++ b/resource_packs/files/terrain/clearer_water/biomes/deep_dark.client_biome.json
@@ -30,6 +30,9 @@
 					"chance": 0.01
 				},
 				"underwater_loop": "ambient.underwater.loop"
+			},
+			"minecraft:biome_music": {
+				"music_definition": "deep_dark"
 			}
 		}
 	}

--- a/resource_packs/files/terrain/clearer_water/biomes/desert.client_biome.json
+++ b/resource_packs/files/terrain/clearer_water/biomes/desert.client_biome.json
@@ -30,6 +30,9 @@
 					"chance": 0.01
 				},
 				"underwater_loop": "ambient.underwater.loop"
+			},
+			"minecraft:biome_music": {
+				"music_definition": "desert"
 			}
 		}
 	}

--- a/resource_packs/files/terrain/clearer_water/biomes/desert_hills.client_biome.json
+++ b/resource_packs/files/terrain/clearer_water/biomes/desert_hills.client_biome.json
@@ -30,6 +30,9 @@
 					"chance": 0.01
 				},
 				"underwater_loop": "ambient.underwater.loop"
+			},
+			"minecraft:biome_music": {
+				"music_definition": "desert_hills"
 			}
 		}
 	}

--- a/resource_packs/files/terrain/clearer_water/biomes/desert_mutated.client_biome.json
+++ b/resource_packs/files/terrain/clearer_water/biomes/desert_mutated.client_biome.json
@@ -30,6 +30,9 @@
 					"chance": 0.01
 				},
 				"underwater_loop": "ambient.underwater.loop"
+			},
+			"minecraft:biome_music": {
+				"music_definition": "desert_mutated"
 			}
 		}
 	}

--- a/resource_packs/files/terrain/clearer_water/biomes/dripstone_caves.client_biome.json
+++ b/resource_packs/files/terrain/clearer_water/biomes/dripstone_caves.client_biome.json
@@ -30,6 +30,9 @@
 					"chance": 0.01
 				},
 				"underwater_loop": "ambient.underwater.loop"
+			},
+			"minecraft:biome_music": {
+				"music_definition": "dripstone_caves"
 			}
 		}
 	}

--- a/resource_packs/files/terrain/clearer_water/biomes/flower_forest.client_biome.json
+++ b/resource_packs/files/terrain/clearer_water/biomes/flower_forest.client_biome.json
@@ -30,6 +30,9 @@
 					"chance": 0.01
 				},
 				"underwater_loop": "ambient.underwater.loop"
+			},
+			"minecraft:biome_music": {
+				"music_definition": "flower_forest"
 			}
 		}
 	}

--- a/resource_packs/files/terrain/clearer_water/biomes/frozen_peaks.client_biome.json
+++ b/resource_packs/files/terrain/clearer_water/biomes/frozen_peaks.client_biome.json
@@ -30,6 +30,9 @@
 					"chance": 0.01
 				},
 				"underwater_loop": "ambient.underwater.loop"
+			},
+			"minecraft:biome_music": {
+				"music_definition": "frozen_peaks"
 			}
 		}
 	}

--- a/resource_packs/files/terrain/clearer_water/biomes/grove.client_biome.json
+++ b/resource_packs/files/terrain/clearer_water/biomes/grove.client_biome.json
@@ -30,6 +30,9 @@
 					"chance": 0.01
 				},
 				"underwater_loop": "ambient.underwater.loop"
+			},
+			"minecraft:biome_music": {
+				"music_definition": "grove"
 			}
 		}
 	}

--- a/resource_packs/files/terrain/clearer_water/biomes/hell.client_biome.json
+++ b/resource_packs/files/terrain/clearer_water/biomes/hell.client_biome.json
@@ -36,6 +36,9 @@
 			},
 			"minecraft:water_identifier": {
 				"water_identifier": "minecraft:default_water"
+			},
+			"minecraft:biome_music": {
+				"music_definition": "hell"
 			}
 		}
 	}

--- a/resource_packs/files/terrain/clearer_water/biomes/jagged_peaks.client_biome.json
+++ b/resource_packs/files/terrain/clearer_water/biomes/jagged_peaks.client_biome.json
@@ -30,6 +30,9 @@
 					"chance": 0.01
 				},
 				"underwater_loop": "ambient.underwater.loop"
+			},
+			"minecraft:biome_music": {
+				"music_definition": "jagged_peaks"
 			}
 		}
 	}

--- a/resource_packs/files/terrain/clearer_water/biomes/jungle.client_biome.json
+++ b/resource_packs/files/terrain/clearer_water/biomes/jungle.client_biome.json
@@ -30,6 +30,9 @@
 					"chance": 0.01
 				},
 				"underwater_loop": "ambient.underwater.loop"
+			},
+			"minecraft:biome_music": {
+				"music_definition": "jungle"
 			}
 		}
 	}

--- a/resource_packs/files/terrain/clearer_water/biomes/jungle_edge.client_biome.json
+++ b/resource_packs/files/terrain/clearer_water/biomes/jungle_edge.client_biome.json
@@ -30,6 +30,9 @@
 					"chance": 0.01
 				},
 				"underwater_loop": "ambient.underwater.loop"
+			},
+			"minecraft:biome_music": {
+				"music_definition": "jungle_edge"
 			}
 		}
 	}

--- a/resource_packs/files/terrain/clearer_water/biomes/jungle_hills.client_biome.json
+++ b/resource_packs/files/terrain/clearer_water/biomes/jungle_hills.client_biome.json
@@ -30,6 +30,9 @@
 					"chance": 0.01
 				},
 				"underwater_loop": "ambient.underwater.loop"
+			},
+			"minecraft:biome_music": {
+				"music_definition": "jungle_hills"
 			}
 		}
 	}

--- a/resource_packs/files/terrain/clearer_water/biomes/jungle_mutated.client_biome.json
+++ b/resource_packs/files/terrain/clearer_water/biomes/jungle_mutated.client_biome.json
@@ -30,6 +30,9 @@
 					"chance": 0.01
 				},
 				"underwater_loop": "ambient.underwater.loop"
+			},
+			"minecraft:biome_music": {
+				"music_definition": "jungle_mutated"
 			}
 		}
 	}

--- a/resource_packs/files/terrain/clearer_water/biomes/lush_caves.client_biome.json
+++ b/resource_packs/files/terrain/clearer_water/biomes/lush_caves.client_biome.json
@@ -30,6 +30,9 @@
 					"chance": 0.01
 				},
 				"underwater_loop": "ambient.underwater.loop"
+			},
+			"minecraft:biome_music": {
+				"music_definition": "lush_caves"
 			}
 		}
 	}

--- a/resource_packs/files/terrain/clearer_water/biomes/meadow.client_biome.json
+++ b/resource_packs/files/terrain/clearer_water/biomes/meadow.client_biome.json
@@ -30,6 +30,9 @@
 					"chance": 0.01
 				},
 				"underwater_loop": "ambient.underwater.loop"
+			},
+			"minecraft:biome_music": {
+				"music_definition": "meadow"
 			}
 		}
 	}

--- a/resource_packs/files/terrain/clearer_water/biomes/mega_taiga.client_biome.json
+++ b/resource_packs/files/terrain/clearer_water/biomes/mega_taiga.client_biome.json
@@ -30,6 +30,9 @@
 					"chance": 0.01
 				},
 				"underwater_loop": "ambient.underwater.loop"
+			},
+			"minecraft:biome_music": {
+				"music_definition": "mega_taiga"
 			}
 		}
 	}

--- a/resource_packs/files/terrain/clearer_water/biomes/mesa.client_biome.json
+++ b/resource_packs/files/terrain/clearer_water/biomes/mesa.client_biome.json
@@ -36,6 +36,9 @@
 					"chance": 0.01
 				},
 				"underwater_loop": "ambient.underwater.loop"
+			},
+			"minecraft:biome_music": {
+				"music_definition": "mesa"
 			}
 		}
 	}

--- a/resource_packs/files/terrain/clearer_water/biomes/mesa_plateau.client_biome.json
+++ b/resource_packs/files/terrain/clearer_water/biomes/mesa_plateau.client_biome.json
@@ -30,6 +30,9 @@
 					"chance": 0.01
 				},
 				"underwater_loop": "ambient.underwater.loop"
+			},
+			"minecraft:biome_music": {
+				"music_definition": "mesa_plateau"
 			}
 		}
 	}

--- a/resource_packs/files/terrain/clearer_water/biomes/mesa_plateau_mutated.client_biome.json
+++ b/resource_packs/files/terrain/clearer_water/biomes/mesa_plateau_mutated.client_biome.json
@@ -36,6 +36,9 @@
 					"chance": 0.01
 				},
 				"underwater_loop": "ambient.underwater.loop"
+			},
+			"minecraft:biome_music": {
+				"music_definition": "mesa_plateau_mutated"
 			}
 		}
 	}

--- a/resource_packs/files/terrain/clearer_water/biomes/redwood_taiga_hills_mutated.client_biome.json
+++ b/resource_packs/files/terrain/clearer_water/biomes/redwood_taiga_hills_mutated.client_biome.json
@@ -30,6 +30,9 @@
 					"chance": 0.01
 				},
 				"underwater_loop": "ambient.underwater.loop"
+			},
+			"minecraft:biome_music": {
+				"music_definition": "redwood_taiga_hills_mutated"
 			}
 		}
 	}

--- a/resource_packs/files/terrain/clearer_water/biomes/redwood_taiga_mutated.client_biome.json
+++ b/resource_packs/files/terrain/clearer_water/biomes/redwood_taiga_mutated.client_biome.json
@@ -30,6 +30,9 @@
 					"chance": 0.01
 				},
 				"underwater_loop": "ambient.underwater.loop"
+			},
+			"minecraft:biome_music": {
+				"music_definition": "redwood_taiga_mutated"
 			}
 		}
 	}

--- a/resource_packs/files/terrain/clearer_water/biomes/roofed_forest_mutated.client_biome.json
+++ b/resource_packs/files/terrain/clearer_water/biomes/roofed_forest_mutated.client_biome.json
@@ -33,6 +33,9 @@
 					"chance": 0.01
 				},
 				"underwater_loop": "ambient.underwater.loop"
+			},
+			"minecraft:biome_music": {
+				"music_definition": "roofed_forest_mutated"
 			}
 		}
 	}

--- a/resource_packs/files/terrain/clearer_water/biomes/snowy_slopes.client_biome.json
+++ b/resource_packs/files/terrain/clearer_water/biomes/snowy_slopes.client_biome.json
@@ -30,6 +30,9 @@
 					"chance": 0.01
 				},
 				"underwater_loop": "ambient.underwater.loop"
+			},
+			"minecraft:biome_music": {
+				"music_definition": "snowy_slopes"
 			}
 		}
 	}

--- a/resource_packs/files/terrain/clearer_water/biomes/stony_peaks.client_biome.json
+++ b/resource_packs/files/terrain/clearer_water/biomes/stony_peaks.client_biome.json
@@ -30,6 +30,9 @@
 					"chance": 0.01
 				},
 				"underwater_loop": "ambient.underwater.loop"
+			},
+			"minecraft:biome_music": {
+				"music_definition": "stony_peaks"
 			}
 		}
 	}

--- a/resource_packs/files/terrain/clearer_water/biomes/swampland.client_biome.json
+++ b/resource_packs/files/terrain/clearer_water/biomes/swampland.client_biome.json
@@ -43,6 +43,9 @@
 					"chance": 0.01
 				},
 				"underwater_loop": "ambient.underwater.loop"
+			},
+			"minecraft:biome_music": {
+				"music_definition": "swampland"
 			}
 		}
 	}

--- a/resource_packs/files/terrain/clearer_water/biomes/swampland_mutated.client_biome.json
+++ b/resource_packs/files/terrain/clearer_water/biomes/swampland_mutated.client_biome.json
@@ -43,6 +43,9 @@
 					"chance": 0.01
 				},
 				"underwater_loop": "ambient.underwater.loop"
+			},
+			"minecraft:biome_music": {
+				"music_definition": "swampland_mutated"
 			}
 		}
 	}

--- a/resource_packs/files/terrain/clearer_water/biomes/the_end.client_biome.json
+++ b/resource_packs/files/terrain/clearer_water/biomes/the_end.client_biome.json
@@ -33,6 +33,9 @@
 					"chance": 0.01
 				},
 				"underwater_loop": "ambient.underwater.loop"
+			},
+			"minecraft:biome_music": {
+				"music_definition": "end"
 			}
 		}
 	}

--- a/resource_packs/files/terrain/lush_grass_all_round/biomes/cherry_grove.client_biome.json
+++ b/resource_packs/files/terrain/lush_grass_all_round/biomes/cherry_grove.client_biome.json
@@ -35,6 +35,9 @@
 					"chance": 0.01
 				},
 				"underwater_loop": "ambient.underwater.loop"
+			},
+			"minecraft:biome_music": {
+				"music_definition": "cherry_grove"
 			}
 		}
 	}

--- a/resource_packs/files/terrain/lush_grass_all_round/biomes/mesa.client_biome.json
+++ b/resource_packs/files/terrain/lush_grass_all_round/biomes/mesa.client_biome.json
@@ -35,6 +35,9 @@
 					"chance": 0.01
 				},
 				"underwater_loop": "ambient.underwater.loop"
+			},
+			"minecraft:biome_music": {
+				"music_definition": "mesa"
 			}
 		}
 	}

--- a/resource_packs/files/terrain/lush_grass_all_round/biomes/mesa_plateau_mutated.client_biome.json
+++ b/resource_packs/files/terrain/lush_grass_all_round/biomes/mesa_plateau_mutated.client_biome.json
@@ -35,6 +35,9 @@
 					"chance": 0.01
 				},
 				"underwater_loop": "ambient.underwater.loop"
+			},
+			"minecraft:biome_music": {
+				"music_definition": "mesa_plateau_mutated"
 			}
 		}
 	}


### PR DESCRIPTION


1. Updated the client biomes to match bedrock samples

By checking the following boxes with an X, you ensure that:

- [X] The pack was tested ingame in at least one device.
- [X] The pack is an existing BT pack, is a missing pack from VT or is an accepted pack/change in a discussion.
- [X] The pack code follows the style guide.
- [X] The commits follow the contribution guidelines.
- [X] The PR follows the contribution guidelines.

- [X] (Optional) Tested in Windows
- [ ] (Optional) Tested in Android
- [ ] (Optional) Tested in iOS
- [ ] (Optional) Tested in any console
- [ ] (Optional) Tested in BDS
