### PR TITLE
feat(files): Added missing panorama packs

### DIFF
--- a/resource_packs/files/gui/menu_panoramas/copper_golem_village_panorama/pack_icon.png
+++ b/resource_packs/files/gui/menu_panoramas/copper_golem_village_panorama/pack_icon.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1b28262e35fa6bee3b046b5a14a97994f881bdaf60348cd86c7d45089f80f5bd
+size 15471

--- a/resource_packs/files/gui/menu_panoramas/copper_golem_village_panorama/textures/ui/panorama_0.png
+++ b/resource_packs/files/gui/menu_panoramas/copper_golem_village_panorama/textures/ui/panorama_0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8daa2b06047e74e350782472e99d8e04a20702afd6c6080dfb7bcdfaefbe9993
+size 902553

--- a/resource_packs/files/gui/menu_panoramas/copper_golem_village_panorama/textures/ui/panorama_1.png
+++ b/resource_packs/files/gui/menu_panoramas/copper_golem_village_panorama/textures/ui/panorama_1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6b58170f01a55c0b54dc50d582e9a6d2ff728166400690e1ebc939a8bc707dde
+size 776428

--- a/resource_packs/files/gui/menu_panoramas/copper_golem_village_panorama/textures/ui/panorama_2.png
+++ b/resource_packs/files/gui/menu_panoramas/copper_golem_village_panorama/textures/ui/panorama_2.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:af734f5180e51dd4d5326f6eecc1ca3e4068827a8da667141091d497acbfef43
+size 1002753

--- a/resource_packs/files/gui/menu_panoramas/copper_golem_village_panorama/textures/ui/panorama_3.png
+++ b/resource_packs/files/gui/menu_panoramas/copper_golem_village_panorama/textures/ui/panorama_3.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:16344dc95eb90a108a6110add7841db024946769ebf8a7ee09344b548cb1045d
+size 873854

--- a/resource_packs/files/gui/menu_panoramas/copper_golem_village_panorama/textures/ui/panorama_4.png
+++ b/resource_packs/files/gui/menu_panoramas/copper_golem_village_panorama/textures/ui/panorama_4.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:80cee7a8ea1fc38d90d849d118b515fab987df1139865a69014a93f457f4f6d6
+size 114701

--- a/resource_packs/files/gui/menu_panoramas/copper_golem_village_panorama/textures/ui/panorama_5.png
+++ b/resource_packs/files/gui/menu_panoramas/copper_golem_village_panorama/textures/ui/panorama_5.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c039e824a6298f7acf8b1f62e59362d222e7852ad857eb8bf3888ac6b21798e9
+size 472571

--- a/resource_packs/files/gui/menu_panoramas/copper_golem_village_panorama/textures/ui/panorama_overlay.png
+++ b/resource_packs/files/gui/menu_panoramas/copper_golem_village_panorama/textures/ui/panorama_overlay.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8086c0b3ff2bac2f5fc5f8f3f55baca46631ba457b8cd29bf739e5cfd09d5f9a
+size 70

--- a/resource_packs/files/gui/menu_panoramas/copper_golem_village_panorama/textures/ui/panoramahdr_0.hdr
+++ b/resource_packs/files/gui/menu_panoramas/copper_golem_village_panorama/textures/ui/panoramahdr_0.hdr
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f47645529f9217cfe3ae6a1593978e94b7b65960d5b73e44ea840f5795122345
+size 1773421

--- a/resource_packs/files/gui/menu_panoramas/copper_golem_village_panorama/textures/ui/panoramahdr_1.hdr
+++ b/resource_packs/files/gui/menu_panoramas/copper_golem_village_panorama/textures/ui/panoramahdr_1.hdr
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:322b6435ff494208fdc75f141b2990f0469d1881658815b1d9056e026cbec182
+size 2087243

--- a/resource_packs/files/gui/menu_panoramas/copper_golem_village_panorama/textures/ui/panoramahdr_2.hdr
+++ b/resource_packs/files/gui/menu_panoramas/copper_golem_village_panorama/textures/ui/panoramahdr_2.hdr
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0c28b9a2dd43ba8fe7faea33ed06445a1fda637c15b873512d8cc733ebd34026
+size 1879096

--- a/resource_packs/files/gui/menu_panoramas/copper_golem_village_panorama/textures/ui/panoramahdr_3.hdr
+++ b/resource_packs/files/gui/menu_panoramas/copper_golem_village_panorama/textures/ui/panoramahdr_3.hdr
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:976dbceb24864e492cc1c47722a3cb95e952a6d78946531db28625f4f25e464e
+size 1656856

--- a/resource_packs/files/gui/menu_panoramas/copper_golem_village_panorama/textures/ui/panoramahdr_4.hdr
+++ b/resource_packs/files/gui/menu_panoramas/copper_golem_village_panorama/textures/ui/panoramahdr_4.hdr
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:55df37d96fb22317becb9c1aa0aa7e83900c4934df1269ddcff4d26ac4a1a0bc
+size 656409

--- a/resource_packs/files/gui/menu_panoramas/copper_golem_village_panorama/textures/ui/panoramahdr_5.hdr
+++ b/resource_packs/files/gui/menu_panoramas/copper_golem_village_panorama/textures/ui/panoramahdr_5.hdr
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7622ae20238efb198a59df2db2cc85dfbcb00270bf9f043a26a0eaa794f5e61f
+size 1098591

--- a/resource_packs/files/gui/menu_panoramas/copper_golem_village_panorama/ui/start_screen.json
+++ b/resource_packs/files/gui/menu_panoramas/copper_golem_village_panorama/ui/start_screen.json
@@ -1,0 +1,26 @@
+{
+	"namespace": "start",
+	"panorama_overlay_image": {
+		"type": "image",
+		"size": [
+			"fill",
+			"fill"
+		],
+		"texture": "textures/ui/panorama_overlay"
+	},
+	"start_screen_content": {
+		"modifications": [
+			{
+				"array_name": "controls",
+				"operation": "insert_back",
+				"value": [
+					{
+						"panorama_overlay@start.panorama_overlay_image": {
+							"layer": -10
+						}
+					}
+				]
+			}
+		]
+	}
+}

--- a/resource_packs/files/gui/menu_panoramas/mounts_of_mayhem_panorama/pack_icon.png
+++ b/resource_packs/files/gui/menu_panoramas/mounts_of_mayhem_panorama/pack_icon.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:182ca02a76df685414287ef544257e9fbe7a8f06f784a7086ff3e12b77e751ac
+size 12071

--- a/resource_packs/files/gui/menu_panoramas/mounts_of_mayhem_panorama/textures/ui/panorama_0.png
+++ b/resource_packs/files/gui/menu_panoramas/mounts_of_mayhem_panorama/textures/ui/panorama_0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:484168c7720676d4f7a859e897d5d7278d1a9954e3afdf77fe59a2d367a89cb4
+size 1149610

--- a/resource_packs/files/gui/menu_panoramas/mounts_of_mayhem_panorama/textures/ui/panorama_1.png
+++ b/resource_packs/files/gui/menu_panoramas/mounts_of_mayhem_panorama/textures/ui/panorama_1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:988c230f286f8ce8e8ecd7e16efa6f7373d0f965df0e541815c4d9c7d0331a94
+size 1250221

--- a/resource_packs/files/gui/menu_panoramas/mounts_of_mayhem_panorama/textures/ui/panorama_2.png
+++ b/resource_packs/files/gui/menu_panoramas/mounts_of_mayhem_panorama/textures/ui/panorama_2.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a1ba44ac1ff2d888d7132563f4fdd30e6d044bf2a2cc3791fb45bf492b85a379
+size 938998

--- a/resource_packs/files/gui/menu_panoramas/mounts_of_mayhem_panorama/textures/ui/panorama_3.png
+++ b/resource_packs/files/gui/menu_panoramas/mounts_of_mayhem_panorama/textures/ui/panorama_3.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8351295e2749f4972d45b499b3d50303508f3b152c712f8babd26ab3d69dbf01
+size 858644

--- a/resource_packs/files/gui/menu_panoramas/mounts_of_mayhem_panorama/textures/ui/panorama_4.png
+++ b/resource_packs/files/gui/menu_panoramas/mounts_of_mayhem_panorama/textures/ui/panorama_4.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:90de66f6e594123da9fc86e7ed018e546f67e5d2250f23f3c272a5f5afea74c8
+size 451207

--- a/resource_packs/files/gui/menu_panoramas/mounts_of_mayhem_panorama/textures/ui/panorama_5.png
+++ b/resource_packs/files/gui/menu_panoramas/mounts_of_mayhem_panorama/textures/ui/panorama_5.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:56d7c806993e5d3848d28b74dd1f72a256fbfa65dfc727dcebc8d25e4ad00203
+size 433362

--- a/resource_packs/files/gui/menu_panoramas/mounts_of_mayhem_panorama/textures/ui/panorama_overlay.png
+++ b/resource_packs/files/gui/menu_panoramas/mounts_of_mayhem_panorama/textures/ui/panorama_overlay.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8086c0b3ff2bac2f5fc5f8f3f55baca46631ba457b8cd29bf739e5cfd09d5f9a
+size 70

--- a/resource_packs/files/gui/menu_panoramas/mounts_of_mayhem_panorama/textures/ui/panoramahdr_0.hdr
+++ b/resource_packs/files/gui/menu_panoramas/mounts_of_mayhem_panorama/textures/ui/panoramahdr_0.hdr
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2742a3b329c39063ee6d8a7c32cf86ac517a0bdd5d5b6a2ede4375a2fee58f94
+size 2161410

--- a/resource_packs/files/gui/menu_panoramas/mounts_of_mayhem_panorama/textures/ui/panoramahdr_1.hdr
+++ b/resource_packs/files/gui/menu_panoramas/mounts_of_mayhem_panorama/textures/ui/panoramahdr_1.hdr
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:54ab683af33e2de14854411cd36721495460640a8d621e1ea416869047772ac4
+size 2550466

--- a/resource_packs/files/gui/menu_panoramas/mounts_of_mayhem_panorama/textures/ui/panoramahdr_2.hdr
+++ b/resource_packs/files/gui/menu_panoramas/mounts_of_mayhem_panorama/textures/ui/panoramahdr_2.hdr
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6b14e63277b0350cc5d05ca610ada5f29883a0aa3f022e237bcfaa911d6ddd88
+size 1833283

--- a/resource_packs/files/gui/menu_panoramas/mounts_of_mayhem_panorama/textures/ui/panoramahdr_3.hdr
+++ b/resource_packs/files/gui/menu_panoramas/mounts_of_mayhem_panorama/textures/ui/panoramahdr_3.hdr
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6ee515f6334cc2449d3190e6e16331dd2cd77b16719d1aa534fef61de1d780ad
+size 1629533

--- a/resource_packs/files/gui/menu_panoramas/mounts_of_mayhem_panorama/textures/ui/panoramahdr_4.hdr
+++ b/resource_packs/files/gui/menu_panoramas/mounts_of_mayhem_panorama/textures/ui/panoramahdr_4.hdr
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ff090bc2bcd8efa13c2d432988608e86bfb96c2482388f831661134d6694673f
+size 575042

--- a/resource_packs/files/gui/menu_panoramas/mounts_of_mayhem_panorama/textures/ui/panoramahdr_5.hdr
+++ b/resource_packs/files/gui/menu_panoramas/mounts_of_mayhem_panorama/textures/ui/panoramahdr_5.hdr
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f32113d87fecbc2ff19d56c984d682b55aa6522c21f247a951515deba30f97a3
+size 1149050

--- a/resource_packs/files/gui/menu_panoramas/mounts_of_mayhem_panorama/ui/start_screen.json
+++ b/resource_packs/files/gui/menu_panoramas/mounts_of_mayhem_panorama/ui/start_screen.json
@@ -1,0 +1,26 @@
+{
+	"namespace": "start",
+	"panorama_overlay_image": {
+		"type": "image",
+		"size": [
+			"fill",
+			"fill"
+		],
+		"texture": "textures/ui/panorama_overlay"
+	},
+	"start_screen_content": {
+		"modifications": [
+			{
+				"array_name": "controls",
+				"operation": "insert_back",
+				"value": [
+					{
+						"panorama_overlay@start.panorama_overlay_image": {
+							"layer": -10
+						}
+					}
+				]
+			}
+		]
+	}
+}

--- a/resource_packs/files/gui/menu_panoramas/tiny_takeover_panorama/pack_icon.png
+++ b/resource_packs/files/gui/menu_panoramas/tiny_takeover_panorama/pack_icon.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:38997675f55fa50545b9d1dc34248c2ad1b89ba04fe2712aee8397d63ed5cb8e
+size 12805

--- a/resource_packs/files/gui/menu_panoramas/tiny_takeover_panorama/textures/ui/panorama_0.png
+++ b/resource_packs/files/gui/menu_panoramas/tiny_takeover_panorama/textures/ui/panorama_0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d4c6f5bc3276b6d188391900871ae2279bd39deb30572d3dc031d249cf58dca7
+size 1151686

--- a/resource_packs/files/gui/menu_panoramas/tiny_takeover_panorama/textures/ui/panorama_1.png
+++ b/resource_packs/files/gui/menu_panoramas/tiny_takeover_panorama/textures/ui/panorama_1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:635096a2e2a619d291cf827c4597142a91c985d372b7942075e7d63e5d0f6c0a
+size 924980

--- a/resource_packs/files/gui/menu_panoramas/tiny_takeover_panorama/textures/ui/panorama_2.png
+++ b/resource_packs/files/gui/menu_panoramas/tiny_takeover_panorama/textures/ui/panorama_2.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8a5e069961ec355a62d67c28df88a75b9148cbc7ea147d0d940eb60a31b14d03
+size 947283

--- a/resource_packs/files/gui/menu_panoramas/tiny_takeover_panorama/textures/ui/panorama_3.png
+++ b/resource_packs/files/gui/menu_panoramas/tiny_takeover_panorama/textures/ui/panorama_3.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4788bda0edd89fc7791264b4dc377d2a4371a84b7509de2f0dedeb7e21d6e787
+size 1119018

--- a/resource_packs/files/gui/menu_panoramas/tiny_takeover_panorama/textures/ui/panorama_4.png
+++ b/resource_packs/files/gui/menu_panoramas/tiny_takeover_panorama/textures/ui/panorama_4.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0ce234304cee5df382833da477ce58792df20aacc53fa34c3fa9b37c96b8a7c4
+size 169434

--- a/resource_packs/files/gui/menu_panoramas/tiny_takeover_panorama/textures/ui/panorama_5.png
+++ b/resource_packs/files/gui/menu_panoramas/tiny_takeover_panorama/textures/ui/panorama_5.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9ce34e06cea03cd56a286d00eef452a04d441412d38b7a776bfa7918fd0a6f95
+size 642513

--- a/resource_packs/files/gui/menu_panoramas/tiny_takeover_panorama/textures/ui/panorama_overlay.png
+++ b/resource_packs/files/gui/menu_panoramas/tiny_takeover_panorama/textures/ui/panorama_overlay.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8086c0b3ff2bac2f5fc5f8f3f55baca46631ba457b8cd29bf739e5cfd09d5f9a
+size 70

--- a/resource_packs/files/gui/menu_panoramas/tiny_takeover_panorama/textures/ui/panoramahdr_0.hdr
+++ b/resource_packs/files/gui/menu_panoramas/tiny_takeover_panorama/textures/ui/panoramahdr_0.hdr
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2c9a192b546c54b6d1be806c2ad8a7d2a36d067716a11ea4c8e3135a5f0dc89f
+size 2788656

--- a/resource_packs/files/gui/menu_panoramas/tiny_takeover_panorama/textures/ui/panoramahdr_1.hdr
+++ b/resource_packs/files/gui/menu_panoramas/tiny_takeover_panorama/textures/ui/panoramahdr_1.hdr
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:06d3a30ffd23a75c3899508352b8d0da9c1100f5cfd80f17e6a114776caa3c6f
+size 2289698

--- a/resource_packs/files/gui/menu_panoramas/tiny_takeover_panorama/textures/ui/panoramahdr_2.hdr
+++ b/resource_packs/files/gui/menu_panoramas/tiny_takeover_panorama/textures/ui/panoramahdr_2.hdr
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5fa16275b57c10a619457fe7907153c5f378a5c689bb31031a3a336695a063d2
+size 2125794

--- a/resource_packs/files/gui/menu_panoramas/tiny_takeover_panorama/textures/ui/panoramahdr_3.hdr
+++ b/resource_packs/files/gui/menu_panoramas/tiny_takeover_panorama/textures/ui/panoramahdr_3.hdr
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ab235717ed86a1638988df74697fd3606aa10f3192279cfba85cea37bedafcd4
+size 2596988

--- a/resource_packs/files/gui/menu_panoramas/tiny_takeover_panorama/textures/ui/panoramahdr_4.hdr
+++ b/resource_packs/files/gui/menu_panoramas/tiny_takeover_panorama/textures/ui/panoramahdr_4.hdr
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fc5005b456f6d5ccd758cdc6d02a664cbe8846a481e91517bcfe52b2ad112991
+size 764339

--- a/resource_packs/files/gui/menu_panoramas/tiny_takeover_panorama/textures/ui/panoramahdr_5.hdr
+++ b/resource_packs/files/gui/menu_panoramas/tiny_takeover_panorama/textures/ui/panoramahdr_5.hdr
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cb891138b1094ee85ee331a84af3f46fc7d8a475d6379d9b279ed8b3e7ef3af2
+size 1407962

--- a/resource_packs/files/gui/menu_panoramas/tiny_takeover_panorama/ui/start_screen.json
+++ b/resource_packs/files/gui/menu_panoramas/tiny_takeover_panorama/ui/start_screen.json
@@ -1,0 +1,26 @@
+{
+	"namespace": "start",
+	"panorama_overlay_image": {
+		"type": "image",
+		"size": [
+			"fill",
+			"fill"
+		],
+		"texture": "textures/ui/panorama_overlay"
+	},
+	"start_screen_content": {
+		"modifications": [
+			{
+				"array_name": "controls",
+				"operation": "insert_back",
+				"value": [
+					{
+						"panorama_overlay@start.panorama_overlay_image": {
+							"layer": -10
+						}
+					}
+				]
+			}
+		]
+	}
+}

--- a/resource_packs/packs.json
+++ b/resource_packs/packs.json
@@ -1925,7 +1925,21 @@
 				{
 					"id": "pale_garden_panorama",
 					"name": "Pale Garden Panorama",
-					"description": "Replaces the default Minecraft menu panorama with a 360° view of a Pale Garden (from 1.21.4)"
+					"description": "Replaces the default Minecraft menu panorama with a 360° view of a Pale Garden (from 1.21.50)"
+				},
+				{
+					"id": "copper_golem_village_panorama",
+					"name": "Copper Golem Village Panorama",
+					"description":"Replaces the default Minecraft menu panorama with a 360° view of Copper Golems in a village! (from 1.21.111)"
+				},
+				{
+					"id": "mounts_of_mayhem_panorama",
+					"name": "Mounts of Mayhem Panorama",
+					"description":"Replaces the default Minecraft menu panorama with a 360° view of Zombies and Drowneds riding Horses and Nautilus! (from 1.21.130)"},
+				{
+					"id": "tiny_takeover_panorama",
+					"name": "Tiny Takeover Panorama",
+					"description": "Replaces the default Minecraft menu panorama with a 360° view of baby mobs in a cherry grove! (from 26.10)"
 				},
 				{
 					"id": "the_end_panorama",


### PR DESCRIPTION
<description_pr>
adds missing tiny takeover, mounts of mayhem, and copper age drop panoramas
resolves: #930 

By checking the following boxes with an X, you ensure that:

- [X] The pack was tested ingame in at least one device.
- [X] The pack is an existing BT pack, is a missing pack from VT or is an accepted pack/change in a discussion.
- [X] The pack code follows the style guide.
- [X] The commits follow the contribution guidelines.
- [X] The PR follows the contribution guidelines.

- [ ] (Optional) Tested in Windows
- [X] (Optional) Tested in Android
- [ ] (Optional) Tested in iOS
- [ ] (Optional) Tested in any console
- [ ] (Optional) Tested in BDS
